### PR TITLE
Fix #500 - identify variables in `if` tests

### DIFF
--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -917,6 +917,9 @@ def get_docx_variables( text:str )->set:
   # Variables in very simple `if` statements (allow paragraph and whitespace flags)
   for possible_variable in re.findall(r'{%[^ \t]* +if ([^\} ]+) +[^ \t]*%}', text):
     minimally_filtered.add( possible_variable )
+  # Capture variables in `if` statements that contain a comparison
+  for possible_variable in re.findall(r'{%[^ \t]* +if ([^\} ]+) ==|is|>|<|!=|<=|>= .* +[^ \t]*%}', text):  
+    minimally_filtered.add( possible_variable )
 
   fields = set()
 


### PR DESCRIPTION
Fix #500 

You can test with the file uploaded to #500 , and directly test the regex on regex101.com

Regex:
```
{%[^ \t]* +if ([^\} ]+) ==|is|>|<|!=|<=|>= .* +[^ \t]*%}
```

Sample text:

```jinja2
{%p if will_type == “testate” %}
Testate (Decedent Died with a Will) 
•	Petition for Formal Probate of Will/Adjudication of Intestacy/Appointment of PR (MPC 160)
•	Surviving Spouse, Children, Heirs at Law (MPC 162)
•	Devisees (MPC 163) 
•	Original Will, if available, if not, a copy or statement of Will contents
•	Certified Copy of Death Certificate, if available or affidavit
•	Citation- Return of Service (MPC 560)
•	Decree and Order on Petition for Formal Adjudication (MPC 755)
{%p if wants_personal_representative %}
•	Bond (MPC 801)
{%p endif %}

•	Military Affidavit (MPC 470)
•	Authenticated Copy of Will and Appointment 


{%p endif %}

```