### PR TITLE
Adds an exit screen for another PDF parsing error

### DIFF
--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -60,18 +60,11 @@ code: |
     template_upload
     if template_upload[0].filename.endswith('pdf'):
       validate_pdf
-      log( 'wat?', 'console' )
       if no_recognized_pdf_fields:
-        log( 'a', 'console' )
         warn_no_recognized_al_labels
-        log( 'b', 'console' )
-      log( 1, 'console' )
       fields_checkup_status
-      log( 2, 'console' )
       all_look_good
-      log( 3, 'console' )
       validation_success
-      log( 4, 'console' )
     else:
       if no_recognized_docx_fields:
         warn_no_recognized_al_labels

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -699,9 +699,7 @@ event: exit_PSEOF_error
 question: |
   Something is wrong with the internals of this PDF
 subquestion: |
-  Docassemble was not able to read ${ template_upload[0].filename }. The error
-  was a "pdfminer.psparser.PSEOF: Unexpected EOF". It might be an XFA form or
-  something else might be wrong with its formatting.
+  Docassemble was not able to read ${ template_upload[0].filename }.
   
   You can try using [documate.org/pdf](https://www.documate.org/pdf)
   or [qpdf](http://qpdf.sourceforge.net/) to fix it, but some of your

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -701,8 +701,8 @@ question: |
 subquestion: |
   Docassemble was not able to read ${ template_upload[0].filename }.
   
-  You can try using [documate.org/pdf](https://www.documate.org/pdf)
-  or [qpdf](http://qpdf.sourceforge.net/) to fix it, but some of your
+  You can try using [qpdf](http://qpdf.sourceforge.net/) or
+  [documate.org/pdf](https://www.documate.org/pdf) to fix it, but some of your
   interactive elements may stop working.
 buttons:
   - Restart: restart

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -48,7 +48,7 @@ objects:
 ---
 mandatory: True
 id: Interview Order
-code: |  
+code: |
   process_url_args  
   # Check to see if we are launched from the form explorer, and
   # skip the file validation if so
@@ -60,11 +60,18 @@ code: |
     template_upload
     if template_upload[0].filename.endswith('pdf'):
       validate_pdf
+      log( 'wat?', 'console' )
       if no_recognized_pdf_fields:
+        log( 'a', 'console' )
         warn_no_recognized_al_labels
+        log( 'b', 'console' )
+      log( 1, 'console' )
       fields_checkup_status
-      all_look_good    
+      log( 2, 'console' )
+      all_look_good
+      log( 3, 'console' )
       validation_success
+      log( 4, 'console' )
     else:
       if no_recognized_docx_fields:
         warn_no_recognized_al_labels
@@ -651,6 +658,7 @@ comment: |
   right away
 code: |
   from pdfminer.pdfparser import PDFSyntaxError
+  from pdfminer.psparser import PSEOF
   from PyPDF2.utils import PdfReadError
   from zipfile import BadZipFile
   
@@ -674,6 +682,8 @@ code: |
   except (PDFSyntaxError, PdfReadError):
     # Handle PDF read error
     force_ask('exit_invalid_pdf')
+  except PSEOF:
+    force_ask('exit_PSEOF_error')
   except (BadZipFile, KeyError):
     force_ask('exit_invalid_docx')
 ---
@@ -689,6 +699,20 @@ subquestion: |
   
   If it is a PDF, try using [documate.org/pdf](https://www.documate.org/pdf)
   or [qpdf](http://qpdf.sourceforge.net/) to fix it.
+buttons:
+  - Restart: restart
+---
+event: exit_PSEOF_error
+question: |
+  Something is wrong with the format of this PDF
+subquestion: |
+  Docassemble was not able to read ${ template_upload[0].filename }. The error
+  was a "pdfminer.psparser.PSEOF: Unexpected EOF". It might be an XFA form or
+  something else might be wrong with its formatting.
+  
+  You can try using [documate.org/pdf](https://www.documate.org/pdf)
+  or [qpdf](http://qpdf.sourceforge.net/) to fix it, but some of your
+  interactive elements may stop working.
 buttons:
   - Restart: restart
 ---

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -697,7 +697,7 @@ buttons:
 ---
 event: exit_PSEOF_error
 question: |
-  Something is wrong with the format of this PDF
+  Something is wrong with the internals of this PDF
 subquestion: |
   Docassemble was not able to read ${ template_upload[0].filename }. The error
   was a "pdfminer.psparser.PSEOF: Unexpected EOF". It might be an XFA form or

--- a/docassemble/ALWeaver/data/questions/pdf_field_tester.yml
+++ b/docassemble/ALWeaver/data/questions/pdf_field_tester.yml
@@ -256,12 +256,12 @@ attachment:
 code: |
   from pdfminer.pdfparser import PDFSyntaxError
   from PyPDF2.utils import PdfReadError
-
+  
   try:
     pdf_concatenate(template_upload)
   except PDFSyntaxError:
     # Handle PDF read error
-    force_ask('exit_invalid_file')
+    force_ask('exit_invalid_pdf')
   except PdfReadError:
     force_ask('exit_xref_table')
   except:


### PR DESCRIPTION
Closes #521. I wasn't able to find a (free) way for humans to fix this without losing the functionality of interactive elements of the form. Feel free to edit the error page if you know more. Also fixes an outdated variable name.