### PR TITLE
Address #538, add var for ALKiln tests to compare YAML output as text

### DIFF
--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -109,6 +109,7 @@ code: |
   
   # Assemble output package 
   wrote_interview
+  interview_source = interview.source()
 
   # Display output download screen
   show_interview


### PR DESCRIPTION
Addresses #538. [Can't be tested until #540 is merged to fix the error.]