### PR TITLE
Formfyxer is Back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version v1.6.3
+
+FormFyxer is back?
+
 # Version v1.6.2
 
 Revert FormFyxer, spacy models aren't installing correctly. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Version v1.6.3
 
-FormFyxer is back?
+FormFyxer is back!
 
 # Version v1.6.2
 

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -100,7 +100,6 @@ code: |
     weaver_intro
     template_upload
     if template_upload[0].filename.endswith('pdf'):
-      yes_normalize_fields = False
       if yes_normalize_fields:
         process_field_normalization
       validate_pdf
@@ -272,11 +271,11 @@ fields:
     datatype: file
     accept: |
       ".pdf, application/pdf, .docx, application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-#  - Rename fields automatically (PDFs only): yes_normalize_fields
-#    datatype: yesno
-#    help: |
-#      Use our experimental code to automatically apply AssemblyLine naming conventions.
-#      If you already followed naming conventions, you might want to skip this.
+  - Rename fields automatically (PDFs only): yes_normalize_fields
+    datatype: yesno
+    help: |
+      Use our experimental code to automatically apply AssemblyLine naming conventions.
+      If you already followed naming conventions, you might want to skip this.
 validation code: |
   try:
     pdf_concatenate(template_upload, template_upload)

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -6,8 +6,8 @@ metadata:
     <img src="/packagestatic/docassemble.ALWeaver/logo.png" class="ma_icon" alt="Assembly Line Weaver Logo" title="ALWeaver">
   exit url: https://courtformsonline.org  
 ---
-#imports:
-#  - formfyxer
+imports:
+  - formfyxer
 ---
 mandatory: True
 code: |
@@ -313,8 +313,8 @@ code: |
 ---
 code: |
   import os
-  #formfyxer.parse_form(template_upload[0].path(), title=os.path.basename(template_upload[0].path()), jur="MA", normalize=1,rewrite=1)
-  #template_upload[0].commit()
+  formfyxer.parse_form(template_upload[0].path(), title=os.path.basename(template_upload[0].path()), jur="MA", normalize=1,rewrite=1)
+  template_upload[0].commit()
   process_field_normalization = True
 ---
 modules:

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.ALWeaver',
       url='https://docassemble.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['PyYAML>=5.1.2', 'beautifulsoup4>=4.9.3', 'docassemble.ALToolbox>=0.3.6', 'docassemble.AssemblyLine>=2.10.1', 'docx2python>=1.27.1', 'formfyxer>=0.0.6', 'more-itertools>=8.6.0', 'numpy>=1.0.4', 'pikepdf>=5.1.0', 'sklearn>=0.0', 'spacy>=3.2.0'],
+      install_requires=['PyYAML>=5.1.2', 'beautifulsoup4>=4.9.3', 'docassemble.ALToolbox>=0.3.6', 'docassemble.AssemblyLine>=2.10.1', 'docx2python>=1.27.1', 'formfyxer>=0.0.7', 'more-itertools>=8.6.0', 'numpy>=1.0.4', 'pikepdf>=5.1.0', 'sklearn>=0.0', 'spacy>=3.2.0'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/ALWeaver/', package='docassemble.ALWeaver'),
      )

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.ALWeaver',
       url='https://docassemble.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['PyYAML>=5.1.2', 'beautifulsoup4>=4.9.3', 'docassemble.ALToolbox>=0.3.6', 'docassemble.AssemblyLine>=2.10.1', 'docx2python>=1.27.1', 'more-itertools>=8.6.0', 'numpy>=1.0.4', 'pikepdf>=5.1.0', 'sklearn>=0.0', 'spacy>=3.2.0'],
+      install_requires=['PyYAML>=5.1.2', 'beautifulsoup4>=4.9.3', 'docassemble.ALToolbox>=0.3.6', 'docassemble.AssemblyLine>=2.10.1', 'docx2python>=1.27.1', 'formfyxer>=0.0.6', 'more-itertools>=8.6.0', 'numpy>=1.0.4', 'pikepdf>=5.1.0', 'sklearn>=0.0', 'spacy>=3.2.0'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/ALWeaver/', package='docassemble.ALWeaver'),
      )


### PR DESCRIPTION
Reverts the reversion in #577.  Should be merged only after https://github.com/SuffolkLITLab/FormFyxer/pull/44 is merged and published on Pypi. 