### PR TITLE
Fix use of custom people in DOCX files

### DIFF
--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -945,7 +945,7 @@ def map_raw_to_final_display(label:str, document_type:str="pdf",
   """For a given set of specific cases, transform a
   PDF field name into a standardized object name
   that will be the value for the attachment field."""
-  if document_type.lower() == "docx":
+  if document_type.lower() == "docx" or '.' in label:
     return label # don't transform DOCX variables
 
   # Turn spaces into `_`, strip non identifier characters


### PR DESCRIPTION
Fix  #464

It turns out the issue in #464 was mostly user error (alien_ambassador was not given a list index), however, there still was an issue with DOCX files that have an index of `0` wrongly triggering an exception. This PR fixes that issue.

[Test_custom_names.pdf](https://github.com/SuffolkLITLab/docassemble-ALWeaver/files/7069970/Test_custom_names.pdf)
[hello_planet2 - Copy.docx](https://github.com/SuffolkLITLab/docassemble-ALWeaver/files/7069971/hello_planet2.-.Copy.docx)
