### PR TITLE
Multi weaver

### DIFF
--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -810,7 +810,7 @@ event: exit_invalid_pdf
 question: |
   Is this a valid PDF?
 subquestion: |
-  ${ template_upload[0].filename } does not seem to be a PDF file. Usually
+  ${ document.filename } does not seem to be a PDF file. Usually
   this error happens because the file is corrupt or has the wrong extension.
 
   Docassemble was not able to read the file you uploaded. Make sure it is a
@@ -825,7 +825,7 @@ event: exit_PSEOF_error
 question: |
   Something is wrong with the internals of this PDF
 subquestion: |
-  Docassemble was not able to read ${ template_upload[0].filename }.
+  Docassemble was not able to read ${ document.filename }.
   
   You can try using [qpdf](http://qpdf.sourceforge.net/) or
   [documate.org/pdf](https://www.documate.org/pdf) to fix it, but some of your
@@ -837,7 +837,7 @@ event: exit_invalid_docx
 question: |
   Is this a valid DOCX file?
 subquestion: |
-  ${ template_upload[0].filename } does not seem to be a DOCX file. Usually
+  ${ document.filename } does not seem to be a DOCX file. Usually
   this error happens because the file is corrupt or has the wrong extension.
 
   Docassemble was not able to read the file you uploaded. Make sure it is a
@@ -989,12 +989,16 @@ code: |
 code: |
   # Create code for the question that we use to label
   # each field.
-  
-  temp_field_question = []
-  for index, field in enumerate(fields.elements):
-    temp_field_question.extend(field.user_ask_about_field(index))
+  from itertools import chain
 
-  field_question = temp_field_question
+  field_question_tmp = [ 
+    field.user_ask_about_field()
+    for field in fields.custom()
+  ]
+  field_question = [item for item in chain.from_iterable(field_question_tmp)]
+
+  del field_question_tmp
+  del chain
 ---
 id: choose field types
 continue button field: choose_field_types
@@ -1040,7 +1044,7 @@ fields:
       code: |
         len(fields.builtins()) or len(fields.signatures())
 validation code: |
-  for field in fields:
+  for field in fields.custom():
     if field.field_type == "code":
         expression = f"{field.final_display_var} = {field.code}"
         if not is_valid_python(expression):
@@ -1705,9 +1709,10 @@ objects:
   - renamed_upload: DAFile.using(filename=sanitized_filename)
 ---
 code: |
-  if have_template_to_load: 
-    renamed_upload.copy_into(template_upload[0])
-    renamed_upload.commit()
+  # Unfortunately, there's no good "new" name for the file
+  # when someone uploads multiple templates at once
+  if have_template_to_load and len(template_upload) == 1:
+    template_upload[0].set_attributes(filename=sanitized_filename)
   inflate_renamed_upload = True
 ---
 need:
@@ -1732,8 +1737,8 @@ code: |
   if generate_download_screen:
     folders_and_files["templates"] = [
         next_steps_documents[interview.form_type]['attachment'].docx,
-        renamed_upload,
-      ]
+    ]      
+    folders_and_files["templates"].extend(template_upload)
   else:    
     folders_and_files["templates"] = []
     
@@ -1824,22 +1829,33 @@ code: |
   file2.fields = 'na'
   file2.has_addendum = False
 
-  # Set attributes for the uploaded template file     
-  file1 = labels_lists.appendObject()    
-  file1.input_filename = sanitized_filename  
-  file1.output_filename = sanitized_filename
-  file1.attachment_varname = attachment_variable_name    
-  file1.type = template_upload[0].extension  
-  file1.description = interview.title
-  file1.fields = fields
-  file1.has_addendum = bool(len(addendum_fields))
+  if len(template_upload) == 1:
+    # Set attributes for the uploaded template file     
+    file1 = labels_lists.appendObject()    
+    file1.input_filename = sanitized_filename  
+    file1.output_filename = sanitized_filename
+    file1.attachment_varname = attachment_variable_name    
+    file1.type = template_upload[0].extension  
+    file1.description = interview.title
+    file1.fields = fields
+    file1.has_addendum = bool(len(addendum_fields))
+  else:
+    for document in template_upload:
+      temp_file = labels_lists.appendObject()    
+      temp_file.input_filename = document.filename
+      temp_file.output_filename = document.filename
+      temp_file.attachment_varname = space_to_underscore(base_name(document.filename))
+      temp_file.type = document.extension
+      temp_file.description = document.filename.replace("_", " ")
+      temp_file.fields = fields
+      temp_file.has_addendum = bool(len(addendum_fields))
 
   # TODO: it would be possible to merge the "bundles" list with the
   # attachments/labels_list.
   bundles.clear()
   user_bundle = bundles.appendObject()
   user_bundle.name = 'al_user_bundle'
-  user_bundle.elements = [file2, file1]
+  user_bundle.elements = labels_lists
   
   court_bundle = bundles.appendObject()
   if interview.court_related:
@@ -1847,15 +1863,16 @@ code: |
   else:
     court_bundle.name = 'al_recipient_bundle'
   # Court does not get the user next steps instructions
-  court_bundle.elements = [file1]
+  # Skip instructions TODO: remove if instructions become optional  
+  court_bundle.elements = labels_lists[1:] 
   bundles.gathered = True
   
   
   # Bundl-name is a single value
   if len(labels_lists) > 1:
-    bundle_name = file1.output_filename + '_package.pdf'
+    bundle_name =  sanitized_filename + '_package.pdf'
   else:
-    bundle_name = file1.output_filename + '.pdf'
+    bundle_name = sanitized_filename + '.pdf'
     
   #-----------------------------------------------------------------
   # Use the above data to generate blocks related to attachment files.

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -290,7 +290,7 @@ fields:
   - no label: template_upload
     datatype: files
     accept: |
-      ".pdf, application/pdf, .docx, application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+      "application/pdf, application/vnd.openxmlformats-officedocument.wordprocessingml.document"
   - Re-process and auto-identify form fields (PDFs, removes existing fields): yes_recognize_form_fields
     datatype: yesno
     help: |
@@ -303,10 +303,17 @@ fields:
       Use our experimental code to automatically apply AssemblyLine naming conventions.
       If you already followed naming conventions, you might want to skip this.
 validation code: |
-  try:
-    pdf_concatenate(template_upload, template_upload)
-  except:
-    validation_error("Your file may be corrupt. Please try <a href='https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/pdfs#corrupted-or-locked-pdfs'>repairing</a> it.", field="template_upload")
+  for document in template_upload:
+    if document.mimetype == "application/pdf":
+      try:
+        document.fix_up()
+      except:
+        validation_error("Your file may be corrupt. Please try <a href='https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/pdfs#corrupted-or-locked-pdfs'>repairing</a> it.", field="template_upload")
+    else:
+      try:
+        pdf_concatenate(document)
+      except:
+        validation_error("Unable to convert DOCX file to PDF. It may be an invalid file.")
 ---
 code: |
   has_safe_pdf_in_url = url_args.get('form_to_use') and url_args.get('form_to_use').startswith('https://courtformsonline.org')
@@ -752,32 +759,45 @@ comment: |
   Get the list of fields, and check for any possible labeling errors
   right away
 code: |
-  from pdfminer.pdfparser import PDFSyntaxError
-  from pdfminer.psparser import PSEOF
-  from PyPDF2.utils import PdfReadError
-  from zipfile import BadZipFile
+  for document in template_upload:
+    if document.mimetype == "application/pdf":
+      errors = get_pdf_validation_errors(document)
+      if errors:
+        log(errors[1])
+        if errors[0] == "parsing_exception":
+          parsing_ex = errors[1]
+          force_ask('parsing_exception')
+        elif errors[0] == "invalid_pdf":
+          force_ask('exit_invalid_pdf')
+        elif errors[0] == "pseof":
+          force_ask('exit_PSEOF_error')
+        elif errors[0] == "concatenation_error":
+          force_ask("exit_invalid_pdf")
+    elif document.mimetype == "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+      errors = get_docx_validation_errors(document)
+      if errors:
+        force_ask('exit_invalid_docx')        
+      # Check for syntax that indicates a user error
+      validate_docx 
+    else:
+      force_ask("exit_unknown_file_type")
+
+  fields.clear()
+  fields.add_fields_from_file(template_upload)
+  fields.gathered = True
+
+  if not len(fields) > 0:
+    force_ask('empty_pdf')
   
-  try:
-    fields.clear()
-    fields.add_fields_from_file(template_upload)
-    fields.gathered = True
-    if not len(fields) > 0:
-      force_ask('empty_pdf')
-    bad_fields = list(filter(
-        lambda elem: elem is not None,
-        map(bad_name_reason, fields)))
-    if len(bad_fields) > 0:
-      force_ask('non_descriptive_field_name')
-  except ParsingException as ex:
-    parsing_ex = ex
-    force_ask('parsing_exception')
-  except (PDFSyntaxError, PdfReadError):
-    # Handle PDF read error
-    force_ask('exit_invalid_pdf')
-  except PSEOF:
-    force_ask('exit_PSEOF_error')
-  except (BadZipFile, KeyError):
-    force_ask('exit_invalid_docx')
+  bad_fields = get_variable_name_warnings(fields)
+  if len(bad_fields) > 0:
+    force_ask('non_descriptive_field_name')
+---
+event: exit_unknown_file_type
+question: |
+  Is this a valid PDF or DOCX file?
+subquestion: |
+  The file you uploaded doesn't appear to be a valid DOCX or PDF document.
 ---
 event: exit_invalid_pdf
 question: |

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -76,9 +76,7 @@ include:
 ---
 objects:  
   - interview: DAInterview.using(template_path='data/sources/output_patterns.yml')
-  - built_in_fields_used: DAFieldList.using(gathered=True)
-  - fields: DAFieldList.using(gathered=True)
-  - signature_fields: DAFieldList.using(gathered=True)
+  - fields: DAFieldList.using(auto_gather=False)
   - questions: DAQuestionList.using(complete_attribute='complete')
   - interview_download: DAFile
   - interview_package_download: DAFile
@@ -102,7 +100,7 @@ code: |
     set_interview_type_vars 
     if have_template_to_load: 
       template_upload
-      if template_upload[0].filename.endswith('pdf'):
+      if any(f for f in template_upload if f.filename.endswith('pdf') ):
         if yes_normalize_fields:
           process_field_normalization
         validate_pdf
@@ -111,13 +109,13 @@ code: |
         fields_checkup_status
         all_look_good
         validation_success
-      else:
+      if any(f for f in template_upload if f.filename.endswith('docx')):
         if no_recognized_docx_fields:
           warn_no_recognized_al_labels
         validate_docx
  
   if have_template_to_load:  
-    get_all_fields
+    fields.gathered
   # Display Weaver question screens   
   interview.jurisdiction_choices 
   if generate_download_screen:      
@@ -201,15 +199,9 @@ id: no recognized fields
 question: |
   You do not have any labels that match the Assembly Line labels
 subquestion: |
-  % if template_upload[0].filename.endswith('pdf'):
   It is a good idea to use labels that match the Assembly Line documentation.
-  Most forms at least should use labels like `users1_name`, `petitioners`,
-  or `defendants`.
-  % else:
-  It is a good idea to use labels that match the Assembly Line documentation.
-  Most forms at least should use labels like `users[0].name.first`, `petitioners`,
-  or `defendants`.
-  % endif
+  Almost every form has a user and most forms also have an opposing party.
+  You should use the Assembly Line labels for these concepts.
   
   You can also add labels for:
   
@@ -218,7 +210,7 @@ subquestion: |
   * addresses
   * court information
 
-  [Read the labeling documentation](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/label_variables)
+  ${ action_button_html("https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/label_variables", label="Read the labeling documentation", color="info") }
 sets: warn_no_recognized_al_labels
 buttons: 
   - I know what I'm doing, let me continue:    
@@ -229,12 +221,11 @@ buttons:
   - Restart: restart
 ---
 code: |
+  # TODO: refactor to use the new config system
   set_custom_people_map( people_variables.true_values() )  
-  if len(people_variables.true_values()):    
-    # Process regular fields
-    process_custom_people(people_variables.true_values(), fields, built_in_fields_used, document_type=document_type)
-    # Process signature fields
-    process_custom_people(people_variables.true_values(), signature_fields, built_in_fields_used, document_type=document_type)
+
+  if len(people_variables.true_values()):
+    fields.mark_people_as_builtins(people_variables.true_values())
   process_people_variables = True
 ---
 continue button field: weaver_intro
@@ -297,7 +288,7 @@ subquestion: |
   Select a PDF or Word template: 
 fields:   
   - no label: template_upload
-    datatype: file
+    datatype: files
     accept: |
       ".pdf, application/pdf, .docx, application/vnd.openxmlformats-officedocument.wordprocessingml.document"
   - Re-process and auto-identify form fields (PDFs, removes existing fields): yes_recognize_form_fields
@@ -315,7 +306,7 @@ validation code: |
   try:
     pdf_concatenate(template_upload, template_upload)
   except:
-    validation_error("Your PDF file may be corrupt. Please try <a href='https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/pdfs#corrupted-or-locked-pdfs'>repairing</a> it.", field="template_upload")
+    validation_error("Your file may be corrupt. Please try <a href='https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/pdfs#corrupted-or-locked-pdfs'>repairing</a> it.", field="template_upload")
 ---
 code: |
   has_safe_pdf_in_url = url_args.get('form_to_use') and url_args.get('form_to_use').startswith('https://courtformsonline.org')
@@ -349,23 +340,27 @@ imports:
   - os
 ---
 code: |
-  formfyxer.parse_form(template_upload[0].path(), title=os.path.basename(template_upload[0].path()), jur="MA", normalize=1,rewrite=1)
-  template_upload[0].commit()
+  for template in template_upload:
+    if template.filename.endswith("pdf"):
+      formfyxer.parse_form(template.path(), title=os.path.basename(template.path()), jur="MA", normalize=1,rewrite=1)
+      template.commit()
   process_field_normalization = True
 ---
 objects:
   - temp_new_pdf: DAFile.using(filename=os.path.basename(template_upload[0].path()))
 ---
 code: |
-  temp_new_pdf.initialize()
-  formfyxer.auto_add_fields(template_upload[0].path(), temp_new_pdf.path())
+  for template in template_upload:
+    if template.filename.endswith("pdf"):
+      temp_new_pdf.initialize()
+      formfyxer.auto_add_fields(template.path(), temp_new_pdf.path())
   
-  # also normalize field names after newly recognizing them
-  formfyxer.parse_form(temp_new_pdf.path(), title=template_upload[0].filename, jur="MA", normalize=1, rewrite=1)
+      # also normalize field names after newly recognizing them
+      formfyxer.parse_form(temp_new_pdf.path(), title=template.filename, jur="MA", normalize=1, rewrite=1)
   
-  temp_new_pdf.commit()
-  template_upload[0].copy_into(temp_new_pdf)
-  process_field_recognition = True  
+      temp_new_pdf.commit()
+      template.copy_into(temp_new_pdf)
+  process_field_recognition = True
 ---
 modules:
   - .field_grouping
@@ -387,20 +382,17 @@ code: |
     interview.getting_started = "Before you get started, you need to..."
 
     interview.typical_role = "unknown"
-    tmp_people_variables = get_person_variables(all_fields, custom_only=True)
-    people_variables = DADict("people_variables", auto_gather=False, gathered=True)
-    for person in tmp_people_variables:
-      people_variables[person] = True
 
-    process_people_variables
+    fields.gathered
+    fields.mark_people_as_builtins(fields.get_person_candidates())
+
     for person in person_candidates:
-      people_quantities[person] = "any"    
-    get_all_fields
+      people_quantities[person] = "any"
     
     for index, field in enumerate(fields.elements):
       field.field_type = field.field_type_guess if hasattr(field, 'field_type_guess') else 'text'
-      field.label = field.variable_name_guess                
-    # choose_field_types  
+      field.label = field.variable_name_guess
+    # choose_field_types
     # review_fields_after_labeling
     
     questions.auto_gather = False
@@ -424,7 +416,9 @@ code: |
   process_im_feeling_lucky = True
 ---
 code: |
-  if have_template_to_load: 
+  # Note: we just use the first document to create the placeholder name even if multiple forms are uploaded.
+  # That's fine as it is a placeholder
+  if have_template_to_load:
     if template_upload[0].filename.endswith('pdf'):
       short_filename = space_to_underscore(varname(template_upload[0].filename.lower()[:-len(".pdf")]))
     else:
@@ -506,13 +500,6 @@ fields:
   - Link to original form: interview.original_form
     hint: http://masslegalhelp.org/my_form
     required: False
-help:
-  label: |
-    View variable debug information
-  content: |
-    There are ${len(all_fields)} fields total.
-    
-    `${all_fields}`
 ---
 code: |
   interview.default_country_code = 'US'
@@ -674,12 +661,12 @@ fields:
       The list of names below look like names for people, based on
       how you use them in your document.
     show if:
-      code: |
-        len(get_person_variables(all_fields, custom_only=True)) > 0
+      code: |        
+        len(fields.get_person_candidates(custom_only=True)) > 0
   - Which variable names represent people?: people_variables
     datatype: checkboxes
     code: |
-      get_person_variables(all_fields, custom_only=True)
+      fields.get_person_candidates(custom_only=True)
     help: |
       "person" variables will get things like addresses, multi-part
       names, and proper questions handled automatically. Using them
@@ -771,17 +758,14 @@ code: |
   from zipfile import BadZipFile
   
   try:
-    if template_upload[0].extension == 'pdf':
-      all_fields = get_pdf_fields(template_upload)
-    else:
-      all_fields = get_fields(template_upload)
-      
-    if not all_fields:
+    fields.clear()
+    fields.add_fields_from_file(template_upload)
+    fields.gathered = True
+    if not len(fields) > 0:
       force_ask('empty_pdf')
-
     bad_fields = list(filter(
-        lambda elem: elem is not None, 
-        map(bad_name_reason, all_fields)))
+        lambda elem: elem is not None,
+        map(bad_name_reason, fields)))
     if len(bad_fields) > 0:
       force_ask('non_descriptive_field_name')
   except ParsingException as ex:
@@ -836,57 +820,9 @@ buttons:
 ---
 code: |
   if have_template_to_load: 
-    built_in_people_vars_used = get_person_variables(all_fields, custom_only=False) - get_person_variables(all_fields, custom_only=True)
+    built_in_people_vars_used = fields.get_person_candidates(custom_only=False) - fields.get_person_candidates(custom_only=True)
   else:
     built_in_people_vars_used = []
----
-comment: |
-  Convert the PDF fields into Docassemble fields
-code: |
-  # These all must be defined in advance to avoid duplicates
-  people_variables.true_values()
-  all_fields
-  fields
-  signature_fields
-  built_in_fields_used  
-  
-  yesno_map = defaultdict(list)
-  document_type = 'pdf' if template_upload[0].extension == 'pdf' else 'docx'
-
-  if document_type == 'pdf':
-    # Probably all of this should move into a class
-    for pdf_field_tuple in all_fields:
-      pdf_field_name = pdf_field_tuple[0]
-      # Check to see if we think this field is built-in (handled in
-      # basic-questions.yml), a signature, or an arbitrary field.
-      #is_reserved_name = 
-      if is_reserved_label(pdf_field_name) or pdf_field_name in people_variables.true_values():
-        new_field = built_in_fields_used.appendObject()
-      elif len(pdf_field_tuple) > 4 and pdf_field_tuple[4] == '/Sig':
-        new_field = signature_fields.appendObject()
-      else:
-        new_field = fields.appendObject()
-      
-      # This function determines what type of variable
-      # we're dealing with
-      new_field.fill_in_pdf_attributes(pdf_field_tuple)
-
-  else:
-    # if this is a docx, fields are a list of strings, not a list of tuples
-    for field in all_fields:
-      if is_reserved_docx_label(field) or field in people_variables.true_values():
-        new_field = built_in_fields_used.appendObject()
-      elif field.endswith('.signature'):
-        new_field = signature_fields.appendObject()
-      else:                
-        new_field = fields.appendObject()
-      new_field.fill_in_docx_attributes(field)
-
-  built_in_fields_used.consolidate_duplicate_fields(document_type)
-  signature_fields.consolidate_duplicate_fields(document_type)
-  fields.consolidate_duplicate_fields(document_type)
-  fields.consolidate_yesnos()
-  get_all_fields = True
 ---
 code: |
   # Build the list of includes
@@ -1059,23 +995,23 @@ fields:
   - code: field_question
   - note: |
       **Built-in questions this form triggers**[BR]
-      % if len(built_in_fields_used) > 1:
-      These fields are not listed above because a built-in question already handles them: ${ built_in_fields_used }.
+      % if len(fields.builtins()) > 1:
+      These fields are not listed above because a built-in question already handles them: ${ fields.builtins() }.
       % elif have_template_to_load: 
       This field is not listed above because a built-in question already handles
-      it: ${ built_in_fields_used }.
+      it: ${ fields.builtins() }.
       % endif
-      % if len(signature_fields):
+      % if len(fields.signatures()):
       
       These signature fields are not listed because they cannot be asked
-      on the same screen as any other variable: ${ signature_fields }
+      on the same screen as any other variable: ${ fields.signatures() }
       % endif      
       
       You will have a chance to change the order of these fields later in
       this interview.
     show if:
       code: |
-        len(built_in_fields_used) or len(signature_fields)
+        len(fields.builtins()) or len(fields.signatures())
 validation code: |
   for field in fields:
     if field.field_type == "code":
@@ -1125,7 +1061,7 @@ code: |
   fields.there_is_another = False
 ---
 table: fields.review_table
-rows: fields + built_in_fields_used
+rows: fields + fields.builtins()
 columns:
   - On-screen label: |
       row_item.label if hasattr(row_item, 'label') else '(n/a)'
@@ -1161,7 +1097,7 @@ code: |
 code: |
   # We keep adding questions until ALL of the fields have been
   # assigned.
-  questions.there_is_another = len(questions.all_fields_used(all_fields=fields)) < len(fields)
+  questions.there_is_another = len(questions.all_fields_used(all_fields=fields.custom())) < len(fields.custom())
 ---
 id: create a draft of screen i
 question: |
@@ -1185,7 +1121,7 @@ fields:
     datatype: object_checkboxes
     # We show all of the fields, but exclude the ones present
     # anywhere in the list of questions we already drafted
-    exclude: questions.all_fields_used(all_fields=fields)
+    exclude: questions.all_fields_used(all_fields=fields.custom())
     none of the above: False
     choices: fields      
     object labeler: labeller_bold_plus_label
@@ -1218,12 +1154,12 @@ code: |
   # Used for adding a new field
   fields[i].field_type_guess = fields[i].field_type
   fields[i].raw_field_names = [fields[i].variable]
-  
+  fields[i].source_document_type = "docx" # don't process the variable name
 ---
 code: |
   # Use screen_reordered to reflect the user adjusted table order  
   for question in screen_reordered:    
-    if question not in built_in_fields_used and question not in signature_fields:
+    if question not in fields.builtins() and question not in fields.signatures():
 		  question.type = "question"
 		  interview.blocks.append(question)
   add_question_screens = True
@@ -1317,14 +1253,14 @@ code: |
   # Note that some built-in fields are not unique screens. This could
   # mess up the count
   unique_fields = set()
-  for field in built_in_fields_used:
+  for field in fields.builtins():
     # Don't add the users[0].signature field to this list
     if field.final_display_var == "users[0].signature":
       continue
     if not field.final_display_var in unique_fields:
       unique_fields.add(field.final_display_var)
       screen_order.append(field)
-  for field in signature_fields:
+  for field in fields.signatures():
     screen_order.append(field)
   screen_order.gathered = True
   set_initial_screen_order = True
@@ -1501,7 +1437,7 @@ code: |
         logic_list.append(question.field_list[0].trigger_gather())
     else:
       # it's a built-in field OR a signature, not a question block
-      if not (question in built_in_fields_used and question.trigger_gather().endswith('.signature')):
+      if not (question in fields.builtins() and question.trigger_gather().endswith('.signature')):
         logic_list.append(question.trigger_gather())      
         # set the saved answer name so it includes the user's name in saved
         # answer list
@@ -1514,10 +1450,10 @@ code: |
     logic_list.append("saved_report_data")
     
   built_in_signatures = set()
-  for field in built_in_fields_used:
+  for field in fields.builtins():
     if field.trigger_gather().endswith('.signature'):
       built_in_signatures.add(field.trigger_gather())
-  # TODO for field in signature_fields:    
+  # TODO for field in fields.signatures():    
   
   # 2. Build interview-specific question order
   code_block =  interview.blocks.appendObject() # 'interview order code block'
@@ -1548,19 +1484,18 @@ code: |
   signature_fields_block = interview.blocks.appendObject()
   signature_fields_block.template_key = 'signature fields'
   signature_fields_block.data = {
-    "signature_fields": signature_fields,
+    "signature_fields": fields.signatures(),
     "built_in_signatures": built_in_signatures
   }
   add_signature_trigger = True
 ---
 need:
   - fields
-  - built_in_fields_used
   - interview_label
 code: |
   review_block = interview.blocks.appendObject()
   review_block.template_key = "review"  
-  field_list = fields + built_in_fields_used + signature_fields
+  field_list = fields
   parent_collections = field_list.find_parent_collections()
   review_block.data = {
     "field_list": field_list,
@@ -1869,7 +1804,7 @@ code: |
   file1.attachment_varname = attachment_variable_name    
   file1.type = template_upload[0].extension  
   file1.description = interview.title
-  file1.fields = built_in_fields_used + fields + signature_fields
+  file1.fields = fields
   file1.has_addendum = bool(len(addendum_fields))
 
   # TODO: it would be possible to merge the "bundles" list with the
@@ -2132,7 +2067,7 @@ code: |
 only sets: no_template_default_values
 code: |
   if not have_template_to_load:
-    all_fields = fields  
+    fields.gathered = True
   interview.original_form = 'NA'  
   interview.typical_role = 'anonymous'
   interview_label_draft = interview.short_title

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -2213,7 +2213,7 @@ content: |
   % if template_upload[i].mimetype == "application/pdf":
   ${ template_upload[i].pdf_field_preview }
   % else:
-  ${ pdf_concatenate(template_upload) }
+  ${ pdf_concatenate(template_upload[i]) }
   % endif
 ---
 attachment:

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -100,7 +100,7 @@ code: |
     set_interview_type_vars 
     if have_template_to_load: 
       template_upload
-      if any(f for f in template_upload if f.filename.endswith('pdf') ):
+      if all(map(lambda y: True if y.filename.endswith(".pdf") else False, template_upload)):
         if yes_normalize_fields:
           process_field_normalization
         validate_pdf
@@ -109,10 +109,12 @@ code: |
         fields_checkup_status
         all_look_good
         validation_success
-      if any(f for f in template_upload if f.filename.endswith('docx')):
+      elif all(map(lambda y: True if y.filename.endswith(".docx") else False, template_upload)):
         if no_recognized_docx_fields:
           warn_no_recognized_al_labels
         validate_docx
+      else: # mixed PDF and DOCX templates
+        validate_mixed_documents
  
   if have_template_to_load:  
     fields.gathered
@@ -778,7 +780,12 @@ code: |
       if errors:
         force_ask('exit_invalid_docx')        
       # Check for syntax that indicates a user error
-      validate_docx 
+      jinja_errors = get_jinja_errors(document)
+      if jinja_errors:
+        jinja_exception
+      mako_matches = get_mako_matches(document)
+      if mako_matches:
+        mako_syntax_in_docx
     else:
       force_ask("exit_unknown_file_type")
 
@@ -2117,3 +2124,103 @@ code: |
     generate_download_screen = True
     
   set_interview_type_vars = 'Done'
+---
+id: confirm-mixed-document-fields
+continue button field: validate_mixed_documents
+question: |
+  Validate your templates
+subquestion: |
+  #### Your upload contains both DOCX and PDF files
+
+  #### Fields
+  
+  All of the fields in your template files are listed in the table below.
+  Confirm that the table looks right.
+  
+  A **bold** name means that this field is **reserved**.
+  Reserved fields are fields that will be handled with a question that
+  comes from the AL Question Library. For example:
+  
+  * Name fields
+  * Address fields
+  * Basic contact information and court information
+  
+  If you expect a field to be bold but it isn't, check the field's spelling.
+
+  The **type** of each field is just a guess, based on the field's name.
+  You can override the guess later.
+
+  Name (bold if {reserved}) | Type
+  --------------------------|------
+  % for field in validation_fields.builtins():
+  ${ bold(field.variable) } :question: | ${ field.field_type_guess } |
+  % endfor
+  % for field in validation_fields.custom():
+  ${ bold(field.variable) if field.reserved else field.variable } |  ${ field.field_type_guess } | 
+  % endfor
+  % for field in validation_fields.signatures():
+  ${ bold(field.variable) if field.reserved else field.variable } | signature  |
+  % endfor
+    
+  #### Preview  
+  Look over the PDF preview of your file below. Make sure that the
+  fonts, spacing, and styles look about right. Note: the conditional logic
+  and text your user enters can change the formatting. You will also
+  see the placeholder variable names unchanged in this preview.
+  
+  For safety, we recommend that you use the standard [Microsoft Core Fonts
+  for the Web](https://en.wikipedia.org/wiki/Core_fonts_for_the_Web), including
+  Arial and Times New Roman, as the standard fonts in Word templates.
+  
+  If spacing or other formatting looks wrong, try editing your file in
+  [LibreOffice](https://www.libreoffice.org/) and get it looking right
+  there.
+  
+  % for document in template_upload:  
+  ${ collapse_template(document.preview_template) }
+
+  % endfor
+
+fields:
+  - no label: mixed_fields_checkup_status
+    datatype: checkboxes
+    choices:
+      - All of my fields are listed in the table above: all_fields_present
+      - There are no unexpected fields in the table: no_unexpected_fields
+      - All the reserved fields are bolded as I expected: correct_reserved_fields    
+      - The fonts and styles in the preview look okay: fonts_okay
+        help: |
+          Note: use the Microsoft Core Fonts for the Web to be safe.
+    minlength: 4
+    validation messages:
+      minlength: |
+        You must select all of the checkboxes to keep going.
+    none of the above: False
+terms:
+  - reserved: |
+      Means there is a built-in question for this field.
+css: |
+  <style>
+  .question-confirm-docx-fields div.container {
+    max-width: 2000px;
+  }  
+  </style>
+---
+template: template_upload[i].preview_template
+subject: |
+  Preview ${ template_upload[i].filename }
+content: |
+  % if template_upload[i].mimetype == "application/pdf":
+  ${ template_upload[i].pdf_field_preview }
+  % else:
+  ${ pdf_concatenate(template_upload) }
+  % endif
+---
+attachment:
+  variable name: template_upload[i].pdf_field_preview
+  editable: False
+  pdf template file:
+    code: |
+      template_upload[i]
+  code: |
+    reflect_fields(template_upload[i].get_pdf_fields())

--- a/docassemble/ALWeaver/data/questions/docx_field_tester.yml
+++ b/docassemble/ALWeaver/data/questions/docx_field_tester.yml
@@ -165,13 +165,11 @@ objects:
 need:
   - docx_validation_fields
 code: |
-  docx_validation_fields.clear()
   people_list = fields.get_person_candidates(custom_only=True)
+  docx_validation_fields = fields.copy_deep("docx_validation_fields")
 
-  for field in fields:
-    new_field = docx_validation_fields.appendObject()
-    new_field.fill_in_docx_attributes(field.variable)
-    new_field.reserved = is_reserved_docx_label(field.variable) or field.variable in people_list
+  for field in docx_validation_fields:
+    field.reserved = is_reserved_docx_label(field.variable) or field.variable in people_list
     
   docx_validation_fields.mark_people_as_builtins(people_list)
 

--- a/docassemble/ALWeaver/data/questions/docx_field_tester.yml
+++ b/docassemble/ALWeaver/data/questions/docx_field_tester.yml
@@ -96,11 +96,14 @@ subquestion: |
 
   Name (bold if {reserved}) | Type
   --------------------------|------
-  % for field in docx_validation_fields:
-  ${ bold(field.variable) if field.reserved else field.variable} |  ${ field.field_type_guess }| 
+  % for field in docx_validation_fields.builtins():
+  ${ bold(field.variable) } :question: | ${ field.field_type_guess } |
   % endfor
-  % for field in docx_custom_people:
-  ${ bold(field.variable) } :question: | ${ field.field_type_guess }
+  % for field in docx_validation_fields.custom():
+  ${ bold(field.variable) if field.reserved else field.variable } |  ${ field.field_type_guess } | 
+  % endfor
+  % for field in docx_validation_fields.signatures():
+  ${ bold(field.variable) if field.reserved else field.variable } | signature  |
   % endfor
   
   % if len(docx_custom_people) > 0:
@@ -163,12 +166,13 @@ need:
   - docx_validation_fields
 code: |
   docx_validation_fields.clear()
-  for field in all_fields:
+  people_list = fields.get_person_candidates(custom_only=True)
+
+  for field in fields:
     new_field = docx_validation_fields.appendObject()
-    new_field.fill_in_docx_attributes(field)
-    new_field.reserved = is_reserved_docx_label(field) or field in possible_base
+    new_field.fill_in_docx_attributes(field.variable)
+    new_field.reserved = is_reserved_docx_label(field.variable) or field.variable in people_list
     
-  possible_base = list(get_person_variables(all_fields, custom_only=True))
-  process_custom_people(possible_base, docx_validation_fields, docx_custom_people)  
+  docx_validation_fields.mark_people_as_builtins(people_list)
 
   update_docx_validation_fields = True  

--- a/docassemble/ALWeaver/data/questions/docx_field_tester.yml
+++ b/docassemble/ALWeaver/data/questions/docx_field_tester.yml
@@ -9,23 +9,11 @@ fields:
     datatype: file
 ---
 code: |
-  jinja_errors = get_jinja_errors(template_upload)
-  if jinja_errors:
-    jinja_exception
-  if contains_mako:
-    mako_syntax_in_docx  
-  verify_docx_fields
-  
+  verify_docx_fields 
   validate_docx = True
 ---
 code: |
-  mako_matches = get_mako_matches(template_upload[0])
-  contains_mako = len(mako_matches)
----
-need: 
-  - update_docx_validation_fields
-code: |
-  no_recognized_docx_fields = not (any(field for field in docx_validation_fields if field.reserved) or len(docx_custom_people))
+  no_recognized_docx_fields = not (any(field for field in validation_fields if field.reserved) or len(validation_people_list))
 ---
 id: Did you intend to use Mako syntax
 question: |
@@ -70,8 +58,6 @@ subquestion: |
   and for [Jinja2](https://jinja.palletsprojects.com/en/3.0.x/) to learn more.
 ---
 id: confirm-docx-fields
-need: 
-  - update_docx_validation_fields
 continue button field: verify_docx_fields
 question: |
   Validate your template
@@ -96,17 +82,17 @@ subquestion: |
 
   Name (bold if {reserved}) | Type
   --------------------------|------
-  % for field in docx_validation_fields.builtins():
+  % for field in validation_fields.builtins():
   ${ bold(field.variable) } :question: | ${ field.field_type_guess } |
   % endfor
-  % for field in docx_validation_fields.custom():
+  % for field in validation_fields.custom():
   ${ bold(field.variable) if field.reserved else field.variable } |  ${ field.field_type_guess } | 
   % endfor
-  % for field in docx_validation_fields.signatures():
+  % for field in validation_fields.signatures():
   ${ bold(field.variable) if field.reserved else field.variable } | signature  |
   % endfor
   
-  % if len(docx_custom_people) > 0:
+  % if len(validation_people_list) > 0:
   :question: Indicates that we think this field could be handled by 
   questions in our question library, so you don't have to write your own 
   questions for it! You can choose whether to use our default questions later.
@@ -141,7 +127,7 @@ fields:
     validation messages:
       minlength: |
         You must select all of the checkboxes to keep going.
-    none of the above: False    
+    none of the above: False
 terms:
   - reserved: |
       Means there is a built-in question for this field.
@@ -158,19 +144,17 @@ subject: |
 content: |
   ${ pdf_concatenate(template_upload) }
 ---
-objects:
-  - docx_validation_fields: DAFieldList.using(gathered=True)
-  - docx_custom_people: DAFieldList.using(gathered=True)
----
-need:
-  - docx_validation_fields
+only sets:
+  - validation_fields
+  - validation_people_list
 code: |
-  people_list = fields.get_person_candidates(custom_only=True)
-  docx_validation_fields = fields.copy_deep("docx_validation_fields")
+  validation_people_list = fields.get_person_candidates(custom_only=True)
+  validation_fields = fields.copy_deep("validation_fields")
 
-  for field in docx_validation_fields:
-    field.reserved = is_reserved_docx_label(field.variable) or field.variable in people_list
+  for field in validation_fields:
+    if field.source_document_type == "docx":
+      field.reserved = is_reserved_docx_label(field.variable) or field.variable in people_list
+    elif field.source_document_type == "pdf":
+      field.reserved = is_reserved_label(field.variable)
     
-  docx_validation_fields.mark_people_as_builtins(people_list)
-
-  update_docx_validation_fields = True  
+  validation_fields.mark_people_as_builtins(people_list)

--- a/docassemble/ALWeaver/data/questions/generator-test.yml
+++ b/docassemble/ALWeaver/data/questions/generator-test.yml
@@ -1,3 +1,4 @@
+
 # Get output from tests.
 modules:
   - .test_map_names

--- a/docassemble/ALWeaver/data/questions/pdf_field_tester.yml
+++ b/docassemble/ALWeaver/data/questions/pdf_field_tester.yml
@@ -96,7 +96,7 @@ subquestion: |
   Name (bold if {reserved}) | Type | {Internal DA name} | Max length
   -----------|------------|-------------------|-----------
   % for field in fields:
-  ${":exclamation-triangle: " if ' ' in field.variables else ''} ${":exclamation-circle: " if len(remove_multiple_appearance_indicator(varname(field.variable))) == 0 else ''} ${'**' + str(field.variable) + '**' if is_reserved_label(field.variable) or field.variable in possible_custom else field.variable} ${ ':question:' if field.variable in possible_custom else ''} | ${ field.field_type_guess } | ${map_raw_to_final_display(field.variable) if not (map_raw_to_final_display(field.variable) == field.variable) else ''} | ${ field.maxlength if hasattr(field, "maxlength") else 'n/a' }
+  ${":exclamation-triangle: " if ' ' in field.variable else ''} ${":exclamation-circle: " if len(remove_multiple_appearance_indicator(varname(field.variable))) == 0 else ''} ${'**' + str(field.variable) + '**' if is_reserved_label(field.variable) or field.variable in possible_custom else field.variable} ${ ':question:' if field.variable in possible_custom else ''} | ${ field.field_type_guess } | ${map_raw_to_final_display(field.variable) if not (map_raw_to_final_display(field.variable) == field.variable) else ''} | ${ field.maxlength if hasattr(field, "maxlength") else 'n/a' }
   % endfor
   
   % if 'space' in warnings:

--- a/docassemble/ALWeaver/data/questions/pdf_field_tester.yml
+++ b/docassemble/ALWeaver/data/questions/pdf_field_tester.yml
@@ -10,12 +10,11 @@ images:
   green_light: green_light.png
 ---
 code: |
+  fields.gathered
   try:
-    checkbox_fields = [field[0] for field in all_fields if len(field) > 4 and field[4] == '/Btn']
-    signature_fields_test = [field[0] for field in all_fields if len(field) >4 and field[4] == '/Sig']
-    possible_base = get_person_variables(all_fields, custom_only=True)
-    possible_custom = [field[0] for field in all_fields
-        if any([field[0].startswith(base) for base in possible_base])]
+    people_list = fields.get_person_candidates(custom_only=True)
+    possible_custom = [field.variable for field in fields
+        if is_reserved_label(field.variable, reserved_prefixes=people_list)]
   except ParsingException as ex:
     parsing_ex = ex
     force_ask('parsing_exception')
@@ -66,8 +65,8 @@ buttons:
 ---
 code: |
   warnings_temp = set()
-  for field in all_fields:
-    if ' ' in field[0]:
+  for field in fields:
+    if ' ' in field.variable:
       warnings_temp.add('space')
     if field[4] not in ['/Sig','/Btn','/Tx']:
       warnings_temp.add('not handled')
@@ -75,7 +74,7 @@ code: |
   del warnings_temp
 ---
 code: |
-  no_recognized_pdf_fields = not (any(field for field in all_fields if is_reserved_label(field[0])) or len(possible_custom) > 0)
+  no_recognized_pdf_fields = not (any(field for field in fields if is_reserved_label(field.variable)) or len(possible_custom) > 0)
 ---
 id: confirm-pdf-fields
 question: |
@@ -96,25 +95,9 @@ subquestion: |
 
   Name (bold if {reserved}) | Type | {Internal DA name} | Max length
   -----------|------------|-------------------|-----------
-  % for field in all_fields:
-  ${":exclamation-triangle: " if ' ' in field[0] else ''} ${":exclamation-circle: " if len(remove_multiple_appearance_indicator(varname(field[0]))) == 0 else ''} ${'**' + str(field[0]) + '**' if is_reserved_label(field[0]) or field[0] in possible_custom else field[0]} ${ ':question:' if field[0] in possible_custom else ''} | ${ pdf_field_type_str(field) } (${field[4]}) | ${map_raw_to_final_display(field[0]) if not (map_raw_to_final_display(field[0]) == field[0]) else ''} | ${ get_character_limit(field) if get_character_limit(field) else 'n/a' }
+  % for field in fields:
+  ${":exclamation-triangle: " if ' ' in field.variables else ''} ${":exclamation-circle: " if len(remove_multiple_appearance_indicator(varname(field.variable))) == 0 else ''} ${'**' + str(field.variable) + '**' if is_reserved_label(field.variable) or field.variable in possible_custom else field.variable} ${ ':question:' if field.variable in possible_custom else ''} | ${ field.field_type_guess } | ${map_raw_to_final_display(field.variable) if not (map_raw_to_final_display(field.variable) == field.variable) else ''} | ${ field.maxlength if hasattr(field, "maxlength") else 'n/a' }
   % endfor
-
-  % if len(signature_fields_test) > 0:
-  The following are signature fields: 
-  
-  % for sig in signature_fields_test:
-  * ${ sig }
-  % endfor
-  % endif  
-
-  % if len(checkbox_fields) > 0:
-  The following are checkbox fields: 
-  
-  % for chk in checkbox_fields:
-  * ${ chk }
-  % endfor
-  % endif
   
   % if 'space' in warnings:
   :exclamation-triangle: Indicates that the field name has a space in it.
@@ -170,7 +153,7 @@ validation code: |
 help:
   label: Debug Info
   content: |
-    % for field in all_fields:
+    % for field in fields:
     * ${field}
     % endfor
 terms:
@@ -194,13 +177,10 @@ right: |
   _Limitations_: we do not have a way to show you the labels for
   checkbox fields yet.
   
-  ${ action_button_html(url_ask(["display_rename_field_choices", "renamed_fields", {"recompute": ["all_fields", "field_preview_pdf"]} ]), label="Rename fields") }
+  ${ action_button_html(url_ask(["display_rename_field_choices", "renamed_fields", {"recompute": ["fields", "field_preview_pdf"]} ]), label="Rename fields") }
 ---
 code: |
-  signatures = [{field: placeholder_signature} for field in signature_fields_test]
-  checkboxes = [{field: 'Yes'} for field in checkbox_fields]
-  other_fields = [{field[0]: map_raw_to_final_display(field[0])} for field in all_fields if not field[0] in signatures and not field[0] in checkbox_fields]
-  pdf_fields = other_fields + checkboxes + signatures
+  pdf_fields = [{field.variable: map_raw_to_final_display(field.variable)} for field in fields]
 ---
 objects:
   - quality_check_overlay: DAStaticFile.using(filename='quality_check_overlay.pdf')

--- a/docassemble/ALWeaver/data/questions/pdf_field_tester.yml
+++ b/docassemble/ALWeaver/data/questions/pdf_field_tester.yml
@@ -68,7 +68,7 @@ code: |
   for field in fields:
     if ' ' in field.variable:
       warnings_temp.add('space')
-    if field[4] not in ['/Sig','/Btn','/Tx']:
+    if hasattr(field, "field_type_not_handled") and field.field_type_not_handled:
       warnings_temp.add('not handled')
   warnings = warnings_temp
   del warnings_temp

--- a/docassemble/ALWeaver/data/questions/pdf_field_tester.yml
+++ b/docassemble/ALWeaver/data/questions/pdf_field_tester.yml
@@ -11,13 +11,12 @@ images:
 ---
 code: |
   fields.gathered
-  try:
-    people_list = fields.get_person_candidates(custom_only=True)
-    possible_custom = [field.variable for field in fields
-        if is_reserved_label(field.variable, reserved_prefixes=people_list)]
-  except ParsingException as ex:
-    parsing_ex = ex
-    force_ask('parsing_exception')
+  people_list = fields.get_person_candidates(custom_only=True)
+  possible_custom = [
+    field.variable 
+    for field in fields
+    if is_reserved_label(field.variable, reserved_prefixes=people_list)
+  ]
 ---
 event: empty_pdf
 question: You uploaded an empty PDF

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -450,11 +450,11 @@ class DAField(DAObject):
         elif self.variable.endswith("_amount"):
             self.field_type_guess = "currency"
         elif self.variable.endswith("_value"):
-            self.field_type_guess = "currency"            
+            self.field_type_guess = "currency"
         else:
             self.field_type_guess = "text"
-        
-        if pdf_field_tuple[4] not in ['/Sig','/Btn','/Tx']:
+
+        if pdf_field_tuple[4] not in ["/Sig", "/Btn", "/Tx"]:
             self.field_type_unhandled = True
 
     def mark_as_paired_yesno(self, paired_field_names: List[str]):
@@ -1046,7 +1046,7 @@ class DAFieldList(DAList):
             for var_and_type, fields in parent_coll_map.items()
         ]
 
-    def add_fields_from_file(self, the_file:Union[DAFile, DAFileList]) -> None:
+    def add_fields_from_file(self, the_file: Union[DAFile, DAFileList]) -> None:
         """
         Given a DAFile or DAFileList, process the raw fields in each file
         and add to the current list. Deduplication happens after each additional
@@ -1063,7 +1063,9 @@ class DAFieldList(DAList):
         elif the_file.filename.lower().endswith("docx"):
             document_type = "docx"
         else:
-            raise Exception(f"{f.filename} doesn't appear to be a PDF or DOCX file. Check the filename extension.")
+            raise Exception(
+                f"{f.filename} doesn't appear to be a PDF or DOCX file. Check the filename extension."
+            )
 
         if document_type == "pdf":
             for pdf_field_tuple in all_fields:
@@ -1074,11 +1076,11 @@ class DAFieldList(DAList):
                 # Built-in fields and signatures don't get custom questions written
                 if is_reserved_label(pdf_field_name):
                     new_field.group = DAFieldGroup.BUILT_IN
-                elif len(pdf_field_tuple) > 4 and pdf_field_tuple[4] == '/Sig':
+                elif len(pdf_field_tuple) > 4 and pdf_field_tuple[4] == "/Sig":
                     new_field.group = DAFieldGroup.SIGNATURE
                 else:
                     new_field.group = DAFieldGroup.CUSTOM
-                
+
                 # This function determines what type of variable
                 # we're dealing with
                 new_field.fill_in_pdf_attributes(pdf_field_tuple)
@@ -1089,16 +1091,17 @@ class DAFieldList(DAList):
                 new_field.source_document_type = "docx"
                 if is_reserved_docx_label(field):
                     new_field.group = DAFieldGroup.BUILT_IN
-                elif field.endswith('.signature'):
+                elif field.endswith(".signature"):
                     new_field.group = DAFieldGroup.SIGNATURE
-                else:                
+                else:
                     new_field.group = DAFieldGroup.CUSTOM
                 new_field.fill_in_docx_attributes(field)
 
         self.consolidate_duplicate_fields(document_type)
         self.consolidate_yesnos()
 
-    def get_person_candidates(self,
+    def get_person_candidates(
+        self,
         undefined_person_prefixes=generator_constants.UNDEFINED_PERSON_PREFIXES,
         people_suffixes=generator_constants.PEOPLE_SUFFIXES,
         people_suffixes_map=generator_constants.PEOPLE_SUFFIXES_MAP,
@@ -1110,7 +1113,7 @@ class DAFieldList(DAList):
         Identify the field names that appear to represent people in the list of
         string fields pulled from docx/PDF. Exclude people we know
         are singular Persons (such as trial_court).
-        """    
+        """
         people_vars = reserved_person_pluralizers_map.values()
         people = set()
         for field in self:
@@ -1127,7 +1130,9 @@ class DAFieldList(DAList):
                 people.add(field_to_check)
             elif (field_to_check) in undefined_person_prefixes:
                 pass  # Do not ask how many there will be about a singluar person
-            elif file_type == "docx" and ("[" in field_to_check or "." in field_to_check):
+            elif file_type == "docx" and (
+                "[" in field_to_check or "." in field_to_check
+            ):
                 # Check for a valid Python identifier before brackets or .
                 match_with_brackets_or_attribute = r"([A-Za-z_]\w*)((\[.*)|(\..*))"
                 matches = re.match(match_with_brackets_or_attribute, field_to_check)
@@ -1169,26 +1174,31 @@ class DAFieldList(DAList):
         else:
             return people - (set(reserved_pluralizers_map.values()) - set(people_vars))
 
-
-    def mark_people_as_builtins(self, people_list:List[str], people_suffixes: List[str] = (
-        generator_constants.PEOPLE_SUFFIXES + generator_constants.DOCX_ONLY_SUFFIXES
-    )) -> None:
+    def mark_people_as_builtins(
+        self,
+        people_list: List[str],
+        people_suffixes: List[str] = (
+            generator_constants.PEOPLE_SUFFIXES + generator_constants.DOCX_ONLY_SUFFIXES
+        ),
+    ) -> None:
         """Scan the list of fields and see if any of them should be renamed
         or marked as built-ins given the list of new, custom prefixes."""
         for field in self:
-            if field.source_document_type == "pdf":           
+            if field.source_document_type == "pdf":
                 if is_reserved_label(field.variable, reserved_prefixes=people_list):
                     field.group = DAFieldGroup.BUILT_IN
                     # Try checking to see if the custom prefix + predefined suffixes
                     # result in a new variable name
                     new_potential_name = map_raw_to_final_display(
-                        field.variable, document_type=field.source_document_type, reserved_prefixes=people_list
+                        field.variable,
+                        document_type=field.source_document_type,
+                        reserved_prefixes=people_list,
                     )
                     if new_potential_name != field.variable:
                         field.final_display_var = new_potential_name
-            elif is_reserved_docx_label(field.variable,
-                    reserved_pluralizers_map = dict(enumerate(people_list))
-                ):
+            elif is_reserved_docx_label(
+                field.variable, reserved_pluralizers_map=dict(enumerate(people_list))
+            ):
                 field.group = DAFieldGroup.BUILT_IN
 
         # This treats all fields as PDF fields, which should be a reasonable
@@ -1198,16 +1208,17 @@ class DAFieldList(DAList):
     def builtins(self):
         """Returns "built-in" fields, including ones the user indicated contain
         custom person-prefixes"""
-        return self.filter(group = DAFieldGroup.BUILT_IN)
+        return self.filter(group=DAFieldGroup.BUILT_IN)
 
     def signatures(self):
         """Returns all signature fields in list"""
-        return self.filter(group = DAFieldGroup.SIGNATURE)
+        return self.filter(group=DAFieldGroup.SIGNATURE)
 
     def custom(self):
         """Returns the fields that can be assigned to screens and which will require
         custom labels"""
-        return self.filter(group = DAFieldGroup.CUSTOM)
+        return self.filter(group=DAFieldGroup.CUSTOM)
+
 
 class DAQuestion(DABlock):
     """
@@ -1353,6 +1364,7 @@ def get_fields(the_file):
     docx_data = docx2python(the_file.path())  # Will error with invalid value
     text = docx_data.text
     return get_docx_variables(text)
+
 
 def get_docx_variables(text: str) -> set:
     """
@@ -1702,6 +1714,7 @@ def pdf_field_type_str(field):
 # Recognizing errors with PDF and DOCX files and variable names
 ######################################
 
+
 def is_valid_python(code: str) -> bool:
     try:
         ast.parse(code)
@@ -1721,50 +1734,62 @@ def bad_name_reason(field: DAField):
     else:
         # log(field[0], "console")
         python_var = map_raw_to_final_display(
-            remove_multiple_appearance_indicator(varname(field.variable)), document_type="pdf"
+            remove_multiple_appearance_indicator(varname(field.variable)),
+            document_type="pdf",
         )
         if len(python_var) == 0:
             return f"{ field.variable }, the { field.field_type_guess } field, should be in [snake case](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/naming#pdf-variables--snake_case) and use alphabetical characters"
         return None
 
+
 def get_pdf_validation_errors(f: DAFile):
     try:
         fields = DAFieldList()
-        fields.add_fields_from_file(f)        
+        fields.add_fields_from_file(f)
     except ParsingException as ex:
         return ("parsing_exception", ex)
     except (PDFSyntaxError, PdfReadError):
         return ("invalid_pdf", "Invalid PDF")
     except PSEOF:
-        return ("pseof", "File appears incomplete (PSEOF error). Is this a valid PDF file?")
+        return (
+            "pseof",
+            "File appears incomplete (PSEOF error). Is this a valid PDF file?",
+        )
     except:
         return ("unknown", "Unknown error reading PDF file. Is this a valid PDF?")
     try:
         pdf_concatenate(f, f)
     except:
-        return ("concatenation_error", "Unknown error concatenating PDF file to itself. The file may be invalid.")
+        return (
+            "concatenation_error",
+            "Unknown error concatenating PDF file to itself. The file may be invalid.",
+        )
+
 
 def get_docx_validation_errors(f: DAFile):
     try:
         fields = DAFieldList()
-        fields.add_fields_from_file(f)        
+        fields.add_fields_from_file(f)
     except (BadZipFile, KeyError):
         return ("bad_docx", "Error opening DOCX. Is this a valid DOCX file?")
-    
+
     try:
         pdf_concatenate(f)
     except:
-        return ("unable_to_convert_to_pdf", "Unable to convert to PDF. Is this is a valid DOCX file?")
+        return (
+            "unable_to_convert_to_pdf",
+            "Unable to convert to PDF. Is this is a valid DOCX file?",
+        )
 
 
 def get_variable_name_warnings(fields):
-    return list(filter(
-        lambda elem: elem is not None,
-        map(bad_name_reason, fields)))
+    return list(filter(lambda elem: elem is not None, map(bad_name_reason, fields)))
+
 
 ############################
 # Create a Docassemble .zip package
 ############################
+
 
 def create_package_zip(
     pkgname: str,

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -443,9 +443,12 @@ class DAField(DAObject):
         elif self.variable.endswith("_amount"):
             self.field_type_guess = "currency"
         elif self.variable.endswith("_value"):
-            self.field_type_guess = "currency"
+            self.field_type_guess = "currency"            
         else:
             self.field_type_guess = "text"
+        
+        if pdf_field_tuple[4] not in ['/Sig','/Btn','/Tx']:
+            self.field_type_unhandled = True
 
     def mark_as_paired_yesno(self, paired_field_names: List[str]):
         """Marks this field as actually representing multiple template fields:

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -1477,7 +1477,7 @@ def map_raw_to_final_display(
         return label
 
     # Break up label into its parts: prefix, digit, the rest
-    all_prefixes = reserved_prefixes + list(custom_people_plurals_map.values())
+    all_prefixes = list(reserved_prefixes) + list(custom_people_plurals_map.values())
     label_groups = get_reserved_label_parts(all_prefixes, label)
 
     # If no matches to automateable labels were found,

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -660,19 +660,15 @@ class DAField(DAObject):
 
         return content.rstrip("\n")
 
-    def user_ask_about_field(self, index):
+    def user_ask_about_field(self):
         field_questions = []
         settable_var = self.get_settable_var()
         if hasattr(self, "paired_yesno") and self.paired_yesno:
-            field_title = "{} (will be expanded to include _yes and _no)".format(
-                self.final_display_var
-            )
+            field_title = f"{ self.final_display_var } (will be expanded to include _yes and _no)"
         elif len(self.raw_field_names) > 1:
-            field_title = "{} (will be expanded to all instances)".format(settable_var)
+            field_title = f"{ settable_var } (will be expanded to all instances)"
         elif self.raw_field_names[0] != settable_var:
-            field_title = "{} (will be renamed to {})".format(
-                settable_var, self.raw_field_names[0]
-            )
+            field_title = f"{ settable_var } (will be renamed to { self.raw_field_names[0] })"
         else:
             field_title = self.final_display_var
 
@@ -680,14 +676,14 @@ class DAField(DAObject):
         field_questions.append(
             {
                 "label": "On-screen label",
-                "field": "fields[" + str(index) + "].label",
+                "field": self.attr_name("label"),
                 "default": self.variable_name_guess,
             }
         )
         field_questions.append(
             {
                 "label": "Field Type",
-                "field": f"fields[{index}].field_type",
+                "field": self.attr_name("field_type"),
                 "choices": [
                     "text",
                     "area",
@@ -717,17 +713,17 @@ class DAField(DAObject):
         field_questions.append(
             {
                 "label": f"Complete the expression, `{self.final_display_var} = `",
-                "field": f"fields[{index}].code",
-                "show if": {"variable": f"fields[{index}].field_type", "is": "code"},
+                "field": self.attr_name("code"),
+                "show if": {"variable": self.attr_name("field_type"), "is": "code"},
                 "help": f"Enter a valid Python expression, such as `'Hello World'` or `users[0].birthdate.plus(days=10)`. This will create a code block like `{self.final_display_var} = expression`",
             }
         )
         field_questions.append(
             {
                 "label": "Options (one per line)",
-                "field": f"fields[{index}].choices",
+                "field": self.attr_name("choices"),
                 "datatype": "area",
-                "js show if": f"['multiple choice dropdown','multiple choice combobox','multiselect', 'multiple choice radio', 'multiple choice checkboxes'].includes(val('fields[{index}].field_type'))",
+                "js show if": f"['multiple choice dropdown','multiple choice combobox','multiselect', 'multiple choice radio', 'multiple choice checkboxes'].includes(val('{ self.attr_name('field_type') }'))",
                 "hint": "Like 'Descriptive name: key_name', or just 'Descriptive name'",
             }
         )
@@ -735,9 +731,9 @@ class DAField(DAObject):
             field_questions.append(
                 {
                     "label": "Send overflow text to addendum",
-                    "field": f"fields[{index}].send_to_addendum",
+                    "field": self.attr_name("send_to_addendum"),
                     "datatype": "yesno",
-                    "js show if": f"val('fields[{index}].field_type') === 'area' ",
+                    "js show if": f"val('{ self.attr_name('field_type') }') === 'area' ",
                     "help": "Check the box to send text that doesn't fit in the PDF to an additional page, instead of limiting the input length.",
                 }
             )
@@ -1208,16 +1204,29 @@ class DAFieldList(DAList):
     def builtins(self):
         """Returns "built-in" fields, including ones the user indicated contain
         custom person-prefixes"""
-        return self.filter(group=DAFieldGroup.BUILT_IN)
+        # Can't use .filter() because that would create new intrinsicNames
+        return [
+            item
+            for item in self.elements
+            if item.group == DAFieldGroup.BUILT_IN
+        ]
 
     def signatures(self):
         """Returns all signature fields in list"""
-        return self.filter(group=DAFieldGroup.SIGNATURE)
+        return [
+            item
+            for item in self.elements
+            if item.group == DAFieldGroup.SIGNATURE
+        ]
 
     def custom(self):
         """Returns the fields that can be assigned to screens and which will require
         custom labels"""
-        return self.filter(group=DAFieldGroup.CUSTOM)
+        return [
+            item
+            for item in self.elements
+            if item.group == DAFieldGroup.CUSTOM
+        ]
 
 
 class DAQuestion(DABlock):

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -1045,6 +1045,7 @@ class DAFieldList(DAList):
         if isinstance(the_file, DAFileList):
             for f in the_file:
                 self.add_fields_from_file(f)
+            return None
 
         all_fields = get_fields(the_file)
         if the_file.filename.lower().endswith("pdf"):

--- a/docassemble/ALWeaver/validate_docx_files.py
+++ b/docassemble/ALWeaver/validate_docx_files.py
@@ -11,6 +11,7 @@ from docassemble.base.parse import (
     registered_jinja_filters,
     builtin_jinja_filters,
 )
+
 from typing import Optional, Iterable
 import re
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -33,3 +33,6 @@ ignore_missing_imports=true
 
 [mypy-ruamel]
 ignore_missing_imports=true
+
+[mypy-PyPDF2.*]
+ignore_missing_imports=true

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.ALWeaver',
       url='https://docassemble.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['PyYAML>=5.1.2', 'beautifulsoup4>=4.11.1', 'docassemble.ALToolbox>=0.4.2', 'docassemble.AssemblyLine>=2.11.2', 'docx2python>=1.27.1', 'formfyxer>=0.0.9', 'more-itertools>=8.6.0', 'numpy>=1.0.4', 'pikepdf>=5.1.1', 'sklearn>=0.0', 'spacy>=3.2.0'],
+      install_requires=['PyYAML>=5.1.2', 'beautifulsoup4>=4.11.1', 'docassemble.ALToolbox>=0.4.2', 'docassemble.AssemblyLine>=2.11.3', 'docx2python>=1.27.1', 'formfyxer>=0.0.9', 'more-itertools>=8.6.0', 'numpy>=1.0.4', 'pikepdf>=5.1.1', 'sklearn>=0.0', 'spacy>=3.2.0'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/ALWeaver/', package='docassemble.ALWeaver'),
      )


### PR DESCRIPTION
This has some big refactors in it, so I wouldn't mind some early eyes as I continue to work on it. Right now the only thing you can test is: 

1. single file uploads still work
2. multiple-file uploads will get through validation.

Refactors:
- moved most of the validation code exception handling into the .py module
- we no longer deal with tuples or lists of strings in the YAML - fields are turned into DAFields immediately when we process the template
- cleaned up some of the validation pages
- moved a few functions that manipulate the list of fields, including the custom person handling, into methods of the DAFieldList class. this might fix #559 

I haven't implemented the multiple output templates piece at all yet, so only single-file uploads would be meaningful.

Fix #484
Fix #629
progress on #628 
possible progress on #559 


