### PR TITLE
Fix #539, `objects_from_file()` is now in docassemble.base.util

### DIFF
--- a/docassemble/ALWeaver/custom_values.py
+++ b/docassemble/ALWeaver/custom_values.py
@@ -1,8 +1,7 @@
 from typing import List, Union
 from pathlib import Path
 import yaml
-from docassemble.base.util import log, DADict
-from docassemble.base.core import objects_from_file
+from docassemble.base.util import log, DADict, objects_from_file
 # TODO(brycew): is this too deep into DA? Unclear if there are options to write
 # sources files to a package while it's running.
 from docassemble.base.functions import package_data_filename

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -108,7 +108,7 @@ code: |
     add_addendum_fields
   
   # Assemble output package 
-  wrote_interview  
+  wrote_interview
 
   # Display output download screen
   show_interview


### PR DESCRIPTION
Fixes #539