### PR TITLE
Fix #76, support multiple choice options in Weaver

### DIFF
--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -471,6 +471,7 @@ class DAField(DAObject):
       'field': f'fields[{index}].choices',
       'datatype': 'area',
       'js show if': f"val('fields[{index}].field_type') === 'multiple choice radio' || val('fields[{index}].field_type') === 'multiple choice checkboxes'",
+      'hint': "Like 'Descriptive name: key_name', or just 'Descriptive name'",
     })
     return field_questions
 


### PR DESCRIPTION
Fix #76 

This is a very basic implementation of radio buttons and checkboxes as an additional datatype, but enough to be usable.