### PR TITLE
Fix 0th docx & Allow `manual_line_break`

### DIFF
--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -221,9 +221,9 @@ code: |
   set_custom_people_map( people_variables.true_values() )
   if len(people_variables.true_values()):
     # Process regular fields
-    process_custom_people(people_variables.true_values(), fields, built_in_fields_used)
+    process_custom_people(people_variables.true_values(), fields, built_in_fields_used, document_type=document_type)
     # Process signature fields
-    process_custom_people(people_variables.true_values(), signature_fields, built_in_fields_used)
+    process_custom_people(people_variables.true_values(), signature_fields, built_in_fields_used, document_type=document_type)
   process_people_variables = True
 ---
 continue button field: weaver_intro

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -1394,7 +1394,7 @@ def map_raw_to_final_display(
                 correct_label = adjusted_prefix + "1" + label_groups[3]
                 main_issue = "Cannot get the 0th item in a list"
                 err_str = f'The "{label}" label refers to the 0th item in a list, when it is likely meant the 1st item. You should replace that label with "{correct_label}".'
-                url = "https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/label_variables#more-than-one"
+                url = "https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/label_variables/#special-situation-for-names-of-people-in-pdfs"
                 raise ParsingException(main_issue, err_str, url)
             else:
                 index = "[" + str(digit - 1) + "]"
@@ -1532,6 +1532,7 @@ def process_custom_people(
     custom_people: list,
     fields: list,
     built_in_fields: list,
+    document_type: str = "pdf",
     people_suffixes: list = (
         generator_constants.PEOPLE_SUFFIXES + generator_constants.DOCX_ONLY_SUFFIXES
     ),
@@ -1548,7 +1549,7 @@ def process_custom_people(
     for field in fields:
         # Simpler case: PDF variables matching our naming rules
         new_potential_name = map_raw_to_final_display(
-            field.variable, reserved_prefixes=custom_people
+            field.variable, document_type=document_type, reserved_prefixes=custom_people
         )
         # If it's not already a DOCX-like variable and the new mapped name doesn't match old name
         if not ("[" in field.variable) and new_potential_name != field.variable:
@@ -1713,7 +1714,8 @@ def bad_name_reason(field: Union[str, Tuple]):
     else:
         log(field[0], "console")
         python_var = map_raw_to_final_display(
-            remove_multiple_appearance_indicator(varname(field[0]))
+            remove_multiple_appearance_indicator(varname(field[0])), 
+            document_type="pdf"
         )
         if len(python_var) == 0:
             return "{}, the {}, should be in [snake case](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/naming#pdf-variables--snake_case) and use alphabetical characters".format(

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -1714,8 +1714,7 @@ def bad_name_reason(field: Union[str, Tuple]):
     else:
         log(field[0], "console")
         python_var = map_raw_to_final_display(
-            remove_multiple_appearance_indicator(varname(field[0])), 
-            document_type="pdf"
+            remove_multiple_appearance_indicator(varname(field[0])), document_type="pdf"
         )
         if len(python_var) == 0:
             return "{}, the {}, should be in [snake case](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/naming#pdf-variables--snake_case) and use alphabetical characters".format(

--- a/docassemble/ALWeaver/validate_docx_files.py
+++ b/docassemble/ALWeaver/validate_docx_files.py
@@ -5,6 +5,7 @@ from docx2python import docx2python
 from jinja2 import Environment, BaseLoader
 import jinja2.exceptions
 from docassemble.base.util import DAFile
+from docassemble.base.parse import DAEnvironment, DAExtension, registered_jinja_filters, builtin_jinja_filters
 from typing import Optional, Iterable
 import re
 
@@ -29,7 +30,9 @@ def get_jinja_errors(the_file: DAFile) -> Optional[str]:
     """Just try rendering the DOCX file as a Jinja2 template and catch any errors.
     Returns a string with the errors, if any.
     """
-    env = Environment(loader=BaseLoader(), undefined=CallAndDebugUndefined)
+    env = DAEnvironment(undefined=CallAndDebugUndefined, extensions=[DAExtension])
+    env.filters.update(registered_jinja_filters)
+    env.filters.update(builtin_jinja_filters)
 
     doc = DocxTemplate(the_file.path())
     try:

--- a/docassemble/ALWeaver/validate_docx_files.py
+++ b/docassemble/ALWeaver/validate_docx_files.py
@@ -5,7 +5,12 @@ from docx2python import docx2python
 from jinja2 import Environment, BaseLoader
 import jinja2.exceptions
 from docassemble.base.util import DAFile
-from docassemble.base.parse import DAEnvironment, DAExtension, registered_jinja_filters, builtin_jinja_filters
+from docassemble.base.parse import (
+    DAEnvironment,
+    DAExtension,
+    registered_jinja_filters,
+    builtin_jinja_filters,
+)
 from typing import Optional, Iterable
 import re
 


### PR DESCRIPTION
Two different fixes in the same document (only because my example had both of those errors):
* If you have a possible person variable, the Weaver tries to map the string to a python variable. However, it isn't passing around the document type where it should, so it considers some DOCX variables as PDF variables, and will error if you include a valid 0-indexed DOCX person variable. This adds the correct document type to the proper functions.
* Fixes https://github.com/SuffolkLITLab/docassemble-ALWeaver/issues/605 by creating a DA environment closer to what DA actually does when running DOCXs through Jinja.

Tested with this document:
[test_manual_line.docx](https://github.com/SuffolkLITLab/docassemble-ALWeaver/files/8702889/test_manual_line.docx)