### PR TITLE
Properly escape quotes in field labels

### DIFF
--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -1072,7 +1072,7 @@ def escape_quotes(text: str) -> str:
 
 def escape_double_quoted_yaml(text: str) -> str:
     """Escape only double quotes in a string and the escape character itself"""
-    return text.replace(r"\",r"\\").replace('"', r"\"")
+    return text.replace("\\",r"\\").replace('"', r"\"")
 
 
 def to_yaml_file(text: str) -> str:

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -454,7 +454,9 @@ class DAField(DAObject):
         settable_var = self.get_settable_var()
         content = ""
         if self.has_label:
-            content += '  - "{}": {}\n'.format(escape_quotes(self.label), settable_var)
+            # See: https://stackoverflow.com/questions/19109912/yaml-do-i-need-quotes-for-strings-in-yaml
+            # We want to quote words like yes, no, and also symbols like :.
+            content += '  - "{}": {}\n'.format(escape_double_quotes(self.label), settable_var)
         else:
             content += "  - no label: {}\n".format(settable_var)
         # Use all of these fields plainly. No restrictions/validation yet
@@ -1065,6 +1067,9 @@ def escape_quotes(text: str) -> str:
     """Escape both single and double quotes in strings"""
     return text.replace('"', '\\"').replace("'", "\\'")
 
+def escape_double_quotes(text:str) -> str:
+    """Escape only double quotes in a string"""
+    return text.replace('"',r'\"')
 
 def to_yaml_file(text: str) -> str:
     text = varname(text)

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -1072,7 +1072,7 @@ def escape_quotes(text: str) -> str:
 
 def escape_double_quoted_yaml(text: str) -> str:
     """Escape only double quotes in a string and the escape character itself"""
-    return text.replace("\\",r"\\").replace('"', r"\"")
+    return text.replace("\\", r"\\").replace('"', r"\"")
 
 
 def to_yaml_file(text: str) -> str:

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -457,7 +457,7 @@ class DAField(DAObject):
             # See: https://stackoverflow.com/questions/19109912/yaml-do-i-need-quotes-for-strings-in-yaml
             # We want to quote words like yes, no, and also symbols like :.
             content += '  - "{}": {}\n'.format(
-                escape_double_quotes(self.label), settable_var
+                escape_double_quoted_yaml(self.label), settable_var
             )
         else:
             content += "  - no label: {}\n".format(settable_var)
@@ -1070,9 +1070,9 @@ def escape_quotes(text: str) -> str:
     return text.replace('"', '\\"').replace("'", "\\'")
 
 
-def escape_double_quotes(text: str) -> str:
-    """Escape only double quotes in a string"""
-    return text.replace('"', r"\"")
+def escape_double_quoted_yaml(text: str) -> str:
+    """Escape only double quotes in a string and the escape character itself"""
+    return text.replace(r"\",r"\\").replace('"', r"\"")
 
 
 def to_yaml_file(text: str) -> str:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description_file = README.md
+description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.ALWeaver',
       url='https://docassemble.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['PyYAML>=5.1.2', 'beautifulsoup4>=4.9.3', 'docassemble.ALToolbox>=0.3.6', 'docassemble.AssemblyLine>=2.10.1', 'docx2python>=1.27.1', 'formfyxer>=0.0.8', 'more-itertools>=8.6.0', 'numpy>=1.0.4', 'pikepdf>=5.1.0', 'sklearn>=0.0', 'spacy>=3.2.0'],
+      install_requires=['PyYAML>=5.1.2', 'beautifulsoup4>=4.9.3', 'docassemble.ALToolbox>=0.4.0', 'docassemble.AssemblyLine>=2.10.1', 'docx2python>=1.27.1', 'formfyxer>=0.0.9', 'more-itertools>=8.6.0', 'numpy>=1.0.4', 'pikepdf>=5.1.1', 'sklearn>=0.0', 'spacy>=3.2.0'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/ALWeaver/', package='docassemble.ALWeaver'),
      )


### PR DESCRIPTION
Fix #560 (problem when people use an apostrophe inside a field label)

It turns out there are very weird rules about how to escape strings in YAML. We could use one of the many line continuation markers in combination with the `label` key for a Docassemble field, but that makes all of our `fields` statements harder to read and less idiomatic. We could remove quotes, which would mostly work, but it could cause problems when people use special symbols like `:` or the literal words `yes` and `no`. This fix just stops escaping quotes that can't be escaped in that position in a YAML file and leaves the rest alone.