### PR TITLE
Turn on `skip undefined` by default for DOCX templates

### DIFF
--- a/docassemble/ALWeaver/data/sources/output_patterns.yml
+++ b/docassemble/ALWeaver/data/sources/output_patterns.yml
@@ -318,6 +318,7 @@ da attachments block: |
   ${ field.attachment_yaml(attachment_name=v.attachment_varname) }
       % endfor
     % else: 
+      skip undefined: True
       docx template file: ${ v.input_filename }
     % endif	    
   % endfor	


### PR DESCRIPTION
Add `skip undefined` as a default for DOCX files now that it is available, to mirror behavior of PDF files.

This feature will help us add a custom error handling page that lets someone recover a document that is in progress when Docassemble runs into a bug.