### PR TITLE
Separate out the next_steps generation to speed it up

### DIFF
--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -1563,30 +1563,53 @@ objects:
   - labels_lists: DAList.using(auto_gather=False, gathered=True)
   - next_steps_documents: DADict.using(object_type=DADict)
 ---
+############ Next Steps documents generation ################
+comment: |
+  All of the below code is split into separate code blocks so we don't slow things down
 code: |
   next_steps_documents['starts_case']['attachment'] = next_steps_starts_case
+---
+code: |
   next_steps_documents['existing_case']['attachment'] = next_steps_existing_case
+---
+code: |
   next_steps_documents['appeal']['attachment'] = next_steps_appeal
+---
+code: |
   next_steps_documents['letter']['attachment'] = next_steps_letter
+---
+code: |
   next_steps_documents['other_form']['attachment'] = next_steps_other_form
+---
+code: |
   next_steps_documents['other']['attachment'] = next_steps_other
 ---
 attachments:
   - variable name: next_steps_starts_case
     docx template file: next_steps_starts_case.docx
     filename: ${ interview_label + '_next_steps' }
+---
+attachments:
   - variable name: next_steps_existing_case
     docx template file: next_steps_existing_case.docx
     filename: ${ interview_label + '_next_steps' }    
+---
+attachments:
   - variable name: next_steps_appeal
     docx template file: next_steps_appeal.docx
     filename: ${ interview_label + '_next_steps' }    
+---
+attachments:
   - variable name: next_steps_letter
     docx template file: next_steps_letter.docx
     filename: ${ interview_label + '_next_steps' }    
+---
+attachments:
   - variable name: next_steps_other_form
     docx template file:  next_steps_other_form.docx
     filename: ${ interview_label + '_next_steps' }    
+---
+attachments:
   - variable name: next_steps_other
     docx template file:  next_steps_other.docx
     filename: ${ interview_label + '_next_steps' }    

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -1565,7 +1565,7 @@ objects:
 ---
 ############ Next Steps documents generation ################
 comment: |
-  All of the below code is split into separate code blocks so we don't slow things down
+  All of the below code is split into separate code blocks so it doesn't generate all docs when we only need 1
 code: |
   next_steps_documents['starts_case']['attachment'] = next_steps_starts_case
 ---


### PR DESCRIPTION
While the "I'm feeling lucky button" was taking 19 seconds to run, I decided to see why it was taking that long. It seem that the largest timesink was that DA was taking 10 seconds to generate all of the DOCX forms for the next steps (~2 seconds per form to get the libreoffice lock), even though only one was being used.  I did a simple I'm feeling lucky test with this code (installed it on the Dev server for ~5 minutes and triggered a run from the form-explorer during that time) and things worked. It's not extremely snappy, but we did take off 8 or so seconds from clicking the button to seeing the "done" screen.