### PR TITLE
Use a DAStore to hold configuration settings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,13 +5,11 @@ on:
   workflow_dispatch:
 
 jobs:
-  env:
-    ISUNITTEST: true
-
   test-weaver:
     runs-on: ubuntu-latest
-
     name: Run weaver tests
+    env:
+      ISUNITTEST: true
     steps:
       - run: sudo apt-get update && sudo apt-get -y install libcurl4-openssl-dev
       - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,8 @@ on:
   workflow_dispatch:
 
 jobs:
+  env:
+    ISUNITTEST: true
 
   test-weaver:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       ISUNITTEST: true
     steps:
-      - run: sudo apt-get update && sudo apt-get -y install libcurl4-openssl-dev
+      - run: sudo apt-get update && sudo apt-get -y install libcurl4-openssl-dev build-essential python3-dev libldap2-dev libsasl2-dev slapd ldap-utils tox lcov valgrind
       - name: Checkout
         uses: actions/checkout@v2
       - run: pip3 install virtualenv

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       ISUNITTEST: true
     steps:
-      - run: sudo apt-get update && sudo apt-get -y install libcurl4-openssl-dev build-essential python3-dev libldap2-dev libsasl2-dev slapd ldap-utils tox lcov valgrind
+      - run: sudo apt-get update && sudo apt-get -y install libcurl4-openssl-dev build-essential python3-dev libldap2-dev libsasl2-dev slapd ldap-utils tox lcov valgrind libzbar0
       - name: Checkout
         uses: actions/checkout@v2
       - run: pip3 install virtualenv

--- a/docassemble/ALWeaver/advertise_capabilities.py
+++ b/docassemble/ALWeaver/advertise_capabilities.py
@@ -1,18 +1,33 @@
 # pre-load
 
 import os
-from docassemble.base.util import DAStore
+from docassemble.base.util import DAStore, log
 
 __all__ = ['advertise_capabilities']
 
+def _package_name():
+  """Get package name without the name of the current module, like: docassemble.ALWeaver instead of
+  docassemble.ALWeaver.advertise_capabilities"""
+  try:
+    return ".".join(__name__.split(".")[:-1])
+  except:
+    return __name__
+
 def advertise_capabilities(package_name:str=None, yaml_name:str="configuration_capabilities.yml", base:str="docassemble.ALWeaver", minimum_version="1.5"):
+  """
+  Tell the server that the current Docassemble package contains a configuration_capabilities.yml file with settings that
+  ALWeaver can use, by adding an entry to the global DAStore. This function should be set to run with a 
+  # pre-load hook so it advertises itself on each server uwsgi reset.
+  """
   weaverdata = DAStore(base=base)
   if not package_name:
-    package_name = __name__
+    package_name = _package_name()    
   published_configuration_capabilities = weaverdata.get("published_configuration_capabilities") or {}
-  published_configuration_capabilities[package_name] = (yaml_name, minimum_version)
+  if not isinstance(published_configuration_capabilities, dict):
+    published_configuration_capabilities = {}
+  published_configuration_capabilities[package_name] = [yaml_name, minimum_version]
   weaverdata.set('published_configuration_capabilities', published_configuration_capabilities)
   
-# After docassemble.demo.test is removed from #pre-load we can also check 'unittest' in sys.modules.keys()  
-if not __name__ == '__main__' and not os.environ.get('ISUNITTEST'):
-  advertise_capabilities()
+# If you want to prevent this script from running in unittests, add an environment variable ISUNITTEST set to TRUE  
+if not os.environ.get('ISUNITTEST'):
+  advertise_capabilities() 

--- a/docassemble/ALWeaver/advertise_capabilities.py
+++ b/docassemble/ALWeaver/advertise_capabilities.py
@@ -1,7 +1,6 @@
 # pre-load
 
 import os
-from docassemble.base.util import DAStore, log
 from .custom_values import advertise_capabilities
 
 __all__ = []

--- a/docassemble/ALWeaver/advertise_capabilities.py
+++ b/docassemble/ALWeaver/advertise_capabilities.py
@@ -1,0 +1,18 @@
+# pre-load
+
+import os
+from docassemble.base.util import DAStore
+
+__all__ = ['advertise_capabilities']
+
+def advertise_capabilities(package_name:str=None, yaml_name:str="configuration_capabilities.yml", base:str="docassemble.ALWeaver", minimum_version="1.5"):
+  weaverdata = DAStore(base=base)
+  if not package_name:
+    package_name = __name__
+  published_configuration_capabilities = weaverdata.get("published_configuration_capabilities") or {}
+  published_configuration_capabilities[package_name] = (yaml_name, minimum_version)
+  weaverdata.set('published_configuration_capabilities', published_configuration_capabilities)
+  
+# After docassemble.demo.test is removed from #pre-load we can also check 'unittest' in sys.modules.keys()  
+if not __name__ == '__main__' and not os.environ.get('ISUNITTEST'):
+  advertise_capabilities()

--- a/docassemble/ALWeaver/advertise_capabilities.py
+++ b/docassemble/ALWeaver/advertise_capabilities.py
@@ -2,31 +2,9 @@
 
 import os
 from docassemble.base.util import DAStore, log
+from .custom_values import advertise_capabilities
 
-__all__ = ['advertise_capabilities']
-
-def _package_name():
-  """Get package name without the name of the current module, like: docassemble.ALWeaver instead of
-  docassemble.ALWeaver.advertise_capabilities"""
-  try:
-    return ".".join(__name__.split(".")[:-1])
-  except:
-    return __name__
-
-def advertise_capabilities(package_name:str=None, yaml_name:str="configuration_capabilities.yml", base:str="docassemble.ALWeaver", minimum_version="1.5"):
-  """
-  Tell the server that the current Docassemble package contains a configuration_capabilities.yml file with settings that
-  ALWeaver can use, by adding an entry to the global DAStore. This function should be set to run with a 
-  # pre-load hook so it advertises itself on each server uwsgi reset.
-  """
-  weaverdata = DAStore(base=base)
-  if not package_name:
-    package_name = _package_name()    
-  published_configuration_capabilities = weaverdata.get("published_configuration_capabilities") or {}
-  if not isinstance(published_configuration_capabilities, dict):
-    published_configuration_capabilities = {}
-  published_configuration_capabilities[package_name] = [yaml_name, minimum_version]
-  weaverdata.set('published_configuration_capabilities', published_configuration_capabilities)
+__all__ = []
   
 # If you want to prevent this script from running in unittests, add an environment variable ISUNITTEST set to TRUE  
 if not os.environ.get('ISUNITTEST'):

--- a/docassemble/ALWeaver/custom_values.py
+++ b/docassemble/ALWeaver/custom_values.py
@@ -87,15 +87,15 @@ def load_org_specific(all_custom_values=custom_values):
       with open(to_write, 'w') as writ:
         writ.write(yaml.safe_dump(all_custom_values.org_specific_config))
 
-#def get_possible_deps_as_choices(dep_category=None, all_custom=custom_values):
-#  """Gets the possible yml files that the generated interview will depend on"""
-#  load_org_specific(all_custom)
-#  dep_choices = all_custom.org_specific_config['dependency_choices']
-#  if dep_category is None:
-#    return [{dep_key: dep_key, 'default': dep[3]} for dep_key, dep in dep_choices.items()]
-#  else:
-#    return [{dep_key: dep_key, 'default': dep[3]} for dep_key, dep in dep_choices.items() 
-#            if dep[2].lower() == dep_category.lower()]
+def get_possible_deps_as_choices(dep_category=None, all_custom=custom_values):
+  """Gets the possible yml files that the generated interview will depend on"""
+  load_org_specific(all_custom)
+  dep_choices = all_custom.org_specific_config['dependency_choices']
+  if dep_category is None:
+    return [{dep_key: dep_key, 'default': dep[3]} for dep_key, dep in dep_choices.items()]
+  else:
+    return [{dep_key: dep_key, 'default': dep[3]} for dep_key, dep in dep_choices.items() 
+            if dep[2].lower() == dep_category.lower()]
 
 def get_pypi_deps_from_choices(choices:Union[List[str], DADict],
     all_custom=custom_values):
@@ -117,18 +117,24 @@ def get_values_from_choices(choices:Union[List[str], DADict], value_idx:int=0,
   else: # List
     choice_list = choices
   
-  return [all_custom_values.org_specific_config['dependency_choices'][chosen_val][value_idx] 
-      for chosen_val in choice_list] 
+  return [all_custom_values.org_specific_config['dependency_choices'][chosen_val][value_idx]
+      for chosen_val in choice_list]
 
 ######################## pre load ###############################
 # This runs each time the .py file runs, which should be on each uwsgi reset
 
-def advertise_capabilities(package_name=None, yaml_name="configuration_capabilities.yml", base="docassemble.ALWeaver"):
+def advertise_capabilities(package_name:str=None, yaml_name:str="configuration_capabilities.yml", base:str="docassemble.ALWeaver"):
   weaverdata = DAStore(base=base)
   if not package_name:
-    package_name = user_info().package
+    package_name = __name__
   published_configuration_capabilities = weaverdata.get("published_configuration_capabilities") or {}
   published_configuration_capabilities[package_name] = yaml_name
   weaverdata.set('published_configuration_capabilities', published_configuration_capabilities)
+  
+#def load_capabilities(package_name  
+#
+# TODO: how do we want to handle advertising from the playground? We don't want to break the list of 
+# capabilities if someone has a version of the Weaver that is still in progress
 
-advertise_capabilities()
+if not __name__ == '__main__':
+  advertise_capabilities(package_name='docassemble.ALWeaver')

--- a/docassemble/ALWeaver/custom_values.py
+++ b/docassemble/ALWeaver/custom_values.py
@@ -44,7 +44,9 @@ def load_capabilities(base:str="docassemble.ALWeaver", minimum_version="1.5", in
   The local capabilities will always be the default configuration. Optionally, filter capabilities
   by version and whether playground packages can provide capabilities.
   """
-  this_yaml = path_and_mimetype("data/sources/configuration_capabilities.yml")[0]
+  current_package_name = ".".join(__name__.split(".")[:-1])
+  
+  this_yaml = path_and_mimetype(f"{current_package_name}:data/sources/configuration_capabilities.yml")[0]
   weaverdata = DAStore(base=base)
   published_configuration_capabilities = weaverdata.get("published_configuration_capabilities") or {}
   try:
@@ -65,8 +67,7 @@ def load_capabilities(base:str="docassemble.ALWeaver", minimum_version="1.5", in
     # Filter out capability files unless the package is installed system-wide
     if not include_playground and key.startswith("docassemble.playground"):
       del published_configuration_capabilities[key]
-  
-  current_package_name = ".".join(__name__.split(".")[:-1])
+    
   for package_name in published_configuration_capabilities:
     # Don't add the current package twice
     if not current_package_name == package_name:

--- a/docassemble/ALWeaver/custom_values.py
+++ b/docassemble/ALWeaver/custom_values.py
@@ -1,10 +1,12 @@
+# pre-load
 from typing import List, Union
 from pathlib import Path
-import yaml
-from docassemble.base.util import log, DADict
+import ruamel.yaml as yaml
+from docassemble.base.util import log, DADict, DAList, user_info, DAStore
 from docassemble.base.core import objects_from_file
 # TODO(brycew): is this too deep into DA? Unclear if there are options to write
 # sources files to a package while it's running.
+import ruamel.yaml as yaml
 from docassemble.base.functions import package_data_filename
 
 """
@@ -12,7 +14,21 @@ Container for widely used data that may be altered by user inputs.
 """
 
 __all__ = ['get_possible_deps_as_choices', 'get_pypi_deps_from_choices', 
-           'get_yml_deps_from_choices']
+           'get_yml_deps_from_choices', 'SettingsList']
+
+class SettingsList(DAList):
+  """
+  A simple list that can sync itself to a DAStore
+  """
+  def init(self, *pargs, **kwargs):
+    super().init(*pargs, **kwargs)
+
+  def hook_after_gather(self):
+    if hasattr(self, 'store'):
+      self.store.set(self.instanceName, self)
+  
+  def __str__(self):
+    return "\n".join(self.complete_elements())
 
 # This is to workaround fact you can't do local import in Docassemble playground
 class Object(object):
@@ -71,15 +87,15 @@ def load_org_specific(all_custom_values=custom_values):
       with open(to_write, 'w') as writ:
         writ.write(yaml.safe_dump(all_custom_values.org_specific_config))
 
-def get_possible_deps_as_choices(dep_category=None, all_custom=custom_values):
-  """Gets the possible yml files that the generated interview will depend on"""
-  load_org_specific(all_custom)
-  dep_choices = all_custom.org_specific_config['dependency_choices']
-  if dep_category is None:
-    return [{dep_key: dep_key, 'default': dep[3]} for dep_key, dep in dep_choices.items()]
-  else:
-    return [{dep_key: dep_key, 'default': dep[3]} for dep_key, dep in dep_choices.items() 
-            if dep[2].lower() == dep_category.lower()]
+#def get_possible_deps_as_choices(dep_category=None, all_custom=custom_values):
+#  """Gets the possible yml files that the generated interview will depend on"""
+#  load_org_specific(all_custom)
+#  dep_choices = all_custom.org_specific_config['dependency_choices']
+#  if dep_category is None:
+#    return [{dep_key: dep_key, 'default': dep[3]} for dep_key, dep in dep_choices.items()]
+#  else:
+#    return [{dep_key: dep_key, 'default': dep[3]} for dep_key, dep in dep_choices.items() 
+#            if dep[2].lower() == dep_category.lower()]
 
 def get_pypi_deps_from_choices(choices:Union[List[str], DADict],
     all_custom=custom_values):
@@ -103,3 +119,16 @@ def get_values_from_choices(choices:Union[List[str], DADict], value_idx:int=0,
   
   return [all_custom_values.org_specific_config['dependency_choices'][chosen_val][value_idx] 
       for chosen_val in choice_list] 
+
+######################## pre load ###############################
+# This runs each time the .py file runs, which should be on each uwsgi reset
+
+def advertise_capabilities(package_name=None, yaml_name="configuration_capabilities.yml", base="docassemble.ALWeaver"):
+  weaverdata = DAStore(base=base)
+  if not package_name:
+    package_name = user_info().package
+  published_configuration_capabilities = weaverdata.get("published_configuration_capabilities") or {}
+  published_configuration_capabilities[package_name] = yaml_name
+  weaverdata.set('published_configuration_capabilities', published_configuration_capabilities)
+
+advertise_capabilities()

--- a/docassemble/ALWeaver/custom_values.py
+++ b/docassemble/ALWeaver/custom_values.py
@@ -1,4 +1,3 @@
-# pre-load
 from typing import List, Union
 from pathlib import Path
 import ruamel.yaml as yaml
@@ -11,6 +10,14 @@ import sys
 from docassemble.base.functions import package_data_filename
 from packaging.version import Version
 import os
+
+################# To refactor - I don't think these are used but they are mentioned in interview_generator.py
+class Object(object):
+  pass
+custom_values = Object()
+custom_values.people_plurals_map = {}
+custom_values.org_specific_config = None
+########################## End to refactor
 
 """
 Container for widely used data that may be altered by user inputs.
@@ -33,85 +40,12 @@ class SettingsList(DAList):
   def __str__(self):
     return "\n".join(self.complete_elements())
 
-
-################################# Old stuff to refactor
-class Object(object):
-  pass
-
-custom_values = Object()
-# This is to workaround fact you can't do local import in Docassemble playground
-
-# Var names of people-type lists that developers add while using the weaver.
-# Could be a list, but a dict will match RESERVED_PLURALIZERS_MAP in the
-# places it's used, so maybe easier to treat them both the same.
-custom_values.people_plurals_map = {}
-
-# Filled in by load_org_specific. Is a dictionary of configs that each org using
-# the Weaver can set, per installation. The specific configs are:
-# * jurisdiction_dependency_choices: a collection of other yaml files 
-#   that the generated interview will include, specifically a jurisdiction
-#   It's a map from keys, what the user will see when selecting dependencies, that maps to
-#   a list of 3 items: the pypi dependency, the yaml include, and a boolean for default selection
-custom_values.org_specific_config = None
-
-############################# End old stuff
-
-def get_possible_deps_as_choices(dep_category=None, all_custom=custom_values):
-  """Gets the possible yml files that the generated interview will depend on"""
-  
-  dep_choices = []
-  all_capabilities = load_capabilities()
-  for capability in all_capabilities:
-    if dep_category == 'organization':
-      dep_choices.extend([
-        {item.get('include_name'): item.get('description')}
-        for item in all_capabilities[capability].get('organization_choices',[])
-      ])
-    elif dep_category == 'jurisdiction':
-      dep_choices.extend([
-        {item.get('include_name'): item.get('description')}
-        for item in all_capabilities[capability].get('jurisdiction_choices',[])
-      ])
-
-  return dep_choices
-  
-  # load_org_specific(all_custom)
-  # dep_choices = all_custom.org_specific_config['dependency_choices']
-  # if dep_category is None:
-  #   return [{dep_key: dep_key, 'default': dep[3]} for dep_key, dep in dep_choices.items()]
-  # else:
-  #   return [{dep_key: dep_key, 'default': dep[3]} for dep_key, dep in dep_choices.items() 
-  #           if dep[2].lower() == dep_category.lower()]
-
-def get_pypi_deps_from_choices(choices:Union[List[str], DADict],
-    all_custom=custom_values):
-  """Gets the Pypi dependency requirement (i.e. docassemble.AssemblyLine>=2.0.19)
-  from some chosen dependencies"""
-  return get_values_from_choices(choices, 0)
-
-def get_yml_deps_from_choices(choices:Union[List[str], DADict],
-    all_custom_values=custom_values):
-  """Gets the yml file (i.e. docassemble.AssemblyLine:data/question/ql_baseline.yml)
-  from some chosen dependencies"""
-  return get_values_from_choices(choices, 1)
-
-def get_values_from_choices(choices:Union[List[str], DADict], value_idx:int=0,
-    all_custom_values=custom_values):
-  load_org_specific(all_custom_values)
-  if isinstance(choices, DADict):
-    choice_list = choices.true_values()
-  else: # List
-    choice_list = choices
-  
-  return [all_custom_values.org_specific_config['dependency_choices'][chosen_val][value_idx]
-      for chosen_val in choice_list]
-
-######################## pre load ###############################
-# This runs each time the .py file runs, which should be on each uwsgi reset
-
 def load_capabilities(base:str="docassemble.ALWeaver", minimum_version="1.5", include_playground=False):
-  # Get the contents of the current package's capabilities file.
-  # The local capabilities will always be the default configuration
+  """
+  Get the contents of the current package's capabilities file.
+  The local capabilities will always be the default configuration. Optionally, filter capabilities
+  by version and whether playground packages can provide capabilities.
+  """
   this_yaml = path_and_mimetype("data/sources/configuration_capabilities.yml")[0]
   weaverdata = DAStore(base=base)
   published_configuration_capabilities = weaverdata.get("published_configuration_capabilities") or {}
@@ -144,25 +78,51 @@ def load_capabilities(base:str="docassemble.ALWeaver", minimum_version="1.5", in
       except:
         log(f"Unable to load published Weaver configuration file {path}")
   
-  return capabilities
-      
-def _load_templates(self, template_path:str)->None:
-    """
-    Load YAML file with Mako templates into the templates attribute.
-    Overwrites any existing templates.
-    """
-    path = path_and_mimetype(template_path)[0]
-    with open(path) as f:
-      contents = f.read()
-    self.templates = list(yaml.safe_load_all(contents))[0] # Take the first YAML "document"    
-
-def advertise_capabilities(package_name:str=None, yaml_name:str="configuration_capabilities.yml", base:str="docassemble.ALWeaver", minimum_version="1.5"):
-  weaverdata = DAStore(base=base)
-  if not package_name:
-    package_name = __name__
-  published_configuration_capabilities = weaverdata.get("published_configuration_capabilities") or {}
-  published_configuration_capabilities[package_name] = (yaml_name, minimum_version)
-  weaverdata.set('published_configuration_capabilities', published_configuration_capabilities)
+  return capabilities  
   
-if not __name__ == '__main__' and not os.environ.get('ISUNITTEST'):
-  advertise_capabilities()
+_al_weaver_capabilities = load_capabilities()
+
+def get_possible_deps_as_choices(dep_category=None):
+  """Gets the possible yml files that the generated interview will depend on"""
+  
+  dep_choices = []  
+  
+  # TODO: do we want to prefix the choice with the package name?
+  for capability in _al_weaver_capabilities:
+    if dep_category == 'organization':
+      dep_choices.extend([
+        {item.get('include_name'): item.get('description')}
+        for item in _al_weaver_capabilities[capability].get('organization_choices',[])
+      ])
+    elif dep_category == 'jurisdiction':
+      dep_choices.extend([
+        {item.get('include_name'): item.get('description')}
+        for item in _al_weaver_capabilities[capability].get('jurisdiction_choices',[])
+      ])
+
+  return dep_choices
+
+def get_pypi_deps_from_choices(choices:Union[List[str], DADict]):
+  """Gets the Pypi dependency requirement (i.e. docassemble.AssemblyLine>=2.0.19)
+  from some chosen dependencies"""
+  pypi_deps = []
+  if isinstance(choices, DADict):
+    choice_list = choices.true_values()
+  else: # List
+    choice_list = choices
+    
+  for capability in _al_weaver_capabilities:
+    pypi_deps.extend([choice.get('dependency') for choice in _al_weaver_capabilities[capability].get('organization_choices',[]) + _al_weaver_capabilities[capability].get('jurisdiction_choices',[]) if choice.get('dependency') and choice.get('include_name') in choice_list])
+
+  return pypi_deps
+
+def get_yml_deps_from_choices(choices:Union[List[str], DADict]):
+  """Gets the yml file (i.e. docassemble.AssemblyLine:data/question/ql_baseline.yml)
+  from some chosen dependencies"""
+  # TODO
+  # We might want to prefix choices with the name of the package, and if so this would break
+  if isinstance(choices, DADict):
+    return choices.true_values()
+  else: # List
+    return choices
+    

--- a/docassemble/ALWeaver/custom_values.py
+++ b/docassemble/ALWeaver/custom_values.py
@@ -10,6 +10,7 @@ import ruamel.yaml as yaml
 import sys
 from docassemble.base.functions import package_data_filename
 from packaging import version
+import os
 
 """
 Container for widely used data that may be altered by user inputs.
@@ -140,13 +141,5 @@ def advertise_capabilities(package_name:str=None, yaml_name:str="configuration_c
   published_configuration_capabilities[package_name] = (yaml_name, minimum_version)
   weaverdata.set('published_configuration_capabilities', published_configuration_capabilities)
   
-#def load_capabilities(package_name  
-#
-# TODO: how do we want to handle advertising from the playground? We don't want to break the list of 
-# capabilities if someone has a version of the Weaver that is still in progress
-
-log(f"Unittest is in modules: {'unittest' in sys.modules}")
-
-#if not __name__ == '__main__' and not 'unittest' in sys.modules:
-#  advertise_capabilities()
-advertise_capabilities()
+if not __name__ == '__main__' and not os.environ.get('ISUNITTEST'):
+  advertise_capabilities()

--- a/docassemble/ALWeaver/custom_values.py
+++ b/docassemble/ALWeaver/custom_values.py
@@ -9,6 +9,7 @@ from docassemble.base.core import objects_from_file
 import ruamel.yaml as yaml
 import sys
 from docassemble.base.functions import package_data_filename
+from packaging import version
 
 """
 Container for widely used data that may be altered by user inputs.
@@ -124,12 +125,19 @@ def get_values_from_choices(choices:Union[List[str], DADict], value_idx:int=0,
 ######################## pre load ###############################
 # This runs each time the .py file runs, which should be on each uwsgi reset
 
-def advertise_capabilities(package_name:str=None, yaml_name:str="configuration_capabilities.yml", base:str="docassemble.ALWeaver"):
+def load_capabilities(base:str="docassemble.ALWeaver", minimum_version="1.5", include_playground=False):
+  # Get the contents of the current package's capabilities file
+  this_yaml = path_and_mimetype("configuration_capabilities.yml")[0]
+  weaverdata = DAStore(base=base)  
+  published_configuration_capabilities = weaverdata.get("published_configuration_capabilities") or {}
+  
+
+def advertise_capabilities(package_name:str=None, yaml_name:str="configuration_capabilities.yml", base:str="docassemble.ALWeaver", minimum_version="1.5"):
   weaverdata = DAStore(base=base)
   if not package_name:
     package_name = __name__
   published_configuration_capabilities = weaverdata.get("published_configuration_capabilities") or {}
-  published_configuration_capabilities[package_name] = yaml_name
+  published_configuration_capabilities[package_name] = (yaml_name, minimum_version)
   weaverdata.set('published_configuration_capabilities', published_configuration_capabilities)
   
 #def load_capabilities(package_name  
@@ -137,5 +145,8 @@ def advertise_capabilities(package_name:str=None, yaml_name:str="configuration_c
 # TODO: how do we want to handle advertising from the playground? We don't want to break the list of 
 # capabilities if someone has a version of the Weaver that is still in progress
 
-if not __name__ == '__main__' and not 'unittest' in sys.modules:
-  advertise_capabilities(package_name='docassemble.ALWeaver')
+log(f"Unittest is in modules: {'unittest' in sys.modules}")
+
+#if not __name__ == '__main__' and not 'unittest' in sys.modules:
+#  advertise_capabilities()
+advertise_capabilities()

--- a/docassemble/ALWeaver/custom_values.py
+++ b/docassemble/ALWeaver/custom_values.py
@@ -10,6 +10,7 @@ import sys
 from docassemble.base.functions import package_data_filename
 from packaging.version import Version
 import os
+from more_itertools import unique_everseen
 
 ################# To refactor - I don't think these are used but they are mentioned in interview_generator.py
 class Object(object):
@@ -18,10 +19,6 @@ custom_values = Object()
 custom_values.people_plurals_map = {}
 custom_values.org_specific_config = None
 ########################## End to refactor
-
-"""
-Container for widely used data that may be altered by user inputs.
-"""
 
 __all__ = ['get_possible_deps_as_choices', 'get_pypi_deps_from_choices', 
            'get_yml_deps_from_choices', 'SettingsList', 'load_capabilities',
@@ -69,7 +66,7 @@ def load_capabilities(base:str="docassemble.ALWeaver", minimum_version="1.5", in
     if not include_playground and key.startswith("docassemble.playground"):
       del published_configuration_capabilities[key]
   
-  current_package_name = __name__
+  current_package_name = ".".join(__name__.split(".")[:-1])
   for package_name in published_configuration_capabilities:
     # Don't add the current package twice
     if not current_package_name == package_name:
@@ -103,7 +100,7 @@ def get_possible_deps_as_choices(dep_category=None):
         for item in _al_weaver_capabilities[capability].get('jurisdiction_choices',[])
       ])
 
-  return dep_choices
+  return list(unique_everseen(dep_choices))
 
 def get_pypi_deps_from_choices(choices:Union[List[str], DADict]):
   """Gets the Pypi dependency requirement (i.e. docassemble.AssemblyLine>=2.0.19)
@@ -117,7 +114,7 @@ def get_pypi_deps_from_choices(choices:Union[List[str], DADict]):
   for capability in _al_weaver_capabilities:
     pypi_deps.extend([choice.get('dependency') for choice in _al_weaver_capabilities[capability].get('organization_choices',[]) + _al_weaver_capabilities[capability].get('jurisdiction_choices',[]) if choice.get('dependency') and choice.get('include_name') in choice_list])
 
-  return pypi_deps
+  return list(unique_everseen(pypi_deps))
 
 def get_yml_deps_from_choices(choices:Union[List[str], DADict]):
   """Gets the yml file (i.e. docassemble.AssemblyLine:data/question/ql_baseline.yml)

--- a/docassemble/ALWeaver/custom_values.py
+++ b/docassemble/ALWeaver/custom_values.py
@@ -73,7 +73,7 @@ def load_capabilities(base:str="docassemble.ALWeaver", minimum_version="1.5", in
   for package_name in published_configuration_capabilities:
     # Don't add the current package twice
     if not current_package_name == package_name:
-      path = path_and_mimetype(f"{package_name}:data/sources/{published_configuration_capabilities[package_name][0]}")
+      path = path_and_mimetype(f"{package_name}:data/sources/{published_configuration_capabilities[package_name][0]}")[0]
       try:
         with open(path) as f:
           yaml_contents = f.read()

--- a/docassemble/ALWeaver/custom_values.py
+++ b/docassemble/ALWeaver/custom_values.py
@@ -7,6 +7,7 @@ from docassemble.base.core import objects_from_file
 # TODO(brycew): is this too deep into DA? Unclear if there are options to write
 # sources files to a package while it's running.
 import ruamel.yaml as yaml
+import sys
 from docassemble.base.functions import package_data_filename
 
 """
@@ -136,5 +137,5 @@ def advertise_capabilities(package_name:str=None, yaml_name:str="configuration_c
 # TODO: how do we want to handle advertising from the playground? We don't want to break the list of 
 # capabilities if someone has a version of the Weaver that is still in progress
 
-if not __name__ == '__main__':
+if not __name__ == '__main__' and not 'unittest' in sys.modules:
   advertise_capabilities(package_name='docassemble.ALWeaver')

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -6,6 +6,41 @@ metadata:
     <img src="/packagestatic/docassemble.ALWeaver/logo.png" class="ma_icon" alt="Assembly Line Weaver Logo" title="ALWeaver">
   exit url: https://courtformsonline.org  
 ---
+mandatory: True
+code: |
+  menu_items = [ action_menu_item('Configure Weaver', 'configure_weaver') ]
+---
+objects:
+  - weaverdata: DAStore.using(base="docassemble.ALWeaver")
+---
+event: configure_weaver
+question: |
+  Configure Weaver
+subquestion: |
+  The Weaver looks for packages on this server that have said they contain the ability
+  to add customizations, such as new dependencies, variable names, or output patterns.
+  You can add your own Docassemble package that has custom options. For an example
+  package, view [ALAnyState](https://github.com/suffolklitlab/docassemble-alanystate).
+
+  Published Weaver capabilities:
+  
+  % for capability in weaverdata.get("published_configuration_capabilities"):
+  % if "playground" not in capability:
+  * ${ capability }
+  % else:
+  * ${ capability } _(playground only)_
+  % endif
+  % endfor
+  
+  You can clear the configuration by erasing the list of published capabilities. Restarting the
+  server will re-publish capabilities for any packages that are currently on this server.
+  
+  ${ action_button_html(url_action('delete_configuration'), label="Reset published capabilities", icon="trash-alt") }
+---
+event: delete_configuration
+code: |
+  weaverdata.delete("published_configuration_capabilities")  
+---
 imports:
   - pycountry
 ---

--- a/docassemble/ALWeaver/data/questions/config.yml
+++ b/docassemble/ALWeaver/data/questions/config.yml
@@ -23,6 +23,9 @@ objects:
 code: |
   if weaverdata.get("jurisdiction_choices"):
     jurisdiction_choices = weaverdata.get("jurisdiction_choices")
+    
+  #capabilities = load_capabilities()    
+  
   load_values = True
 ---
 id: interview order
@@ -39,6 +42,8 @@ subquestion: |
   
   1. the list of dependencies
   1. the list of prefixes for people and static variables that will not be transformed by the Weaver
+
+  ${ repr(list(load_capabilities())) }
 
   ${ collapse_template(view_weaverdata_template) }
   

--- a/docassemble/ALWeaver/data/questions/config.yml
+++ b/docassemble/ALWeaver/data/questions/config.yml
@@ -5,7 +5,7 @@ modules:
 ---
 features:
   css:
-    - docassemble.ALToolbox:collapse_template.css
+    - docassemble.ALToolbox:collapse_template.css        
 ---
 metadata:
   title: Configure ALWeaver Settings
@@ -21,27 +21,44 @@ objects:
   - jurisdiction_choices: SettingsList.using(object_type=DAObject, there_are_any=True, complete_attribute="description", store=weaverdata)
 ---
 code: |
+  published_configuration_capabilities = weaverdata.get("published_configuration_capabilities") or {}
+  
   if weaverdata.get("jurisdiction_choices"):
     jurisdiction_choices = weaverdata.get("jurisdiction_choices")
-    
-  #capabilities = load_capabilities()    
-  
+      
   load_values = True
+---
+code: |
+  #published_configuration_capabilities["my_fake_key"] = ("some_yaml", "1.5")
+  
+  #weaverdata.set("published_configuration_capabilities", published_configuration_capabilities)
+  
+  add_fake_key = True
 ---
 id: interview order
 mandatory: True
 code: |
   load_values
+  add_fake_key
   intro
+---
+imports:
+  - os
 ---
 id: intro
 question: |
   Weaver customization
 subquestion: |
+  ${ not os.environ.get('ISUNITTEST') }
+
   You can currently customize:
   
   1. the list of dependencies
   1. the list of prefixes for people and static variables that will not be transformed by the Weaver
+
+  ```
+  ${ weaverdata.keys() }
+  ```
 
   ${ repr(list(load_capabilities())) }
 

--- a/docassemble/ALWeaver/data/questions/config.yml
+++ b/docassemble/ALWeaver/data/questions/config.yml
@@ -43,12 +43,18 @@ subquestion: |
   ${ collapse_template(view_weaverdata_template) }
   
   ${ jurisdiction_choices.add_action() }  
+  
+  ${ action_button_html(url_action('delete_configuration'), label="Clear configuration", icon="trash-alt") }
 event: intro
 # docassemble.base.functions.url_action('_da_list_add', list=self.instanceName)
 ---
 question: |
   Is there another juridiction choice?
 yesno: jurisdiction_choices.there_is_another  
+---
+event: delete_configuration
+code: |
+  weaverdata.delete("published_configuration_capabilities")
 ---
 question: |
   Jurisdiction choices

--- a/docassemble/ALWeaver/data/questions/config.yml
+++ b/docassemble/ALWeaver/data/questions/config.yml
@@ -1,0 +1,109 @@
+---
+modules:
+  - docassemble.ALToolbox.misc
+  - .custom_values
+---
+features:
+  css:
+    - docassemble.ALToolbox:collapse_template.css
+---
+metadata:
+  title: Configure ALWeaver Settings
+  short title: Configure ALWeaver
+  temporary session: True
+  required privileges:
+    - admin
+---
+objects:
+  - weaverdata: DAStore.using(base="docassemble.ALWeaver")
+---
+objects:
+  - jurisdiction_choices: SettingsList.using(object_type=DAObject, there_are_any=True, complete_attribute="description", store=weaverdata)
+---
+code: |
+  if weaverdata.get("jurisdiction_choices"):
+    jurisdiction_choices = weaverdata.get("jurisdiction_choices")
+  load_values = True
+---
+id: interview order
+mandatory: True
+code: |
+  load_values
+  intro
+---
+id: intro
+question: |
+  Weaver customization
+subquestion: |
+  You can currently customize:
+  
+  1. the list of dependencies
+  1. the list of prefixes for people and static variables that will not be transformed by the Weaver
+
+  ${ collapse_template(view_weaverdata_template) }
+  
+  ${ jurisdiction_choices.add_action() }  
+event: intro
+# docassemble.base.functions.url_action('_da_list_add', list=self.instanceName)
+---
+question: |
+  Is there another juridiction choice?
+yesno: jurisdiction_choices.there_is_another  
+---
+question: |
+  Jurisdiction choices
+list collect: 
+  is final: True
+fields:
+  - Descriptive name: jurisdiction_choices[i].description
+  - Dependency to add to setup.py: jurisdiction_choices[i].dependency_name
+    help: |
+      Like: `docassemble.ALMassachusetts>=0.7` or just like `docassemble.ALMassachusetts`.
+    validate: |
+      lambda y: y.startswith('docassemble.') and not ' ' in y or validation_error("Enter a valid Docassemble package name, like 'docassemble.ALMassachusetts'")
+  - YAML file name to add to `include` statement (optional): jurisdiction_choices[i].include_name
+    help: |
+      Like: `docassemble.ALMassachusetts:massachusetts.yml`
+    required: False
+    validate: |
+      lambda y: (not y or (y.startswith('docassemble.') and ':' in y and y.endswith('.yml'))) or validation_error("Add a valid path to a YAML file, including the docassemble package name, like: 'docassemble.ALMassachusetts:massachusetts.yml'")
+  - Enable by default: jurisdiction_choices[i].default
+    datatype: yesno
+---
+code: |
+  weaverdata.set("jurisdiction_choices", jurisdiction_choices)
+  update_jurisdictions = True
+---
+template: view_weaverdata_template
+subject: |
+  View current settings
+content: |
+  #### Jurisdiction choices
+  ${ jurisdiction_choices.table }
+  
+  #### Organization choices
+  ```
+  ```
+  
+  #### Output pattern file
+  ```
+  ```
+  
+  #### Published keys
+  
+  ```
+  ${ weaverdata.get("published_configuration_capabilities") }
+  ```
+
+---
+table: jurisdiction_choices.table
+rows: jurisdiction_choices
+columns: 
+  - Descriptive name: |
+      row_item.description
+  - Dependency: |
+      row_item.dependency_name
+  - YAML include: |
+      row_item.include_name
+  - Default: |
+      row_item.default

--- a/docassemble/ALWeaver/data/questions/config.yml
+++ b/docassemble/ALWeaver/data/questions/config.yml
@@ -107,14 +107,18 @@ subject: |
   View current settings
 content: |
   #### Jurisdiction choices
-  ${ jurisdiction_choices.table }
+  ```
+  ${ get_possible_deps_as_choices('jurisdiction') }
+  ```
   
   #### Organization choices
   ```
+  ${ get_possible_deps_as_choices('organization') }
   ```
   
   #### Output pattern file
   ```
+  
   ```
   
   #### Published keys

--- a/docassemble/ALWeaver/data/sources/configuration_capabilities.yml
+++ b/docassemble/ALWeaver/data/sources/configuration_capabilities.yml
@@ -28,15 +28,16 @@ organization_choices:
     state: LA
     country: US
     default: False
-# The paths below will be prefixed with the name of this package: in the data/templates folder for templates and
-# data/sources folder for output_patterns, interview_structure, and variable_names
-next steps template files:
-  starts_case: next_steps_starts_case.docx
-  existing_case: next_steps_existing_case.docx
-  appeal: next_steps_appeal.docx
-  other_form: next_steps_other_form.docx
-  letter: next_steps_letter.docx
-  other: next_steps_other.docx
-output_patterns: output_patterns.yml
-interview_structure: interview_structure.yml
-variable_names: variable_names.yml
+# The paths below will be prefixed with the name of this package: 
+# in the data/templates folder for templates and output_pattern
+# and data/sources folder for variable_names
+# Below are not yet implemented
+# next steps template files:
+#   starts_case: next_steps_starts_case.docx
+#   existing_case: next_steps_existing_case.docx
+#   appeal: next_steps_appeal.docx
+#   other_form: next_steps_other_form.docx
+#   letter: next_steps_letter.docx
+#   other: next_steps_other.docx
+# output_pattern: output_pattern.md
+# variable_names: variable_names.yml

--- a/docassemble/ALWeaver/data/sources/configuration_capabilities.yml
+++ b/docassemble/ALWeaver/data/sources/configuration_capabilities.yml
@@ -13,14 +13,20 @@ organization_choices:
   - description: MassAccess
     dependency: "docassemble.MassAccess"
     include_name: "docassemble.MassAccess:massaccess.yml"
+    state: MA
+    country: US
     default: True
   - description: Illinois Legal Aid Online
     dependency: "docassemble.ILAO"
     include_name: "docassemble.ILAO:ilao-interview-framework.yml"
+    state: IL
+    country: US
     default: False
   - description: Louisiana Supreme Court
     dependency: "docassemble.ALLouisianaSC"
     include_name: "docassemble.ALLouisianaSC:custom_organization.yml"
+    state: LA
+    country: US
     default: False
 # The paths below will be prefixed with the name of this package: in the data/templates folder for templates and
 # data/sources folder for output_patterns, interview_structure, and variable_names

--- a/docassemble/ALWeaver/data/sources/configuration_capabilities.yml
+++ b/docassemble/ALWeaver/data/sources/configuration_capabilities.yml
@@ -7,6 +7,8 @@ jurisdiction_choices:
     dependency: "docassemble.ALMassachusetts>=0.0.7"
     include_name: "docassemble.ALMassachusetts:al_massachusetts.yml"
     default: True
+    state: MA
+    country: US
 organization_choices:
   - description: MassAccess
     dependency: "docassemble.MassAccess"
@@ -20,6 +22,15 @@ organization_choices:
     dependency: "docassemble.ALLouisianaSC"
     include_name: "docassemble.ALLouisianaSC:custom_organization.yml"
     default: False
+# The paths below will be prefixed with the name of this package: in the data/templates folder for templates and
+# data/sources folder for output_patterns, interview_structure, and variable_names
+next steps template files:
+  starts_case: next_steps_starts_case.docx
+  existing_case: next_steps_existing_case.docx
+  appeal: next_steps_appeal.docx
+  other_form: next_steps_other_form.docx
+  letter: next_steps_letter.docx
+  other: next_steps_other.docx
 output_patterns: output_patterns.yml
 interview_structure: interview_structure.yml
 variable_names: variable_names.yml

--- a/docassemble/ALWeaver/data/sources/configuration_capabilities.yml
+++ b/docassemble/ALWeaver/data/sources/configuration_capabilities.yml
@@ -1,0 +1,25 @@
+######################
+# List of available configuration options that this package supplies
+# These are the "default" dependencies, etc.
+package name: Default Weaver Choices (CourtFormsOnline/MassAcccess)
+jurisdiction_choices:
+  - description: Massachusetts
+    dependency: "docassemble.ALMassachusetts>=0.0.7"
+    include_name: "docassemble.ALMassachusetts:al_massachusetts.yml"
+    default: True
+organization_choices:
+  - description: MassAccess
+    dependency: "docassemble.MassAccess"
+    include_name: "docassemble.MassAccess:massaccess.yml"
+    default: True
+  - description: Illinois Legal Aid Online
+    dependency: "docassemble.ILAO"
+    include_name: "docassemble.ILAO:ilao-interview-framework.yml"
+    default: False
+  - description: Louisiana Supreme Court
+    dependency: "docassemble.ALLouisianaSC"
+    include_name: "docassemble.ALLouisianaSC:custom_organization.yml"
+    default: False
+output_patterns: output_patterns.yml
+interview_structure: interview_structure.yml
+variable_names: variable_names.yml

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -5,12 +5,10 @@ import re
 import uuid
 from collections import defaultdict
 from docx2python import docx2python
-from docassemble.base.error import DAError
-from docassemble.base.util import log, space_to_underscore, bold, DAObject, DAList, DAFile, DAFileList, path_and_mimetype, user_info
+from docassemble.base.util import log, space_to_underscore, bold, DAObject, DAList, DAFile, DAFileList, path_and_mimetype, user_info, DAEmpty
 import docassemble.base.functions
 import docassemble.base.parse
 import docassemble.base.pdftk
-from docassemble.base.core import DAEmpty
 import datetime
 import zipfile
 import json

--- a/docassemble/ALWeaver/requirements.txt
+++ b/docassemble/ALWeaver/requirements.txt
@@ -1,3 +1,4 @@
 docassemble.base
 pyyaml
 docx2python
+boto3

--- a/docassemble/ALWeaver/requirements.txt
+++ b/docassemble/ALWeaver/requirements.txt
@@ -1,3 +1,3 @@
-docassemble.base==1.2.65
+docassemble.base
 pyyaml
 docx2python

--- a/docassemble/ALWeaver/requirements.txt
+++ b/docassemble/ALWeaver/requirements.txt
@@ -1,5 +1,6 @@
 docassemble.base>=1.3
 docassemble.webapp
+more_itertools
 pyyaml
 docx2python
 boto3

--- a/docassemble/ALWeaver/requirements.txt
+++ b/docassemble/ALWeaver/requirements.txt
@@ -1,4 +1,5 @@
-docassemble.base
+docassemble.base>=1.3
+docassemble.webapp
 pyyaml
 docx2python
 boto3


### PR DESCRIPTION
This lays the groundwork to allow all kinds of Weaver customizations. The current version offers just one:

* list of state and organization dependencies.

Customizations are contained in a YAML file, `configuration_capabilities.yml`. If a package has a `configuration_capabilities.yml` that
it wants to advertise, it uses the `advertise_capabilities()` function to add an entry into a `DAStore`. The Weaver then scans the DAStore to look for available customizations.

Customizations are versioned to allow for future breaking changes.

This first set of customizations is purely additive--adding the configuration_capabilities expands the list of dependencies the interview author can choose from. Future vision is to allow the interview author to make some selection between customizations at the beginning of each Weaver run, possibly with an option to "remember" the default customization that the author wants to use. Most likely, the customizations would be used for one organization, but it might also make sense to use different interview templates for different kinds of tasks, such as triage tools, intake tools, court forms, etc.

This PR includes a `config.yml` runtime interview that lets you explore and debug the DAStore; note that it also includes features that haven't been implemented yet, such as a way to manually add additional dependencies. It shouldn't be included in the review.

The next phase of this customization push will be to adapt the `output_patterns.yml` file so it contains the full generated interview instead of just individual blocks. This will make it easier for organizations to use the Weaver for different tasks. After that, I plan to tackle the variables that are in `generator_constants.py` and move those to a YAML file. I believe this priority correctly reflects the difficulty of each refactor.

There is only one package (installed on apps-dev) that currently uses the advertise_capabilities API; [docassemble-ALAnyState](https://github.com/suffolklitlab/docassemble-alanystate). This will hook into the [Form-Explorer](https://suffolklitlab.org/form-explorer/) to be the catchall package for interviews created outside of Massachusetts.

Will probably do a squash and merge since there are so many commits in this branch