### PR TITLE
Create a placeholder "addresses_to_search" definition in court-related forms

### DIFF
--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -142,10 +142,12 @@ code: |
   add_short_title
   add_form_type  
   add_objects_block
-  add_sections  
+  add_sections
   add_interview_order
   add_intro_screen
   add_question_screens
+  if interview.court_related:
+    add_addresses_to_search
   add_preview_screen  
   add_signature_trigger
   add_review_screen  
@@ -1691,6 +1693,12 @@ code: |
   else:
     preview_question.data['bundle_name'] = 'al_recipient_bundle'
   add_preview_screen = True
+---
+code: |
+  addresses_to_search_screen = interview.blocks.appendObject()
+  addresses_to_search_screen.template_key = "addresses to search"
+  addresses_to_search_screen.data = {}
+  add_addresses_to_search = True
 ---
 need:
   - interview_label

--- a/docassemble/ALWeaver/data/sources/output_patterns.yml
+++ b/docassemble/ALWeaver/data/sources/output_patterns.yml
@@ -102,6 +102,12 @@ code: |
     % for line in lines:
     ${ line }
     % endfor
+addresses to search: |
+  code: |
+    # This is a placeholder for the addresses that will be searched
+    # for matching address to court. Edit if court venue is based on 
+    # a different address than the user's
+    addresses_to_search = [user.address for user in users]
 # Objects block
 objects: |
   objects:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description_file = README.md
+description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.ALWeaver',
       url='https://docassemble.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['PyYAML>=5.1.2', 'beautifulsoup4>=4.9.3', 'docassemble.ALToolbox>=0.3.6', 'docassemble.AssemblyLine>=2.10.1', 'docx2python>=1.27.1', 'formfyxer>=0.0.8', 'more-itertools>=8.6.0', 'numpy>=1.0.4', 'pikepdf>=5.1.0', 'sklearn>=0.0', 'spacy>=3.2.0'],
+      install_requires=['PyYAML>=5.1.2', 'beautifulsoup4>=4.9.3', 'docassemble.ALToolbox>=0.4.0', 'docassemble.AssemblyLine>=2.10.1', 'docx2python>=1.27.1', 'formfyxer>=0.0.9', 'more-itertools>=8.6.0', 'numpy>=1.0.4', 'pikepdf>=5.1.1', 'sklearn>=0.0', 'spacy>=3.2.0'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/ALWeaver/', package='docassemble.ALWeaver'),
      )


### PR DESCRIPTION
Fix #441

This adds a code block that sets the value of `addresses_to_search` to the user's address in court-related forms. Currently, this block is used in the ALMassachusetts forms. In the future, more jurisdictions will be able to help litigants figure out venue based on addresses though.

Expected behavior:

If someone selects that the form is court related, a block that defines `addresses_to_search` will be added. If they select that the form is NOT court related, no such block is added. The contents of the block, if it is added, do not depend on any input from the user.