### PR TITLE
Sanitize filenames

### DIFF
--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -350,7 +350,7 @@ code: |
   if template_upload[0].filename.endswith('pdf'):
     short_filename = space_to_underscore(varname(template_upload[0].filename[:-len(".pdf")]))
   else:
-    short_filename = space_to_underscore(varname(template_upload[0].filename.lower().strip(".docx")))
+    short_filename = space_to_underscore(varname(template_upload[0].filename.lower()[:len(".docx")]))
   
   short_filename_with_spaces = short_filename.replace('_',' ').capitalize()
 ---

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -348,9 +348,9 @@ code: |
 ---
 code: |
   if template_upload[0].filename.endswith('pdf'):
-    short_filename = template_upload[0].filename[:-4]
+    short_filename = space_to_underscore(varname(template_upload[0].filename.lower().strip(".pdf")))
   else:
-    short_filename = template_upload[0].filename[:-5]
+    short_filename = space_to_underscore(varname(template_upload[0].filename.lower().strip(".docx")))
   
   short_filename_with_spaces = short_filename.replace('_',' ').capitalize()
 ---

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -350,7 +350,7 @@ code: |
   if template_upload[0].filename.endswith('pdf'):
     short_filename = space_to_underscore(varname(template_upload[0].filename.lower()[:-len(".pdf")]))
   else:
-    short_filename = space_to_underscore(varname(template_upload[0].filename.lower()[:len(".docx")]))
+    short_filename = space_to_underscore(varname(template_upload[0].filename.lower()[:-len(".docx")]))
   
   short_filename_with_spaces = short_filename.replace('_',' ').capitalize()
 ---

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -280,7 +280,7 @@ code: |
   if url_args.get('title'):
     short_filename_with_spaces = url_args.get('title')
     interview.title = short_filename_with_spaces
-    short_filename = space_to_underscore(short_filename_with_spaces)
+    short_filename = space_to_underscore(varname(short_filename_with_spaces))
     interview_label_draft = short_filename
   if url_args.get('jur'):
     interview.state = url_args.get('jur')

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -1549,8 +1549,11 @@ code: |
   # Package title is PascalCase, per our AssemblyLine convention
   package_title = re.sub("\W|_","", interview_label.title())
 ---
+code: |
+  sanitized_filename = f"{interview_label}.{template_upload[0].extension}"
+---
 objects:
-  - renamed_upload: DAFile.using(filename=f"{interview_label}.{template_upload[0].extension}")
+  - renamed_upload: DAFile.using(filename=sanitized_filename)
 ---
 code: |
   renamed_upload.copy_into(template_upload[0])
@@ -1654,8 +1657,8 @@ code: |
 
   # Set attributes for the uploaded template file     
   file1 = labels_lists.appendObject()    
-  file1.input_filename = f"{interview_label}.{template_upload[0].extension}"  
-  file1.output_filename = interview_label
+  file1.input_filename = sanitized_filename  
+  file1.output_filename = sanitized_filename
   file1.attachment_varname = attachment_variable_name    
   file1.type = template_upload[0].extension  
   file1.description = interview.title

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -348,7 +348,7 @@ code: |
 ---
 code: |
   if template_upload[0].filename.endswith('pdf'):
-    short_filename = space_to_underscore(varname(template_upload[0].filename[:-len(".pdf")]))
+    short_filename = space_to_underscore(varname(template_upload[0].filename.lower()[:-len(".pdf")]))
   else:
     short_filename = space_to_underscore(varname(template_upload[0].filename.lower()[:len(".docx")]))
   

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -1549,7 +1549,16 @@ code: |
   # Package title is PascalCase, per our AssemblyLine convention
   package_title = re.sub("\W|_","", interview_label.title())
 ---
+objects:
+  - renamed_upload: DAFile.using(filename=f"{interview_label}.{template_upload[0].extension}")
+---
+code: |
+  renamed_upload.copy_into(template_upload[0])
+  renamed_upload.commit()
+  inflate_renamed_upload = True
+---
 need:
+  - inflate_renamed_upload
   - interview.author
 # Prepare content for the Weaver's download screen.
 code: |
@@ -1561,7 +1570,7 @@ code: |
   folders_and_files = {
     "templates": [
       next_steps_documents[interview.form_type]['attachment'].docx,
-      template_upload[0],
+      renamed_upload,
     ],
     "questions": [interview_download],
     "modules":[],
@@ -1645,7 +1654,7 @@ code: |
 
   # Set attributes for the uploaded template file     
   file1 = labels_lists.appendObject()    
-  file1.input_filename = template_upload[0].filename
+  file1.input_filename = f"{interview_label}.{template_upload[0].extension}"  
   file1.output_filename = interview_label
   file1.attachment_varname = attachment_variable_name    
   file1.type = template_upload[0].extension  

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -348,7 +348,7 @@ code: |
 ---
 code: |
   if template_upload[0].filename.endswith('pdf'):
-    short_filename = space_to_underscore(varname(template_upload[0].filename.lower().strip(".pdf")))
+    short_filename = space_to_underscore(varname(template_upload[0].filename[:-len(".pdf")]))
   else:
     short_filename = space_to_underscore(varname(template_upload[0].filename.lower().strip(".docx")))
   


### PR DESCRIPTION
This changes the way that the interview_label is created so that it matches not just the rules for variable names but also the filename sanitization methods that are used by werkzeug.utils.secure_filename(). Docassemble upstream limits the filenames in the playground to those that pass the werkzeug.utils.secure_filename() sanitization rules, so this helps ensure that packages we create in can be edited in the Playground.

This patch also makes the interview_label lowercase by default and renames the template and YAML to match the interview_label.

Fix #561

~Edit: give me a sec to make sure the filenames of a generated interview still all match up, sorry!~ Ready to be reviewed.

If you want you can try running the Weaver with the filename that started this all: `01 - Intake NOTES w all Variables.docx`