### PR TITLE
Allow a little more personalization of interviews + add default state/country

### DIFF
--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -6,6 +6,9 @@ metadata:
     <img src="/packagestatic/docassemble.ALWeaver/logo.png" class="ma_icon" alt="Assembly Line Weaver Logo" title="ALWeaver">
   exit url: https://courtformsonline.org  
 ---
+imports:
+  - pycountry
+---
 features:
   question help button: True
   # labels above fields: True
@@ -238,26 +241,70 @@ help:
     There are ${len(all_fields)} fields total.
 
     `${all_fields}`
+
+---
+code: |
+  interview.country = 'US'
+  # This is weird but needed for check-in logic
+  # TODO(qs): adjust when we have a way to load in org defaults at runtime
+---
+event: update_state_list
+code: |
+  if action_argument('interview.country') and action_argument('interview.country') != interview.country:          
+    interview.country = action_argument('interview.country')
+    background_response('refresh')
+  background_response()    
 ---
 id: dependency question
-question: Which jurisdictions and organizations is this form a part of?
-subquestion: |
-  This will help the Weaver to add appropriate jurisdictions as dependencies for your interview. If you are unsure, leave the default options checked.
-help:
-  label: My jurisdiction or organization is not here
-  content: |
-    New jurisdictions will be added soon. You should add those dependencies manually in the Playground until then.
+question: |
+  Brand, Location and Identity
 fields:
-  - Jurisdictions: interview.jurisdiction_choices
+  - Author's name(s) (one per line): interview.author
+    datatype: area
+    rows: 3
+    default: |
+      % if user_logged_in():
+      ${ user_info().first_name } ${ user_info().last_name }
+      % else:
+      Court Forms Online
+      % endif
+    required: False
+  - note: |
+      ---
+  - Default country: interview.country
+    code: |
+      countries_list()
+    default: ${ interview.country }
+  - Default ${ safe_subdivision_type(interview.country) if safe_subdivision_type(interview.country) else 'State/Province'}: interview.state
+    code: |
+        states_list(country_code=interview.country) if pycountry.subdivisions.get(country_code=interview.country) else []
+    # default: ${ "MA" if interview.country == 'US' else '' }
+    required: False
+  - note: |
+      ---
+  - Jurisdiction package: interview.jurisdiction_choices
     datatype: checkboxes
     required: False
     code: |
       get_possible_deps_as_choices('jurisdiction')
-  - Organizations: interview.org_choices
+  - Organization package: interview.org_choices
     datatype: checkboxes
     required: False
     code: |
       get_possible_deps_as_choices('organization')
+check in: update_state_list      
+help:
+  label: What is this?
+  content: |
+    You can include default styles, courts, and custom written questions
+    that are appropriate for both your jurisdiction (i.e., state-level courts)
+    and for your organization.
+    
+    Leaving the default selections will use packages associated with the 
+    Court Forms Online project.
+    
+    New jurisdictions will be added soon. You should add those dependencies 
+    manually in the Playground until then.
 ---
 code: |    
   if not interview.court_related:   

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -245,22 +245,22 @@ help:
 
 ---
 code: |
-  interview.country = 'US'
-  # This is weird but needed for check-in logic
+  interview.default_country_code = 'US'
+  # This is weird but needed for check-in logic that refreshes list of states
   # TODO(qs): adjust when we have a way to load in org defaults at runtime
 ---
 event: update_state_list
 code: |
-  if action_argument('interview.country') and action_argument('interview.country') != interview.country:          
-    interview.country = action_argument('interview.country')
+  if action_argument('interview.default_country_code') and action_argument('interview.default_country_code') != interview.default_country_code:          
+    interview.default_country_code = action_argument('interview.default_country_code')
     background_response('refresh')
   background_response()    
 ---
 id: dependency question
 question: |
-  Brand, Location and Identity
+  Identity, location, and brand
 fields:
-  - Author's name(s) (one per line): interview.author
+  - Author name(s) (one per line): interview.author
     datatype: area
     rows: 3
     # TODO(qs): update default if we have a way to load org defaults
@@ -273,18 +273,20 @@ fields:
     required: False
     help: |
       The information in this box will be public by default.
-      It will be used on GitHub and on the "About" page of the interview.
-  # TODO(qs): we could add email for github here too, but more complicated      
+      It will appear on the "About" page of the interview. If you
+      save this package to GitHub, it will also appear in your GitHub commit log.
+  # TODO(qs): we could add email for github here too, but more complicated
+  # and risks inappropriate contact by end users
   - note: |
       ---
-  - Default country: interview.country
+  - Default country (for address fields): interview.default_country_code
     code: |
       countries_list()
-    default: ${ interview.country }
-  - Default ${ safe_subdivision_type(interview.country) if safe_subdivision_type(interview.country) else 'State/Province'}: interview.state
+    default: ${ interview.default_country_code }
+  - Default ${ safe_subdivision_type(interview.default_country_code) if safe_subdivision_type(interview.default_country_code) else 'State/Province'}: interview.state
     code: |
-        states_list(country_code=interview.country) if pycountry.subdivisions.get(country_code=interview.country) else ()
-    default: ${ "MA" if interview.country == 'US' else '' }
+        states_list(country_code=interview.default_country_code) if pycountry.subdivisions.get(country_code=interview.default_country_code) else ()
+    default: ${ "MA" if interview.default_country_code == 'US' else '' }
     required: False
     
   - note: |
@@ -294,7 +296,7 @@ fields:
     required: False
     code: |
       get_possible_deps_as_choices('jurisdiction')
-  - Organization package: interview.org_choices
+  - Branding package: interview.org_choices
     datatype: checkboxes
     required: False
     code: |
@@ -700,7 +702,7 @@ code: |
   add_metadata = True
 ---
 need:
-  - interview.country
+  - interview.default_country_code
 code: |
   interview_default_country_and_state_block = interview.blocks.appendObject()
   interview_default_country_and_state_block.template_key = 'default country and state'

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -74,6 +74,7 @@ code: |
   add_includes
   add_metadata
   add_main_interview_key
+  add_default_country_and_state
   add_github_repo_name
   add_short_title
   add_form_type  
@@ -262,6 +263,7 @@ fields:
   - Author's name(s) (one per line): interview.author
     datatype: area
     rows: 3
+    # TODO(qs): update default if we have a way to load org defaults
     default: |
       % if user_logged_in():
       ${ user_info().first_name } ${ user_info().last_name }
@@ -269,6 +271,9 @@ fields:
       Court Forms Online
       % endif
     required: False
+    help: |
+      The information in this box will be public by default.
+      It will be used on GitHub and on the "About" page of the interview.
   - note: |
       ---
   - Default country: interview.country
@@ -277,7 +282,7 @@ fields:
     default: ${ interview.country }
   - Default ${ safe_subdivision_type(interview.country) if safe_subdivision_type(interview.country) else 'State/Province'}: interview.state
     code: |
-        states_list(country_code=interview.country) if pycountry.subdivisions.get(country_code=interview.country) else []
+        states_list(country_code=interview.country) if pycountry.subdivisions.get(country_code=interview.country) else ()
     # default: ${ "MA" if interview.country == 'US' else '' }
     required: False
   - note: |
@@ -690,6 +695,17 @@ code: |
   }
 
   add_metadata = True
+---
+need:
+  - interview.country
+code: |
+  interview_default_country_and_state_block = interview.blocks.appendObject()
+  interview_default_country_and_state_block.template_key = 'default country and state'
+  interview_default_country_and_state_block.data = {
+    "interview": interview
+    }
+
+  add_default_country_and_state = True
 ---
 code: |
   interview_main_metadata_key_block = interview.blocks.appendObject()

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -274,6 +274,7 @@ fields:
     help: |
       The information in this box will be public by default.
       It will be used on GitHub and on the "About" page of the interview.
+  # TODO(qs): we could add email for github here too, but more complicated      
   - note: |
       ---
   - Default country: interview.country
@@ -283,8 +284,9 @@ fields:
   - Default ${ safe_subdivision_type(interview.country) if safe_subdivision_type(interview.country) else 'State/Province'}: interview.state
     code: |
         states_list(country_code=interview.country) if pycountry.subdivisions.get(country_code=interview.country) else ()
-    # default: ${ "MA" if interview.country == 'US' else '' }
+    default: ${ "MA" if interview.country == 'US' else '' }
     required: False
+    
   - note: |
       ---
   - Jurisdiction package: interview.jurisdiction_choices
@@ -1271,6 +1273,8 @@ code: |
   # Package title is PascalCase, per our AssemblyLine convention
   package_title = re.sub("\W|_","", interview_label.title())
 ---
+need:
+  - interview.author
 # Prepare content for the Weaver's download screen.
 code: |
   # 1. Commit the generated interview YAML file
@@ -1289,14 +1293,28 @@ code: |
     "sources": []
   }
   
-  create_package_zip(package_title,
-        interview.package_info(
+  package_info = interview.package_info(
           get_pypi_deps_from_choices(
             interview.jurisdiction_choices.true_values() +
             interview.org_choices.true_values()
           )
-        ),
-        {"author name and email":"author@example.com"},
+        )    
+  
+  if interview.author and str(interview.author).splitlines():
+    # TODO(qs): is it worth ever adding email here?
+    # It would conflict with listing multiple authors
+    default_vals = {
+      "author name and email": str(interview.author).splitlines()[0]
+    }
+    package_info['author_name'] = default_vals['author name and email']
+  else:
+    default_vals = {
+      "author name and email": "author@example.com"
+    }
+  
+  create_package_zip(package_title,
+        package_info,
+        default_vals,
         folders_and_files, 
         interview_package_download)
 

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -678,7 +678,7 @@ code: |
       'title': interview.title,
       'short title': interview.short_title
     },
-    "authors": [author for author in str(interview.author).splitlines()]
+    "authors": str(interview.author).splitlines()
   }
 
   metadata_code = interview.blocks.appendObject()

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -675,7 +675,8 @@ code: |
     "settings": {
       'title': interview.title,
       'short title': interview.short_title
-    }
+    },
+    "authors": [author for author in str(interview.author).splitlines()]
   }
 
   metadata_code = interview.blocks.appendObject()

--- a/docassemble/ALWeaver/data/sources/output_patterns.yml
+++ b/docassemble/ALWeaver/data/sources/output_patterns.yml
@@ -181,6 +181,12 @@ metadata: |
       - ${ category }
   % endfor
   % endif
+  % if len(authors):
+    authors:
+  % for author in authors:
+      - ${ author }
+  % endfor
+  % endif
 # Form-specific metadata that goes into a dictionary, much of it reserved for future use
 # TODO: refactor to a Docassemble `data:` block
 al metadata: |

--- a/docassemble/ALWeaver/data/sources/output_patterns.yml
+++ b/docassemble/ALWeaver/data/sources/output_patterns.yml
@@ -232,10 +232,12 @@ al metadata: |
 # Default country and state
 default country and state: |
   code: |
-    AL_DEFAULT_COUNTRY = "${ interview.country }"
+    # This controls the default country and list of states in address field questions
+    AL_DEFAULT_COUNTRY = "${ interview.default_country_code }"
   % if hasattr(interview, 'state') and interview.state:
   ---
   code: |
+    # This controls the default state in address field questions
     AL_DEFAULT_STATE = "${ interview.state }"
   % endif
 # Includes

--- a/docassemble/ALWeaver/data/sources/output_patterns.yml
+++ b/docassemble/ALWeaver/data/sources/output_patterns.yml
@@ -223,6 +223,15 @@ al metadata: |
         "typical role": "${ typical_role }",
         % endif
       })
+# Default country and state
+default country and state: |
+  code: |
+    AL_DEFAULT_COUNTRY = "${ interview.country }"
+  % if hasattr(interview, 'state') and interview.state:
+  ---
+  code: |
+    AL_DEFAULT_STATE = "${ interview.state }"
+  % endif
 # Includes
 include: |
   include:


### PR DESCRIPTION
1. Uses the author name for "About" page and for package setup.py
2. Add a way for authors to set the initial value of AL_DEFAULT_COUNTRY and AL_DEFAULT_STATE. Defaults to US and MA, respectively, for now.

Fix #267 
Fix #382 
Fix #383 
Fix #384 

To test:

1. Add a few author names when prompted.
2. Verify that the first author is listed in setup.py
3. Verify that other authors appear in the `metadata` and in the `about` page
4. Add a default state and country
5. Verify that the interview can run and that the values of `AL_DEFAULT_COUNTRY` and `AL_DEFAULT_STATE` get set to ISO 2 or 3 letter codes.