### PR TITLE
Fix #461 - make .append() statements idempotent

### DIFF
--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -1196,14 +1196,16 @@ code: |
   }
   add_end_question = True
 ---  
-need:
+need: # trigger these up front for idempotency
   - interview.title
   - interview_intro_prompt
+  - interview.court_related
 code: |
   #-----------------------------------------------------------------
   # Prepare data for output_patterns.yml, each attachment file must provide those 6 attributes.
   #-----------------------------------------------------------------
-      
+
+  labels_lists.clear()
   # Set attributes for the "next_steps" docx. 
   # To add any additional attachment files, follow this example.
   file2 = labels_lists.appendObject()


### PR DESCRIPTION
Resolves #461 by making the statements that build the objects and attachment blocks idempotent.

After this fix, you should see only one attachment for the main document and one for the instructions, and just one objects block for the main document and one for the instructions.

[single_field.docx](https://github.com/SuffolkLITLab/docassemble-ALWeaver/files/6886902/single_field.docx)

In testing this bug I also noticed #464 which I will look at in a separate branch.