### PR TITLE
Display the "send overflow to addendum" checkbox only on `datatype: area` inputs

### DIFF
--- a/docassemble/ALWeaver/generator_constants.py
+++ b/docassemble/ALWeaver/generator_constants.py
@@ -47,6 +47,7 @@ generator_constants.RESERVED_PREFIXES = [
     "courts",
     "decedents",
     "interested_partys",
+    "interested_parties",
     "trial_court",
     "docket_numbers",
     "user",
@@ -69,6 +70,7 @@ generator_constants.RESERVED_PREFIXES = [
     "interested_party",
     "trial_court",
     "docket_numbers",
+    "adoptees",
     # Can't find a way to make order not matter here
     # without making everything in general more messy
     "guardians_ad_litem",
@@ -99,6 +101,7 @@ generator_constants.RESERVED_PERSON_PLURALIZERS_MAP = {
     "interested_parties": "interested_parties",
     "guardians_ad_litem": "guardians_ad_litem",
     "guardians": "guardians",
+    "adoptees": "adoptees",
     # These are left in for backwards compatibility
     "user": "users",
     "plaintiff": "plaintiffs",
@@ -120,6 +123,7 @@ generator_constants.RESERVED_PERSON_PLURALIZERS_MAP = {
     "witness": "witnesses",
     "decedent": "decedents",
     "interested_party": "interested_parties",
+    "adoptee": "adoptees",
 }
 
 generator_constants.RESERVED_PRIMITIVE_PLURALIZERS_MAP = {

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -640,16 +640,16 @@ class DAField(DAObject):
                 "hint": "Like 'Descriptive name: key_name', or just 'Descriptive name'",
             }
         )
-        if hasattr(self, 'maxlength'):
-          field_questions.append(
-              {
-                  "label": "Send overflow text to addendum",
-                  "field": f"fields[{index}].send_to_addendum",
-                  "datatype": "yesno",
-                  "js show if": f"val('fields[{index}].field_type') === 'area' ",
-                  "help": "Check the box to send text that doesn't fit in the PDF to an additional page, instead of limiting the input length.",
-              }
-          )
+        if hasattr(self, "maxlength"):
+            field_questions.append(
+                {
+                    "label": "Send overflow text to addendum",
+                    "field": f"fields[{index}].send_to_addendum",
+                    "datatype": "yesno",
+                    "js show if": f"val('fields[{index}].field_type') === 'area' ",
+                    "help": "Check the box to send text that doesn't fit in the PDF to an additional page, instead of limiting the input length.",
+                }
+            )
         return field_questions
 
     def trigger_gather(

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -640,15 +640,16 @@ class DAField(DAObject):
                 "hint": "Like 'Descriptive name: key_name', or just 'Descriptive name'",
             }
         )
-        field_questions.append(
-            {
-                "label": "Send overflow text to addendum",
-                "field": f"fields[{index}].send_to_addendum",
-                "datatype": "yesno",
-                "show if": {"code": f'hasattr(fields[{index}], "maxlength")'},
-                "help": "Check the box to send text that doesn't fit in the PDF to an additional page, instead of limiting the input length.",
-            }
-        )
+        if hasattr(self, 'maxlength'):
+          field_questions.append(
+              {
+                  "label": "Send overflow text to addendum",
+                  "field": f"fields[{index}].send_to_addendum",
+                  "datatype": "yesno",
+                  "js show if": f"val('fields[{index}].field_type') === 'area' ",
+                  "help": "Check the box to send text that doesn't fit in the PDF to an additional page, instead of limiting the input length.",
+              }
+          )
         return field_questions
 
     def trigger_gather(

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description_file = README.md
+description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.ALWeaver',
       url='https://docassemble.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['PyYAML>=5.1.2', 'beautifulsoup4>=4.9.3', 'docassemble.ALToolbox>=0.3.6', 'docassemble.AssemblyLine>=2.10.1', 'docx2python>=1.27.1', 'formfyxer>=0.0.8', 'more-itertools>=8.6.0', 'numpy>=1.0.4', 'pikepdf>=5.1.0', 'sklearn>=0.0', 'spacy>=3.2.0'],
+      install_requires=['PyYAML>=5.1.2', 'beautifulsoup4>=4.9.3', 'docassemble.ALToolbox>=0.4.0', 'docassemble.AssemblyLine>=2.10.1', 'docx2python>=1.27.1', 'formfyxer>=0.0.9', 'more-itertools>=8.6.0', 'numpy>=1.0.4', 'pikepdf>=5.1.1', 'sklearn>=0.0', 'spacy>=3.2.0'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/ALWeaver/', package='docassemble.ALWeaver'),
      )


### PR DESCRIPTION
fix #574

Before, the "send overflow text to addendum" checkbox was displayed for every input when weaving a PDF form. This could easily lead to user error, as in #574, where a user sent a "float" value to the addendum, causing a type error. This PR changes it so that the "send to addendum" checkbox is only displayed if the user selects "datatype: area".

Test by weaving a PDF and changing the datatype of an input to `area`. You should not see the addendum checkbox for any other input type, nor when weaving a DOCX file.