### PR TITLE
description-file -> description_file and bad attribute in block

### DIFF
--- a/docassemble/ALWeaver/data/questions/pdf_field_tester.yml
+++ b/docassemble/ALWeaver/data/questions/pdf_field_tester.yml
@@ -260,7 +260,6 @@ code: |
 id: rename fields
 question: |
   Rename fields
-labels above fields: True  
 fields: 
   - code: |
       [{item[0]: f"rename_fields['{item[0]}']", "default" : item[0], "label above field": True, "required": False} for item in template_upload[0].get_pdf_fields()]

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -1766,7 +1766,7 @@ include README.md
 """
     setupcfg = """\
 [metadata]
-description-file = README.md
+description_file = README.md
 """
     setuppy = """\
 import os

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
## description-file -> description_file

There's a small warning when install the Weaver:
`Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead`

No explicit removal version is given anywhere, but might as well change it.

https://setuptools.pypa.io/en/latest/history.html#id239

## bad attribute in block

`labels above fields` is only an initial/feature block feature, or per field, not per question.
