### PR TITLE
Moves the use of docx2python into a module

### DIFF
--- a/docassemble/ALWeaver/data/questions/docx_field_tester.yml
+++ b/docassemble/ALWeaver/data/questions/docx_field_tester.yml
@@ -19,12 +19,7 @@ code: |
   validate_docx = True
 ---
 code: |
-  from docx2python import docx2python
-  match_mako = r"\${[^{].*\}" # look for ${ without a double {{, for cases of dollar values
-  docx_data = docx2python( template_upload[0].path() )  # Will error with invalid value
-  
-  mako_matches = re.findall(match_mako, docx_data.text)
-  
+  mako_matches = get_mako_matches(template_upload[0])
   contains_mako = len(mako_matches)
 ---
 need: 

--- a/docassemble/ALWeaver/validate_docx_files.py
+++ b/docassemble/ALWeaver/validate_docx_files.py
@@ -1,11 +1,14 @@
-from jinja2 import Undefined, DebugUndefined
+from jinja2 import DebugUndefined
 from jinja2.utils import missing
 from docxtpl import DocxTemplate
+from docx2python import docx2python
 from jinja2 import Environment, BaseLoader
 import jinja2.exceptions
 from docassemble.base.util import DAFile
+from typing import Optional, Iterable
+import re
 
-__all__ = ["CallAndDebugUndefined", "get_jinja_errors"]
+__all__ = ["CallAndDebugUndefined", "get_jinja_errors", "get_mako_matches"]
 
 
 class CallAndDebugUndefined(DebugUndefined):
@@ -22,7 +25,7 @@ class CallAndDebugUndefined(DebugUndefined):
     __getitem__ = __getattr__  # type: ignore
 
 
-def get_jinja_errors(the_file: DAFile) -> str:
+def get_jinja_errors(the_file: DAFile) -> Optional[str]:
     """Just try rendering the DOCX file as a Jinja2 template and catch any errors.
     Returns a string with the errors, if any.
     """
@@ -31,6 +34,7 @@ def get_jinja_errors(the_file: DAFile) -> str:
     doc = DocxTemplate(the_file.path())
     try:
         doc.render({}, jinja_env=env)
+        return None
     except jinja2.exceptions.TemplateSyntaxError as the_error:
         errmess = str(the_error)
         if hasattr(the_error, "docx_context"):
@@ -38,3 +42,9 @@ def get_jinja_errors(the_file: DAFile) -> str:
                 map(lambda x: "  " + x, the_error.docx_context)
             )
         return errmess
+
+def get_mako_matches(the_file: DAFile) -> Iterable[str]:
+    """Find's instances of mako in the file's DOCX content's """
+    match_mako = r"\${[^{].*\}" # look for ${ without a double {{, for cases of dollar values
+    docx_data = docx2python( the_file.path() )  # Will error with invalid value
+    return re.findall(match_mako, docx_data.text)


### PR DESCRIPTION
Docx2python recently released version 2, which adds a DocxReader insteance to
the docx_data object returned by docx2python. I'm pretty sure that it's
considered a "_io.BufferedReader" object, which can't be pickled and causes
an error in docassemble when it remains in the global variable space.

https://github.com/ShayHill/docx2python/blob/master/changelog.md