### PR TITLE
Hotfix survey interview

### DIFF
--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -2127,9 +2127,7 @@ code: |
 #----------------------------------------------------
 ---
 # Set default values if no template file to upload
-scan for variables: False
-sets:
-  - no_template_default_values
+only sets: no_template_default_values
 code: |
   if not have_template_to_load:
     all_fields = fields  

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -127,6 +127,7 @@ code: |
     process_people_variables
     ask_people_quantity_question    
   if have_template_to_load: 
+    ask_people_quantity_question  
     choose_field_types    
   if not generate_download_screen:    
     no_template_default_values    
@@ -914,9 +915,9 @@ code: |
   form_type_block = interview.blocks.appendObject()
   form_type_block.template_key = 'code'
   form_type_block.data = {
-      "lines": ["al_form_type = '" + interview.form_type + "'"]
+      "lines": [f"""al_form_type = "{ interview.form_type }" """]
     }
-  add_form_type= True
+  add_form_type = True
 ---
 need: interview_label
 code: |
@@ -1268,13 +1269,15 @@ code: |
 ---
 need:
   - built_in_people_vars_used
+  - person_candidates
+  - people_quantities
 code: |
   # Create objects block that specifies the number of people for
   # the developer. Switches between target_number and there_are_any list gathering
   # approaches
   objects_block =  interview.blocks.appendObject()
   objects_block.template_key = "objects"
-  objects = DAList(object_type=DAObject, auto_gather=False)
+  objects = DAList("objects", object_type=DAObject, auto_gather=False)
   for person in person_candidates:
     new_object = objects.appendObject()
     new_object.name = person
@@ -1291,11 +1294,14 @@ code: |
           }
       else:
         new_object.params = {}
+    else:
+      new_object.params = {}        
   objects.gathered=True
   
   objects_block.data = {
     "objects": objects
   } 
+  # log(objects_block.data)
 
   add_objects_block = True
 ---
@@ -1749,6 +1755,7 @@ code: |
 need:
   - inflate_renamed_upload
   - interview.author
+  - generate_download_screen
 # Prepare content for the Weaver's download screen.
 code: |
   # 1. Commit the generated interview YAML file
@@ -1756,21 +1763,22 @@ code: |
   interview_download.write(interview.source())
   interview_download.commit()
   
-  # 2. Build data for folders_and_files and package_info
-  tempfiles = [] 
-  if generate_download_screen:
-    tempfiles = [
-      next_steps_documents[interview.form_type]['attachment'].docx,
-      renamed_upload,
-    ]
+  # 2. Build data for folders_and_files and package_info   
   folders_and_files = {
-    "templates": tempfiles,
     "questions": [interview_download],
     "modules":[],
     "static": [],
     "sources": []
   }
   
+  if generate_download_screen:
+    folders_and_files["templates"] = [
+        next_steps_documents[interview.form_type]['attachment'].docx,
+        renamed_upload,
+      ]
+  else:    
+    folders_and_files["templates"] = []
+    
   package_info = interview.package_info(
           get_pypi_deps_from_choices(
             interview.jurisdiction_choices.true_values() +
@@ -1797,7 +1805,6 @@ code: |
         folders_and_files, 
         interview_package_download)
   
-  del tempfiles
   wrote_interview = True
 ---
 need:
@@ -2126,7 +2133,7 @@ code: |
     all_fields = fields  
   interview.original_form = 'NA'  
   interview.typical_role = 'anonymous'
-  interview_label_draft = interview.short_title    
+  interview_label_draft = interview.short_title
   
   no_template_default_values = 'Done'
 ---

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -1282,6 +1282,7 @@ code: |
     new_object = objects.appendObject()
     new_object.name = person
     new_object.type = "ALPeopleList"
+    new_object.params = {}
     if person in people_quantities:
       if people_quantities[person] == 'one':
         new_object.params = {
@@ -1291,11 +1292,7 @@ code: |
       elif people_quantities[person] == 'more':
         new_object.params = {
           "there_are_any": True,
-          }
-      else:
-        new_object.params = {}
-    else:
-      new_object.params = {}        
+          }            
   objects.gathered=True
   
   objects_block.data = {

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -2127,6 +2127,9 @@ code: |
 #----------------------------------------------------
 ---
 # Set default values if no template file to upload
+scan for variables: False
+sets:
+  - no_template_default_values
 code: |
   if not have_template_to_load:
     all_fields = fields  
@@ -2134,7 +2137,7 @@ code: |
   interview.typical_role = 'anonymous'
   interview_label_draft = interview.short_title
   
-  no_template_default_values = 'Done'
+  no_template_default_values = True
 ---
 comment: |
   This is for interviews that don't need a download screen

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -1301,7 +1301,6 @@ code: |
   objects_block.data = {
     "objects": objects
   } 
-  # log(objects_block.data)
 
   add_objects_block = True
 ---

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -114,7 +114,7 @@ code: |
       else:
         if no_recognized_docx_fields:
           warn_no_recognized_al_labels
-        validate_docx  
+        validate_docx
  
   if have_template_to_load:  
     get_all_fields
@@ -834,7 +834,10 @@ buttons:
   - Restart: restart
 ---
 code: |
- built_in_people_vars_used = get_person_variables(all_fields, custom_only=False) - get_person_variables(all_fields, custom_only=True)
+  if have_template_to_load: 
+    built_in_people_vars_used = get_person_variables(all_fields, custom_only=False) - get_person_variables(all_fields, custom_only=True)
+  else:
+    built_in_people_vars_used = []
 ---
 comment: |
   Convert the PDF fields into Docassemble fields

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -163,8 +163,8 @@ class DABlock(DAObject):
     A Block in a Docassemble interview YAML file.
     """
 
-    template_key: str
-    data: Dict[str, Any]
+    # template_key: str
+    # data: Dict[str, Any]
 
     def source(
         self,

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.ALWeaver',
       url='https://docassemble.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['PyYAML>=5.1.2', 'beautifulsoup4>=4.11.1', 'docassemble.ALToolbox>=0.4.0', 'docassemble.AssemblyLine>=2.11.0', 'docx2python>=1.27.1', 'formfyxer>=0.0.9', 'more-itertools>=8.6.0', 'numpy>=1.0.4', 'pikepdf>=5.1.1', 'sklearn>=0.0', 'spacy>=3.2.0'],
+      install_requires=['PyYAML>=5.1.2', 'beautifulsoup4>=4.11.1', 'docassemble.ALToolbox>=0.4.2', 'docassemble.AssemblyLine>=2.11.2', 'docx2python>=1.27.1', 'formfyxer>=0.0.9', 'more-itertools>=8.6.0', 'numpy>=1.0.4', 'pikepdf>=5.1.1', 'sklearn>=0.0', 'spacy>=3.2.0'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/ALWeaver/', package='docassemble.ALWeaver'),
      )


### PR DESCRIPTION
This was a weird series of hard to debug problems. Really makes we wish we made this logic a bit more declarative, which is something we've had in progress before (using a single declarative mako block to structure the output instead of loading each one separately with unique parameters.)

I left in some very small refactors that were part of my trying to track the cause of this down.

1. The PDF / DOCX checkers weren't being loaded at the right time because a block used to set some defaults was being given the wrong priority. Added a `scan for variables: False` kludge to that for now. We can reexamine the need for this block later. Might be better to set some conditions in the places those variables are being set.
2. Although we were getting an error about interviews.blocks[6].data, it was actually the `objects` block missing `params` attribute causing a problem. The real issue was that the `ask_about_people_variables` screen wasn't being loaded when someone didn't want a template output. That was presumably an accident. Also patched a missing conditional.
3. Set up a default value of `custom_people_variables` for when no template is provided at all.