### PR TITLE
Add more datatypes

### DIFF
--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -1080,7 +1080,7 @@ code: |
 code: |
   # We keep adding questions until ALL of the fields have been
   # assigned.
-  questions.there_is_another = len(questions.all_fields_used()) < len(fields)
+  questions.there_is_another = len(questions.all_fields_used(all_fields=fields)) < len(fields)
 ---
 id: create a draft of screen i
 question: |
@@ -1104,9 +1104,9 @@ fields:
     datatype: object_checkboxes
     # We show all of the fields, but exclude the ones present
     # anywhere in the list of questions we already drafted
-    exclude: questions.all_fields_used()
+    exclude: questions.all_fields_used(all_fields=fields)
     none of the above: False
-    choices: fields
+    choices: fields      
     object labeler: labeller_bold_plus_label
   - Override the default logic flow by adding a "continue button field": questions[i].has_mandatory_field
     datatype: noyes

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -146,9 +146,10 @@ code: |
   add_interview_order
   add_intro_screen
   add_question_screens
+  add_fields_set_by_code
   if interview.court_related:
     add_addresses_to_search
-  add_preview_screen  
+  add_preview_screen
   add_signature_trigger
   add_review_screen  
   # Insert comment block
@@ -1021,6 +1022,12 @@ fields:
     show if:
       code: |
         len(built_in_fields_used) or len(signature_fields)
+validation code: |
+  for field in fields:
+    if field.field_type == "code":
+        expression = f"{field.final_display_var} = {field.code}"
+        if not is_valid_python(expression):
+            validation_error(f"`{expression}` is not a valid Python expression.", field=field.attr_name("code"))
 ---
 id: add fields
 question: |
@@ -1146,6 +1153,21 @@ code: |
 		  question.type = "question"
 		  interview.blocks.append(question)
   add_question_screens = True
+---
+code: |
+  for field in fields:
+    if field.field_type == "code":
+      code_block = interview.blocks.appendObject()
+      code_block.template_key = "code"
+      code_block.data = {
+        "lines": [
+          f"{field.final_display_var} = {field.code}"
+        ]}
+    elif field.field_type == "skip this field":
+      code_block = interview.blocks.appendObject()
+      code_block.template_key = "code"
+      code_block.data = {"lines": [f"{field.final_display_var} = DAEmpty()"]}
+  add_fields_set_by_code = True
 ---
 code: |
   person_candidates_temp = set(people_variables.true_values()).union(set(built_in_people_vars_used))

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -30,6 +30,7 @@ import ruamel.yaml as yaml
 import mako.template
 import mako.runtime
 from pdfminer.pdftypes import PDFObjRef, resolve1
+import ast
 
 mako.runtime.UNDEFINED = DAEmpty()
 
@@ -70,6 +71,7 @@ __all__ = [
     "pdf_field_type_str",
     "bad_name_reason",
     "mako_local_import_str",
+    "is_valid_python",
 ]
 
 always_defined = set(
@@ -669,20 +671,19 @@ class DAField(DAObject):
         )
         field_questions.append(
             {
-                "label": "Python code",
+                "label": f"Complete the expression, `{self.final_display_var} = `",
                 "field": f"fields[{index}].code",
-                "datatype": "area",
                 "show if": {"variable": f"fields[{index}].field_type",
                             "is": "code"
                            },
-                "help": f"Enter a valid Python expression, such as `{self.final_display_var} = 10`",
+                "help": f"Enter a valid Python expression, such as `'Hello World'` or `users[0].birthdate.plus(days=10)`. This will create a code block like `{self.final_display_var} = expression`",
             })
         field_questions.append(
             {
                 "label": "Options (one per line)",
                 "field": f"fields[{index}].choices",
                 "datatype": "area",
-                "js show if": f"val('fields[{index}].field_type') === 'multiple choice radio' || val('fields[{index}].field_type') === 'multiple choice checkboxes'",
+                "js show if": f"['multiple choice dropdown','multiple choice combobox','multiselect', 'multiple choice radio', 'multiple choice checkboxes'].includes(val('fields[{index}].field_type'))",
                 "hint": "Like 'Descriptive name: key_name', or just 'Descriptive name'",
             }
         )
@@ -1697,6 +1698,12 @@ def bad_name_reason(field: Union[str, Tuple]):
             )
         return None
 
+def is_valid_python(code:str) -> bool:
+    try:
+        ast.parse(code)
+    except SyntaxError:
+        return False
+    return True
 
 def create_package_zip(
     pkgname: str,

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -622,19 +622,38 @@ class DAField(DAObject):
                     "text",
                     "area",
                     "yesno",
+                    "noyes",
+                    "yesnoradio",
+                    "noyesradio",
                     "integer",
                     "number",
                     "currency",
                     "date",
                     "email",
+                    "multiple choice dropdown",
+                    "multiple choice combobox",
                     "multiple choice radio",
                     "multiple choice checkboxes",
+                    "multiselect",
+                    "file upload",
+                    "code",
+                    "skip this field",
                 ],
                 "default": self.field_type_guess
                 if hasattr(self, "field_type_guess")
                 else None,
             }
         )
+        field_questions.append(
+            {
+                "label": "Python code",
+                "field": f"fields[{index}].code",
+                "datatype": "area",
+                "show if": {"variable": f"fields[{index}].field_type",
+                            "is": "code"
+                           },
+                "help": f"Enter a valid Python expression, such as `{self.final_display_var} = 10`",
+            })
         field_questions.append(
             {
                 "label": "Options (one per line)",

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -195,7 +195,7 @@ class DABlockList(DAList):
         super().init(*pargs, **kwargs)
         self.object_type = DABlock
 
-    def all_fields_used(self):
+    def all_fields_used(self, all_fields:List = None):
         """This method is used to help us iteratively build a list of fields that have already been assigned to a screen/question
         in our wizarding process. It makes sure the fields aren't displayed to the wizard user on multiple screens.
         It prevents the formatter of the wizard from putting the same fields on two different screens."""
@@ -204,6 +204,8 @@ class DABlockList(DAList):
             if hasattr(question, "field_list"):
                 for field in question.field_list.elements:
                     fields.add(field)
+        if all_fields:
+            fields.update([field for field in all_fields if field.field_type in ["code", "skip this field"]])
         return fields
 
 
@@ -217,15 +219,19 @@ class DAQuestionList(DAList):
         # self.gathered = True
         # self.is_mandatory = False
 
-    def all_fields_used(self):
-        """This method is used to help us iteratively build a list of fields that have already been assigned to a screen/question
-        in our wizarding process. It makes sure the fields aren't displayed to the wizard user on multiple screens.
-        It prevents the formatter of the wizard from putting the same fields on two different screens."""
+    def all_fields_used(self, all_fields:List = None):
+        """This method is used to help us iteratively build a list of fields that have already been assigned to a
+        screen/question. It makes sure the fields aren't displayed to the Weaver user on multiple screens.
+        It will also filter out fields that shouldn't appear on any screen based on the field_type if the optional
+        parameter "all_fields" is provided.
+        """
         fields = set()
         for question in self.elements:
             if hasattr(question, "field_list"):
                 for field in question.field_list.elements:
                     fields.add(field)
+        if all_fields:
+            fields.update([field for field in all_fields if field.field_type in ["code", "skip this field"]])
         return fields
 
 
@@ -453,6 +459,8 @@ class DAField(DAObject):
     def field_entry_yaml(self) -> str:
         settable_var = self.get_settable_var()
         content = ""
+        if self.field_type in ["code", "skip this field"]:
+            return
         if self.has_label:
             # See: https://stackoverflow.com/questions/19109912/yaml-do-i-need-quotes-for-strings-in-yaml
             # We want to quote words like yes, no, and also symbols like :.
@@ -462,7 +470,7 @@ class DAField(DAObject):
         else:
             content += "  - no label: {}\n".format(settable_var)
         # Use all of these fields plainly. No restrictions/validation yet
-        if self.field_type in ["yesno", "yesnomaybe", "file"]:
+        if self.field_type in ["yesno", "yesnomaybe", "file", "yesnoradio", "noyes", "noyesradio"]:
             content += "    datatype: {}\n".format(self.field_type)
         elif self.field_type == "multiple choice radio":
             content += "    input type: radio\n"
@@ -471,6 +479,21 @@ class DAField(DAObject):
                 content += f"      - {choice}\n"
         elif self.field_type == "multiple choice checkboxes":
             content += "    datatype: checkboxes\n"
+            content += "    choices:\n"
+            for choice in self.choices.splitlines():
+                content += f"      - {choice}\n"
+        elif self.field_type == "multiple choice combobox":
+            content += "    datatype: combobox\n"
+            content += "    choices:\n"
+            for choice in self.choices.splitlines():
+                content += f"      - {choice}\n"
+        elif self.field_type == "multiple choice dropdown":
+            content += "    input type: dropdown\n"
+            content += "    choices:\n"
+            for choice in self.choices.splitlines():
+                content += f"      - {choice}\n"
+        elif self.field_type == "multiselect":
+            content += "    datatype: multiselect\n"
             content += "    choices:\n"
             for choice in self.choices.splitlines():
                 content += f"      - {choice}\n"
@@ -635,7 +658,7 @@ class DAField(DAObject):
                     "multiple choice radio",
                     "multiple choice checkboxes",
                     "multiselect",
-                    "file upload",
+                    "file",
                     "code",
                     "skip this field",
                 ],

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -197,7 +197,7 @@ class DABlockList(DAList):
         super().init(*pargs, **kwargs)
         self.object_type = DABlock
 
-    def all_fields_used(self, all_fields:List = None):
+    def all_fields_used(self, all_fields: List = None):
         """This method is used to help us iteratively build a list of fields that have already been assigned to a screen/question
         in our wizarding process. It makes sure the fields aren't displayed to the wizard user on multiple screens.
         It prevents the formatter of the wizard from putting the same fields on two different screens."""
@@ -207,7 +207,13 @@ class DABlockList(DAList):
                 for field in question.field_list.elements:
                     fields.add(field)
         if all_fields:
-            fields.update([field for field in all_fields if field.field_type in ["code", "skip this field"]])
+            fields.update(
+                [
+                    field
+                    for field in all_fields
+                    if field.field_type in ["code", "skip this field"]
+                ]
+            )
         return fields
 
 
@@ -221,7 +227,7 @@ class DAQuestionList(DAList):
         # self.gathered = True
         # self.is_mandatory = False
 
-    def all_fields_used(self, all_fields:List = None):
+    def all_fields_used(self, all_fields: List = None):
         """This method is used to help us iteratively build a list of fields that have already been assigned to a
         screen/question. It makes sure the fields aren't displayed to the Weaver user on multiple screens.
         It will also filter out fields that shouldn't appear on any screen based on the field_type if the optional
@@ -233,7 +239,13 @@ class DAQuestionList(DAList):
                 for field in question.field_list.elements:
                     fields.add(field)
         if all_fields:
-            fields.update([field for field in all_fields if field.field_type in ["code", "skip this field"]])
+            fields.update(
+                [
+                    field
+                    for field in all_fields
+                    if field.field_type in ["code", "skip this field"]
+                ]
+            )
         return fields
 
 
@@ -472,7 +484,14 @@ class DAField(DAObject):
         else:
             content += "  - no label: {}\n".format(settable_var)
         # Use all of these fields plainly. No restrictions/validation yet
-        if self.field_type in ["yesno", "yesnomaybe", "file", "yesnoradio", "noyes", "noyesradio"]:
+        if self.field_type in [
+            "yesno",
+            "yesnomaybe",
+            "file",
+            "yesnoradio",
+            "noyes",
+            "noyesradio",
+        ]:
             content += "    datatype: {}\n".format(self.field_type)
         elif self.field_type == "multiple choice radio":
             content += "    input type: radio\n"
@@ -673,11 +692,10 @@ class DAField(DAObject):
             {
                 "label": f"Complete the expression, `{self.final_display_var} = `",
                 "field": f"fields[{index}].code",
-                "show if": {"variable": f"fields[{index}].field_type",
-                            "is": "code"
-                           },
+                "show if": {"variable": f"fields[{index}].field_type", "is": "code"},
                 "help": f"Enter a valid Python expression, such as `'Hello World'` or `users[0].birthdate.plus(days=10)`. This will create a code block like `{self.final_display_var} = expression`",
-            })
+            }
+        )
         field_questions.append(
             {
                 "label": "Options (one per line)",
@@ -1698,12 +1716,14 @@ def bad_name_reason(field: Union[str, Tuple]):
             )
         return None
 
-def is_valid_python(code:str) -> bool:
+
+def is_valid_python(code: str) -> bool:
     try:
         ast.parse(code)
     except SyntaxError:
         return False
     return True
+
 
 def create_package_zip(
     pkgname: str,


### PR DESCRIPTION
Add some more ways to set datatypes in the Weaver. Specifically, add support for:

* noyes
* noyesradio
* yesnoradio
* file
* combobox
* multiselect
* dropdown

And add support for simple Python expressions. E.g., `some_var = 123`. And for "skipping" a field, which will set the value of the field to DAEmpty() as a decent placeholder.

Fix #513
Fix #512 
Fix #135 