### PR TITLE
Improve appearance of review screens and default handling of field names associated with currency

### DIFF
--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -255,13 +255,13 @@ class DAField(DAObject):
     variable_name_guess = self.variable.replace('_', ' ').capitalize()
     if self.variable.endswith('_date'):
       self.field_type_guess = 'date'
-      self.variable_name_guess = 'Date of ' + self.variable[:-5].replace('_', ' ')
+      self.variable_name_guess = f"Date of {variable_name_guess[:-5]}"
     elif self.variable.endswith('_amount'):
         self.field_type_guess = 'currency'
-        self.variable_name_guess = f"{self.variable[:-7].replace('_',' ')} amount"
+        self.variable_name_guess = f"{variable_name_guess[:-7]} amount"
     elif self.variable.endswith('_value'):
         self.field_type_guess = 'currency'
-        self.variable_name_guess = f"{self.variable[:-7].replace('_',' ')} value"
+        self.variable_name_guess = f"{variable_name_guess[:-7]} value"
     elif self.variable.endswith('.signature'):
       self.field_type_guess = "signature"
       self.variable_name_guess = variable_name_guess
@@ -296,6 +296,12 @@ class DAField(DAObject):
         self.field_type_guess = "signature"
     elif self.maxlength > 100:
         self.field_type_guess = 'area'
+    elif self.variable.endswith('_amount'):
+        self.field_type_guess = 'currency'
+        self.variable_name_guess = f"{variable_name_guess[:-7]} amount"
+    elif self.variable.endswith('_value'):
+        self.field_type_guess = 'currency'
+        self.variable_name_guess = f"{variable_name_guess[:-7]} value"        
     else:
         self.field_type_guess = 'text'
     
@@ -598,7 +604,7 @@ confirm: True
     all_columns = ''
     settable_list = ''
     for att, disp_and_set in self.attribute_map.items():
-      all_columns += '  - {0}: |\n'.format(att.capitalize().replace('_', ''))
+      all_columns += '  - {0}: |\n'.format(att.capitalize().replace('_', ' '))
       all_columns += '      row_item.{0} if defined("row_item.{1}") else ""\n'.format( disp_and_set[0], disp_and_set[1])
       settable_list += '  - {}\n'.format(disp_and_set[1])
     if len(self.attribute_map) == 0:

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -256,6 +256,12 @@ class DAField(DAObject):
     if self.variable.endswith('_date'):
       self.field_type_guess = 'date'
       self.variable_name_guess = 'Date of ' + self.variable[:-5].replace('_', ' ')
+    elif self.variable.endswith('_amount'):
+        self.field_type_guess = 'currency'
+        self.variable_name_guess = f'{self.variable[:-7].replace('_',' ')} amount'
+    elif self.variable.endswith('_value'):
+        self.field_type_guess = 'currency'
+        self.variable_name_guess = f'{self.variable[:-7].replace('_',' ')} value'
     elif self.variable.endswith('.signature'):
       self.field_type_guess = "signature"
       self.variable_name_guess = variable_name_guess

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -253,21 +253,19 @@ class DAField(DAObject):
 
     # variable_name_guess is the placeholder label for the field
     variable_name_guess = self.variable.replace('_', ' ').capitalize()
+    self.variable_name_guess = variable_name_guess
+
     if self.variable.endswith('_date'):
       self.field_type_guess = 'date'
       self.variable_name_guess = f"Date of {variable_name_guess[:-5]}"
     elif self.variable.endswith('_amount'):
         self.field_type_guess = 'currency'
-        self.variable_name_guess = f"{variable_name_guess[:-7]} amount"
     elif self.variable.endswith('_value'):
         self.field_type_guess = 'currency'
-        self.variable_name_guess = f"{variable_name_guess[:-7]} value"
     elif self.variable.endswith('.signature'):
       self.field_type_guess = "signature"
-      self.variable_name_guess = variable_name_guess
     else:
       self.field_type_guess = 'text'
-      self.variable_name_guess = variable_name_guess
 
   def fill_in_pdf_attributes(self, pdf_field_tuple):
     """Let's guess the type of each field from the name / info from PDF"""
@@ -298,10 +296,8 @@ class DAField(DAObject):
         self.field_type_guess = 'area'
     elif self.variable.endswith('_amount'):
         self.field_type_guess = 'currency'
-        self.variable_name_guess = f"{variable_name_guess[:-7]} amount"
     elif self.variable.endswith('_value'):
         self.field_type_guess = 'currency'
-        self.variable_name_guess = f"{variable_name_guess[:-7]} value"        
     else:
         self.field_type_guess = 'text'
     
@@ -634,7 +630,7 @@ confirm: True
       content += indent_by(bold(self.var_name), 6) + '\n'
       for att, disp_set in self.attribute_map.items():
         content += indent_by('% if defined("{}.{}"):'.format(self.var_name, disp_set[1]), 6)
-        content += indent_by('* {}: ${{ {}.{} }}'.format(att, self.var_name.capitalize().replace('_', ''), disp_set[0]), 6)
+        content += indent_by('* {}: ${{ {}.{} }}'.format(att, self.var_name.capitalize().replace('_', ' '), disp_set[0]), 6)
         content += indent_by('% endif', 6)
       return content.rstrip('\n')
     

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -598,11 +598,11 @@ confirm: True
     all_columns = ''
     settable_list = ''
     for att, disp_and_set in self.attribute_map.items():
-      all_columns += '  - {0}: |\n'.format(att)
+      all_columns += '  - {0}: |\n'.format(att.capitalize().replace('_', ''))
       all_columns += '      row_item.{0} if defined("row_item.{1}") else ""\n'.format( disp_and_set[0], disp_and_set[1])
       settable_list += '  - {}\n'.format(disp_and_set[1])
     if len(self.attribute_map) == 0:
-      all_columns += '  - name: |\n'
+      all_columns += '  - Name: |\n'
       all_columns += '      row_item\n'
       settable_list += '  True\n'
     return content.format(var_name=self.var_name, all_columns=all_columns.rstrip('\n'), settable_list=settable_list.rstrip('\n'))
@@ -618,7 +618,7 @@ confirm: True
     content += '    button: |\n'
         
     if self.var_type == 'list': 
-      content += indent_by(bold(self.var_name), 6) + '\n'
+      content += indent_by(bold(self.var_name.capitalize().replace('_', '')), 6) + '\n'
       content += indent_by("% for item in {}:".format(self.var_name), 6)
       content += indent_by("* ${ item }", 8)
       content += indent_by("% endfor", 6)
@@ -628,7 +628,7 @@ confirm: True
       content += indent_by(bold(self.var_name), 6) + '\n'
       for att, disp_set in self.attribute_map.items():
         content += indent_by('% if defined("{}.{}"):'.format(self.var_name, disp_set[1]), 6)
-        content += indent_by('* {}: ${{ {}.{} }}'.format(att, self.var_name, disp_set[0]), 6)
+        content += indent_by('* {}: ${{ {}.{} }}'.format(att, self.var_name.capitalize().replace('_', ''), disp_set[0]), 6)
         content += indent_by('% endif', 6)
       return content.rstrip('\n')
     

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -258,10 +258,10 @@ class DAField(DAObject):
       self.variable_name_guess = 'Date of ' + self.variable[:-5].replace('_', ' ')
     elif self.variable.endswith('_amount'):
         self.field_type_guess = 'currency'
-        self.variable_name_guess = f'{self.variable[:-7].replace('_',' ')} amount'
+        self.variable_name_guess = f"{self.variable[:-7].replace('_',' ')} amount"
     elif self.variable.endswith('_value'):
         self.field_type_guess = 'currency'
-        self.variable_name_guess = f'{self.variable[:-7].replace('_',' ')} value'
+        self.variable_name_guess = f"{self.variable[:-7].replace('_',' ')} value"
     elif self.variable.endswith('.signature'):
       self.field_type_guess = "signature"
       self.variable_name_guess = variable_name_guess

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -624,7 +624,7 @@ confirm: True
     content += '    button: |\n'
         
     if self.var_type == 'list': 
-      content += indent_by(bold(self.var_name.capitalize().replace('_', '')), 6) + '\n'
+      content += indent_by(bold(self.var_name.capitalize().replace('_', ' ')), 6) + '\n'
       content += indent_by("% for item in {}:".format(self.var_name), 6)
       content += indent_by("* ${ item }", 8)
       content += indent_by("% endfor", 6)


### PR DESCRIPTION
Fix #450  - fields ending in _amount or _value default to "Currency" datatype
Fix #468  - Capitalize field names in review screen and revisit table

Sample document with both _amount and _value fields as well as some revisit tables

[FeeWaiver_Civil_Application.pdf](https://github.com/SuffolkLITLab/docassemble-ALWeaver/files/7011207/FeeWaiver_Civil_Application.pdf)
