### PR TITLE
Added docx2python as a dependency of the Weaver

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.assemblylinewizard',
       url='https://docassemble.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=[],
+      install_requires=['docx2python'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/assemblylinewizard/', package='docassemble.assemblylinewizard'),
      )


### PR DESCRIPTION
Tested on a fresh local docker docassemble server, can run the weaver to completion right after installing just the Weaver as a zip file. 

Addresses part of #322.