### PR TITLE
Automate multiple forms in one Weaver run

### DIFF
--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -810,7 +810,7 @@ event: exit_invalid_pdf
 question: |
   Is this a valid PDF?
 subquestion: |
-  ${ template_upload[0].filename } does not seem to be a PDF file. Usually
+  ${ document.filename } does not seem to be a PDF file. Usually
   this error happens because the file is corrupt or has the wrong extension.
 
   Docassemble was not able to read the file you uploaded. Make sure it is a
@@ -825,7 +825,7 @@ event: exit_PSEOF_error
 question: |
   Something is wrong with the internals of this PDF
 subquestion: |
-  Docassemble was not able to read ${ template_upload[0].filename }.
+  Docassemble was not able to read ${ document.filename }.
   
   You can try using [qpdf](http://qpdf.sourceforge.net/) or
   [documate.org/pdf](https://www.documate.org/pdf) to fix it, but some of your
@@ -837,7 +837,7 @@ event: exit_invalid_docx
 question: |
   Is this a valid DOCX file?
 subquestion: |
-  ${ template_upload[0].filename } does not seem to be a DOCX file. Usually
+  ${ document.filename } does not seem to be a DOCX file. Usually
   this error happens because the file is corrupt or has the wrong extension.
 
   Docassemble was not able to read the file you uploaded. Make sure it is a
@@ -989,12 +989,16 @@ code: |
 code: |
   # Create code for the question that we use to label
   # each field.
-  
-  temp_field_question = []
-  for index, field in enumerate(fields.elements):
-    temp_field_question.extend(field.user_ask_about_field(index))
+  from itertools import chain
 
-  field_question = temp_field_question
+  field_question_tmp = [ 
+    field.user_ask_about_field()
+    for field in fields.custom()
+  ]
+  field_question = [item for item in chain.from_iterable(field_question_tmp)]
+
+  del field_question_tmp
+  del chain
 ---
 id: choose field types
 continue button field: choose_field_types
@@ -1040,7 +1044,7 @@ fields:
       code: |
         len(fields.builtins()) or len(fields.signatures())
 validation code: |
-  for field in fields:
+  for field in fields.custom():
     if field.field_type == "code":
         expression = f"{field.final_display_var} = {field.code}"
         if not is_valid_python(expression):
@@ -1705,9 +1709,10 @@ objects:
   - renamed_upload: DAFile.using(filename=sanitized_filename)
 ---
 code: |
-  if have_template_to_load: 
-    renamed_upload.copy_into(template_upload[0])
-    renamed_upload.commit()
+  # Unfortunately, there's no good "new" name for the file
+  # when someone uploads multiple templates at once
+  if have_template_to_load and len(template_upload) == 1:
+    template_upload[0].set_attributes(filename=sanitized_filename)
   inflate_renamed_upload = True
 ---
 need:
@@ -1732,8 +1737,8 @@ code: |
   if generate_download_screen:
     folders_and_files["templates"] = [
         next_steps_documents[interview.form_type]['attachment'].docx,
-        renamed_upload,
-      ]
+    ]      
+    folders_and_files["templates"].extend(template_upload)
   else:    
     folders_and_files["templates"] = []
     
@@ -1824,22 +1829,33 @@ code: |
   file2.fields = 'na'
   file2.has_addendum = False
 
-  # Set attributes for the uploaded template file     
-  file1 = labels_lists.appendObject()    
-  file1.input_filename = sanitized_filename  
-  file1.output_filename = sanitized_filename
-  file1.attachment_varname = attachment_variable_name    
-  file1.type = template_upload[0].extension  
-  file1.description = interview.title
-  file1.fields = fields
-  file1.has_addendum = bool(len(addendum_fields))
+  if len(template_upload) == 1:
+    # Set attributes for the uploaded template file     
+    file1 = labels_lists.appendObject()    
+    file1.input_filename = sanitized_filename  
+    file1.output_filename = sanitized_filename
+    file1.attachment_varname = attachment_variable_name    
+    file1.type = template_upload[0].extension  
+    file1.description = interview.title
+    file1.fields = fields
+    file1.has_addendum = bool(len(addendum_fields))
+  else:
+    for document in template_upload:
+      temp_file = labels_lists.appendObject()    
+      temp_file.input_filename = document.filename
+      temp_file.output_filename = document.filename
+      temp_file.attachment_varname = space_to_underscore(base_name(document.filename))
+      temp_file.type = document.extension
+      temp_file.description = document.filename.replace("_", " ")
+      temp_file.fields = fields
+      temp_file.has_addendum = bool(len(addendum_fields))
 
   # TODO: it would be possible to merge the "bundles" list with the
   # attachments/labels_list.
   bundles.clear()
   user_bundle = bundles.appendObject()
   user_bundle.name = 'al_user_bundle'
-  user_bundle.elements = [file2, file1]
+  user_bundle.elements = labels_lists
   
   court_bundle = bundles.appendObject()
   if interview.court_related:
@@ -1847,15 +1863,16 @@ code: |
   else:
     court_bundle.name = 'al_recipient_bundle'
   # Court does not get the user next steps instructions
-  court_bundle.elements = [file1]
+  # Skip instructions TODO: remove if instructions become optional  
+  court_bundle.elements = labels_lists[1:] 
   bundles.gathered = True
   
   
   # Bundl-name is a single value
   if len(labels_lists) > 1:
-    bundle_name = file1.output_filename + '_package.pdf'
+    bundle_name =  sanitized_filename + '_package.pdf'
   else:
-    bundle_name = file1.output_filename + '.pdf'
+    bundle_name = sanitized_filename + '.pdf'
     
   #-----------------------------------------------------------------
   # Use the above data to generate blocks related to attachment files.

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -1746,7 +1746,7 @@ code: |
   if generate_download_screen:
     folders_and_files["templates"] = [
         next_steps_documents[interview.form_type]['attachment'].docx,
-    ]      
+    ]
     folders_and_files["templates"].extend(template_upload)
   else:    
     folders_and_files["templates"] = []

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -1799,7 +1799,7 @@ code: |
     end_question.template_key = 'download screen'
     end_question.data = {
         "interview_label": interview_label, 
-        "document_type": 'pdf' if any(map(lambda templ: templ.extension == 'pdf', template_upload)) else 'docx'
+        "document_type": "pdf" if any(map(lambda templ: templ.mimetype == "application/pdf", template_upload)) else "docx"
     }
   else:   
     end_question.template_key = 'thank-you screen'
@@ -1835,7 +1835,7 @@ code: |
     file1.input_filename = sanitized_filename  
     file1.output_filename = sanitized_filename
     file1.attachment_varname = attachment_variable_name    
-    file1.type = template_upload[0].extension  
+    file1.type = "pdf" if template_upload[0].mimetype == "application/pdf" else "docx"
     file1.description = interview.title
     file1.fields = fields
     file1.has_addendum = bool(len(addendum_fields))
@@ -1845,7 +1845,7 @@ code: |
       temp_file.input_filename = document.filename
       temp_file.output_filename = base_name(document.filename)
       temp_file.attachment_varname = space_to_underscore(base_name(document.filename))
-      temp_file.type = document.extension
+      temp_file.type = "pdf" if document.mimetype == "application/pdf" else "docx"
       temp_file.description = document.filename.replace("_", " ")
       temp_file.fields = fields.matching_pdf_fields_from_file(document)
       temp_file.has_addendum = bool(len(addendum_fields))

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -290,7 +290,7 @@ fields:
   - no label: template_upload
     datatype: files
     accept: |
-      ".pdf, application/pdf, .docx, application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+      "application/pdf, application/vnd.openxmlformats-officedocument.wordprocessingml.document"
   - Re-process and auto-identify form fields (PDFs, removes existing fields): yes_recognize_form_fields
     datatype: yesno
     help: |
@@ -303,10 +303,17 @@ fields:
       Use our experimental code to automatically apply AssemblyLine naming conventions.
       If you already followed naming conventions, you might want to skip this.
 validation code: |
-  try:
-    pdf_concatenate(template_upload, template_upload)
-  except:
-    validation_error("Your file may be corrupt. Please try <a href='https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/pdfs#corrupted-or-locked-pdfs'>repairing</a> it.", field="template_upload")
+  for document in template_upload:
+    if document.mimetype == "application/pdf":
+      try:
+        document.fix_up()
+      except:
+        validation_error("Your file may be corrupt. Please try <a href='https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/pdfs#corrupted-or-locked-pdfs'>repairing</a> it.", field="template_upload")
+    else:
+      try:
+        pdf_concatenate(document)
+      except:
+        validation_error("Unable to convert DOCX file to PDF. It may be an invalid file.")
 ---
 code: |
   has_safe_pdf_in_url = url_args.get('form_to_use') and url_args.get('form_to_use').startswith('https://courtformsonline.org')
@@ -752,32 +759,45 @@ comment: |
   Get the list of fields, and check for any possible labeling errors
   right away
 code: |
-  from pdfminer.pdfparser import PDFSyntaxError
-  from pdfminer.psparser import PSEOF
-  from PyPDF2.utils import PdfReadError
-  from zipfile import BadZipFile
+  for document in template_upload:
+    if document.mimetype == "application/pdf":
+      errors = get_pdf_validation_errors(document)
+      if errors:
+        log(errors[1])
+        if errors[0] == "parsing_exception":
+          parsing_ex = errors[1]
+          force_ask('parsing_exception')
+        elif errors[0] == "invalid_pdf":
+          force_ask('exit_invalid_pdf')
+        elif errors[0] == "pseof":
+          force_ask('exit_PSEOF_error')
+        elif errors[0] == "concatenation_error":
+          force_ask("exit_invalid_pdf")
+    elif document.mimetype == "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+      errors = get_docx_validation_errors(document)
+      if errors:
+        force_ask('exit_invalid_docx')        
+      # Check for syntax that indicates a user error
+      validate_docx 
+    else:
+      force_ask("exit_unknown_file_type")
+
+  fields.clear()
+  fields.add_fields_from_file(template_upload)
+  fields.gathered = True
+
+  if not len(fields) > 0:
+    force_ask('empty_pdf')
   
-  try:
-    fields.clear()
-    fields.add_fields_from_file(template_upload)
-    fields.gathered = True
-    if not len(fields) > 0:
-      force_ask('empty_pdf')
-    bad_fields = list(filter(
-        lambda elem: elem is not None,
-        map(bad_name_reason, fields)))
-    if len(bad_fields) > 0:
-      force_ask('non_descriptive_field_name')
-  except ParsingException as ex:
-    parsing_ex = ex
-    force_ask('parsing_exception')
-  except (PDFSyntaxError, PdfReadError):
-    # Handle PDF read error
-    force_ask('exit_invalid_pdf')
-  except PSEOF:
-    force_ask('exit_PSEOF_error')
-  except (BadZipFile, KeyError):
-    force_ask('exit_invalid_docx')
+  bad_fields = get_variable_name_warnings(fields)
+  if len(bad_fields) > 0:
+    force_ask('non_descriptive_field_name')
+---
+event: exit_unknown_file_type
+question: |
+  Is this a valid PDF or DOCX file?
+subquestion: |
+  The file you uploaded doesn't appear to be a valid DOCX or PDF document.
 ---
 event: exit_invalid_pdf
 question: |

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -76,9 +76,7 @@ include:
 ---
 objects:  
   - interview: DAInterview.using(template_path='data/sources/output_patterns.yml')
-  - built_in_fields_used: DAFieldList.using(gathered=True)
-  - fields: DAFieldList.using(gathered=True)
-  - signature_fields: DAFieldList.using(gathered=True)
+  - fields: DAFieldList.using(auto_gather=False)
   - questions: DAQuestionList.using(complete_attribute='complete')
   - interview_download: DAFile
   - interview_package_download: DAFile
@@ -102,7 +100,7 @@ code: |
     set_interview_type_vars 
     if have_template_to_load: 
       template_upload
-      if template_upload[0].filename.endswith('pdf'):
+      if any(f for f in template_upload if f.filename.endswith('pdf') ):
         if yes_normalize_fields:
           process_field_normalization
         validate_pdf
@@ -111,13 +109,13 @@ code: |
         fields_checkup_status
         all_look_good
         validation_success
-      else:
+      if any(f for f in template_upload if f.filename.endswith('docx')):
         if no_recognized_docx_fields:
           warn_no_recognized_al_labels
         validate_docx
  
   if have_template_to_load:  
-    get_all_fields
+    fields.gathered
   # Display Weaver question screens   
   interview.jurisdiction_choices 
   if generate_download_screen:      
@@ -201,15 +199,9 @@ id: no recognized fields
 question: |
   You do not have any labels that match the Assembly Line labels
 subquestion: |
-  % if template_upload[0].filename.endswith('pdf'):
   It is a good idea to use labels that match the Assembly Line documentation.
-  Most forms at least should use labels like `users1_name`, `petitioners`,
-  or `defendants`.
-  % else:
-  It is a good idea to use labels that match the Assembly Line documentation.
-  Most forms at least should use labels like `users[0].name.first`, `petitioners`,
-  or `defendants`.
-  % endif
+  Almost every form has a user and most forms also have an opposing party.
+  You should use the Assembly Line labels for these concepts.
   
   You can also add labels for:
   
@@ -218,7 +210,7 @@ subquestion: |
   * addresses
   * court information
 
-  [Read the labeling documentation](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/label_variables)
+  ${ action_button_html("https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/label_variables", label="Read the labeling documentation", color="info") }
 sets: warn_no_recognized_al_labels
 buttons: 
   - I know what I'm doing, let me continue:    
@@ -229,12 +221,11 @@ buttons:
   - Restart: restart
 ---
 code: |
+  # TODO: refactor to use the new config system
   set_custom_people_map( people_variables.true_values() )  
-  if len(people_variables.true_values()):    
-    # Process regular fields
-    process_custom_people(people_variables.true_values(), fields, built_in_fields_used, document_type=document_type)
-    # Process signature fields
-    process_custom_people(people_variables.true_values(), signature_fields, built_in_fields_used, document_type=document_type)
+
+  if len(people_variables.true_values()):
+    fields.mark_people_as_builtins(people_variables.true_values())
   process_people_variables = True
 ---
 continue button field: weaver_intro
@@ -297,7 +288,7 @@ subquestion: |
   Select a PDF or Word template: 
 fields:   
   - no label: template_upload
-    datatype: file
+    datatype: files
     accept: |
       ".pdf, application/pdf, .docx, application/vnd.openxmlformats-officedocument.wordprocessingml.document"
   - Re-process and auto-identify form fields (PDFs, removes existing fields): yes_recognize_form_fields
@@ -315,7 +306,7 @@ validation code: |
   try:
     pdf_concatenate(template_upload, template_upload)
   except:
-    validation_error("Your PDF file may be corrupt. Please try <a href='https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/pdfs#corrupted-or-locked-pdfs'>repairing</a> it.", field="template_upload")
+    validation_error("Your file may be corrupt. Please try <a href='https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/pdfs#corrupted-or-locked-pdfs'>repairing</a> it.", field="template_upload")
 ---
 code: |
   has_safe_pdf_in_url = url_args.get('form_to_use') and url_args.get('form_to_use').startswith('https://courtformsonline.org')
@@ -349,23 +340,27 @@ imports:
   - os
 ---
 code: |
-  formfyxer.parse_form(template_upload[0].path(), title=os.path.basename(template_upload[0].path()), jur="MA", normalize=1,rewrite=1)
-  template_upload[0].commit()
+  for template in template_upload:
+    if template.filename.endswith("pdf"):
+      formfyxer.parse_form(template.path(), title=os.path.basename(template.path()), jur="MA", normalize=1,rewrite=1)
+      template.commit()
   process_field_normalization = True
 ---
 objects:
   - temp_new_pdf: DAFile.using(filename=os.path.basename(template_upload[0].path()))
 ---
 code: |
-  temp_new_pdf.initialize()
-  formfyxer.auto_add_fields(template_upload[0].path(), temp_new_pdf.path())
+  for template in template_upload:
+    if template.filename.endswith("pdf"):
+      temp_new_pdf.initialize()
+      formfyxer.auto_add_fields(template.path(), temp_new_pdf.path())
   
-  # also normalize field names after newly recognizing them
-  formfyxer.parse_form(temp_new_pdf.path(), title=template_upload[0].filename, jur="MA", normalize=1, rewrite=1)
+      # also normalize field names after newly recognizing them
+      formfyxer.parse_form(temp_new_pdf.path(), title=template.filename, jur="MA", normalize=1, rewrite=1)
   
-  temp_new_pdf.commit()
-  template_upload[0].copy_into(temp_new_pdf)
-  process_field_recognition = True  
+      temp_new_pdf.commit()
+      template.copy_into(temp_new_pdf)
+  process_field_recognition = True
 ---
 modules:
   - .field_grouping
@@ -387,20 +382,17 @@ code: |
     interview.getting_started = "Before you get started, you need to..."
 
     interview.typical_role = "unknown"
-    tmp_people_variables = get_person_variables(all_fields, custom_only=True)
-    people_variables = DADict("people_variables", auto_gather=False, gathered=True)
-    for person in tmp_people_variables:
-      people_variables[person] = True
 
-    process_people_variables
+    fields.gathered
+    fields.mark_people_as_builtins(fields.get_person_candidates())
+
     for person in person_candidates:
-      people_quantities[person] = "any"    
-    get_all_fields
+      people_quantities[person] = "any"
     
     for index, field in enumerate(fields.elements):
       field.field_type = field.field_type_guess if hasattr(field, 'field_type_guess') else 'text'
-      field.label = field.variable_name_guess                
-    # choose_field_types  
+      field.label = field.variable_name_guess
+    # choose_field_types
     # review_fields_after_labeling
     
     questions.auto_gather = False
@@ -424,7 +416,9 @@ code: |
   process_im_feeling_lucky = True
 ---
 code: |
-  if have_template_to_load: 
+  # Note: we just use the first document to create the placeholder name even if multiple forms are uploaded.
+  # That's fine as it is a placeholder
+  if have_template_to_load:
     if template_upload[0].filename.endswith('pdf'):
       short_filename = space_to_underscore(varname(template_upload[0].filename.lower()[:-len(".pdf")]))
     else:
@@ -506,13 +500,6 @@ fields:
   - Link to original form: interview.original_form
     hint: http://masslegalhelp.org/my_form
     required: False
-help:
-  label: |
-    View variable debug information
-  content: |
-    There are ${len(all_fields)} fields total.
-    
-    `${all_fields}`
 ---
 code: |
   interview.default_country_code = 'US'
@@ -674,12 +661,12 @@ fields:
       The list of names below look like names for people, based on
       how you use them in your document.
     show if:
-      code: |
-        len(get_person_variables(all_fields, custom_only=True)) > 0
+      code: |        
+        len(fields.get_person_candidates(custom_only=True)) > 0
   - Which variable names represent people?: people_variables
     datatype: checkboxes
     code: |
-      get_person_variables(all_fields, custom_only=True)
+      fields.get_person_candidates(custom_only=True)
     help: |
       "person" variables will get things like addresses, multi-part
       names, and proper questions handled automatically. Using them
@@ -771,17 +758,14 @@ code: |
   from zipfile import BadZipFile
   
   try:
-    if template_upload[0].extension == 'pdf':
-      all_fields = get_pdf_fields(template_upload)
-    else:
-      all_fields = get_fields(template_upload)
-      
-    if not all_fields:
+    fields.clear()
+    fields.add_fields_from_file(template_upload)
+    fields.gathered = True
+    if not len(fields) > 0:
       force_ask('empty_pdf')
-
     bad_fields = list(filter(
-        lambda elem: elem is not None, 
-        map(bad_name_reason, all_fields)))
+        lambda elem: elem is not None,
+        map(bad_name_reason, fields)))
     if len(bad_fields) > 0:
       force_ask('non_descriptive_field_name')
   except ParsingException as ex:
@@ -836,57 +820,9 @@ buttons:
 ---
 code: |
   if have_template_to_load: 
-    built_in_people_vars_used = get_person_variables(all_fields, custom_only=False) - get_person_variables(all_fields, custom_only=True)
+    built_in_people_vars_used = fields.get_person_candidates(custom_only=False) - fields.get_person_candidates(custom_only=True)
   else:
     built_in_people_vars_used = []
----
-comment: |
-  Convert the PDF fields into Docassemble fields
-code: |
-  # These all must be defined in advance to avoid duplicates
-  people_variables.true_values()
-  all_fields
-  fields
-  signature_fields
-  built_in_fields_used  
-  
-  yesno_map = defaultdict(list)
-  document_type = 'pdf' if template_upload[0].extension == 'pdf' else 'docx'
-
-  if document_type == 'pdf':
-    # Probably all of this should move into a class
-    for pdf_field_tuple in all_fields:
-      pdf_field_name = pdf_field_tuple[0]
-      # Check to see if we think this field is built-in (handled in
-      # basic-questions.yml), a signature, or an arbitrary field.
-      #is_reserved_name = 
-      if is_reserved_label(pdf_field_name) or pdf_field_name in people_variables.true_values():
-        new_field = built_in_fields_used.appendObject()
-      elif len(pdf_field_tuple) > 4 and pdf_field_tuple[4] == '/Sig':
-        new_field = signature_fields.appendObject()
-      else:
-        new_field = fields.appendObject()
-      
-      # This function determines what type of variable
-      # we're dealing with
-      new_field.fill_in_pdf_attributes(pdf_field_tuple)
-
-  else:
-    # if this is a docx, fields are a list of strings, not a list of tuples
-    for field in all_fields:
-      if is_reserved_docx_label(field) or field in people_variables.true_values():
-        new_field = built_in_fields_used.appendObject()
-      elif field.endswith('.signature'):
-        new_field = signature_fields.appendObject()
-      else:                
-        new_field = fields.appendObject()
-      new_field.fill_in_docx_attributes(field)
-
-  built_in_fields_used.consolidate_duplicate_fields(document_type)
-  signature_fields.consolidate_duplicate_fields(document_type)
-  fields.consolidate_duplicate_fields(document_type)
-  fields.consolidate_yesnos()
-  get_all_fields = True
 ---
 code: |
   # Build the list of includes
@@ -1059,23 +995,23 @@ fields:
   - code: field_question
   - note: |
       **Built-in questions this form triggers**[BR]
-      % if len(built_in_fields_used) > 1:
-      These fields are not listed above because a built-in question already handles them: ${ built_in_fields_used }.
+      % if len(fields.builtins()) > 1:
+      These fields are not listed above because a built-in question already handles them: ${ fields.builtins() }.
       % elif have_template_to_load: 
       This field is not listed above because a built-in question already handles
-      it: ${ built_in_fields_used }.
+      it: ${ fields.builtins() }.
       % endif
-      % if len(signature_fields):
+      % if len(fields.signatures()):
       
       These signature fields are not listed because they cannot be asked
-      on the same screen as any other variable: ${ signature_fields }
+      on the same screen as any other variable: ${ fields.signatures() }
       % endif      
       
       You will have a chance to change the order of these fields later in
       this interview.
     show if:
       code: |
-        len(built_in_fields_used) or len(signature_fields)
+        len(fields.builtins()) or len(fields.signatures())
 validation code: |
   for field in fields:
     if field.field_type == "code":
@@ -1125,7 +1061,7 @@ code: |
   fields.there_is_another = False
 ---
 table: fields.review_table
-rows: fields + built_in_fields_used
+rows: fields + fields.builtins()
 columns:
   - On-screen label: |
       row_item.label if hasattr(row_item, 'label') else '(n/a)'
@@ -1161,7 +1097,7 @@ code: |
 code: |
   # We keep adding questions until ALL of the fields have been
   # assigned.
-  questions.there_is_another = len(questions.all_fields_used(all_fields=fields)) < len(fields)
+  questions.there_is_another = len(questions.all_fields_used(all_fields=fields.custom())) < len(fields.custom())
 ---
 id: create a draft of screen i
 question: |
@@ -1185,7 +1121,7 @@ fields:
     datatype: object_checkboxes
     # We show all of the fields, but exclude the ones present
     # anywhere in the list of questions we already drafted
-    exclude: questions.all_fields_used(all_fields=fields)
+    exclude: questions.all_fields_used(all_fields=fields.custom())
     none of the above: False
     choices: fields      
     object labeler: labeller_bold_plus_label
@@ -1218,12 +1154,12 @@ code: |
   # Used for adding a new field
   fields[i].field_type_guess = fields[i].field_type
   fields[i].raw_field_names = [fields[i].variable]
-  
+  fields[i].source_document_type = "docx" # don't process the variable name
 ---
 code: |
   # Use screen_reordered to reflect the user adjusted table order  
   for question in screen_reordered:    
-    if question not in built_in_fields_used and question not in signature_fields:
+    if question not in fields.builtins() and question not in fields.signatures():
 		  question.type = "question"
 		  interview.blocks.append(question)
   add_question_screens = True
@@ -1317,14 +1253,14 @@ code: |
   # Note that some built-in fields are not unique screens. This could
   # mess up the count
   unique_fields = set()
-  for field in built_in_fields_used:
+  for field in fields.builtins():
     # Don't add the users[0].signature field to this list
     if field.final_display_var == "users[0].signature":
       continue
     if not field.final_display_var in unique_fields:
       unique_fields.add(field.final_display_var)
       screen_order.append(field)
-  for field in signature_fields:
+  for field in fields.signatures():
     screen_order.append(field)
   screen_order.gathered = True
   set_initial_screen_order = True
@@ -1501,7 +1437,7 @@ code: |
         logic_list.append(question.field_list[0].trigger_gather())
     else:
       # it's a built-in field OR a signature, not a question block
-      if not (question in built_in_fields_used and question.trigger_gather().endswith('.signature')):
+      if not (question in fields.builtins() and question.trigger_gather().endswith('.signature')):
         logic_list.append(question.trigger_gather())      
         # set the saved answer name so it includes the user's name in saved
         # answer list
@@ -1514,10 +1450,10 @@ code: |
     logic_list.append("saved_report_data")
     
   built_in_signatures = set()
-  for field in built_in_fields_used:
+  for field in fields.builtins():
     if field.trigger_gather().endswith('.signature'):
       built_in_signatures.add(field.trigger_gather())
-  # TODO for field in signature_fields:    
+  # TODO for field in fields.signatures():    
   
   # 2. Build interview-specific question order
   code_block =  interview.blocks.appendObject() # 'interview order code block'
@@ -1548,19 +1484,18 @@ code: |
   signature_fields_block = interview.blocks.appendObject()
   signature_fields_block.template_key = 'signature fields'
   signature_fields_block.data = {
-    "signature_fields": signature_fields,
+    "signature_fields": fields.signatures(),
     "built_in_signatures": built_in_signatures
   }
   add_signature_trigger = True
 ---
 need:
   - fields
-  - built_in_fields_used
   - interview_label
 code: |
   review_block = interview.blocks.appendObject()
   review_block.template_key = "review"  
-  field_list = fields + built_in_fields_used + signature_fields
+  field_list = fields
   parent_collections = field_list.find_parent_collections()
   review_block.data = {
     "field_list": field_list,
@@ -1869,7 +1804,7 @@ code: |
   file1.attachment_varname = attachment_variable_name    
   file1.type = template_upload[0].extension  
   file1.description = interview.title
-  file1.fields = built_in_fields_used + fields + signature_fields
+  file1.fields = fields
   file1.has_addendum = bool(len(addendum_fields))
 
   # TODO: it would be possible to merge the "bundles" list with the
@@ -2132,7 +2067,7 @@ code: |
 only sets: no_template_default_values
 code: |
   if not have_template_to_load:
-    all_fields = fields  
+    fields.gathered = True
   interview.original_form = 'NA'  
   interview.typical_role = 'anonymous'
   interview_label_draft = interview.short_title

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -1132,7 +1132,7 @@ code: |
   x.needs_continue_button_field = False
 ---
 code: |
-  questions.there_are_any = len(all_fields) > 0
+  questions.there_are_any = len(all_fields.custom()) > 0
 ---
 code: |
   # We keep adding questions until ALL of the fields have been

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -1027,15 +1027,15 @@ fields:
   - note: |
       **Built-in questions this form triggers**[BR]
       % if len(fields.builtins()) > 1:
-      These fields are not listed above because a built-in question already handles them: ${ fields.builtins() }.
-      % elif have_template_to_load: 
+      These fields are not listed above because a built-in question already handles them: ${ comma_and_list(fields.builtins()) }.
+      % elif have_template_to_load:
       This field is not listed above because a built-in question already handles
-      it: ${ fields.builtins() }.
+      it: ${ comma_and_list(fields.builtins()) }.
       % endif
       % if len(fields.signatures()):
       
       These signature fields are not listed because they cannot be asked
-      on the same screen as any other variable: ${ fields.signatures() }
+      on the same screen as any other variable: ${ comma_and_list(fields.signatures()) }
       % endif      
       
       You will have a chance to change the order of these fields later in
@@ -1154,7 +1154,7 @@ fields:
     # anywhere in the list of questions we already drafted
     exclude: questions.all_fields_used(all_fields=fields.custom())
     none of the above: False
-    choices: fields      
+    choices: fields.custom()
     object labeler: labeller_bold_plus_label
   - Override the default logic flow by adding a "continue button field": questions[i].has_mandatory_field
     datatype: noyes
@@ -1196,7 +1196,7 @@ code: |
   add_question_screens = True
 ---
 code: |
-  for field in fields:
+  for field in fields.custom():
     if field.field_type == "code":
       code_block = interview.blocks.appendObject()
       code_block.template_key = "code"
@@ -1843,7 +1843,7 @@ code: |
     for document in template_upload:
       temp_file = labels_lists.appendObject()    
       temp_file.input_filename = document.filename
-      temp_file.output_filename = document.filename
+      temp_file.output_filename = base_name(document.filename)
       temp_file.attachment_varname = space_to_underscore(base_name(document.filename))
       temp_file.type = document.extension
       temp_file.description = document.filename.replace("_", " ")

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -2213,7 +2213,7 @@ content: |
   % if template_upload[i].mimetype == "application/pdf":
   ${ template_upload[i].pdf_field_preview }
   % else:
-  ${ pdf_concatenate(template_upload) }
+  ${ pdf_concatenate(template_upload[i]) }
   % endif
 ---
 attachment:

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -100,7 +100,7 @@ code: |
     set_interview_type_vars 
     if have_template_to_load: 
       template_upload
-      if any(f for f in template_upload if f.filename.endswith('pdf') ):
+      if all(map(lambda y: True if y.filename.endswith(".pdf") else False, template_upload)):
         if yes_normalize_fields:
           process_field_normalization
         validate_pdf
@@ -109,10 +109,12 @@ code: |
         fields_checkup_status
         all_look_good
         validation_success
-      if any(f for f in template_upload if f.filename.endswith('docx')):
+      elif all(map(lambda y: True if y.filename.endswith(".docx") else False, template_upload)):
         if no_recognized_docx_fields:
           warn_no_recognized_al_labels
         validate_docx
+      else: # mixed PDF and DOCX templates
+        validate_mixed_documents
  
   if have_template_to_load:  
     fields.gathered
@@ -778,7 +780,12 @@ code: |
       if errors:
         force_ask('exit_invalid_docx')        
       # Check for syntax that indicates a user error
-      validate_docx 
+      jinja_errors = get_jinja_errors(document)
+      if jinja_errors:
+        jinja_exception
+      mako_matches = get_mako_matches(document)
+      if mako_matches:
+        mako_syntax_in_docx
     else:
       force_ask("exit_unknown_file_type")
 
@@ -2117,3 +2124,103 @@ code: |
     generate_download_screen = True
     
   set_interview_type_vars = 'Done'
+---
+id: confirm-mixed-document-fields
+continue button field: validate_mixed_documents
+question: |
+  Validate your templates
+subquestion: |
+  #### Your upload contains both DOCX and PDF files
+
+  #### Fields
+  
+  All of the fields in your template files are listed in the table below.
+  Confirm that the table looks right.
+  
+  A **bold** name means that this field is **reserved**.
+  Reserved fields are fields that will be handled with a question that
+  comes from the AL Question Library. For example:
+  
+  * Name fields
+  * Address fields
+  * Basic contact information and court information
+  
+  If you expect a field to be bold but it isn't, check the field's spelling.
+
+  The **type** of each field is just a guess, based on the field's name.
+  You can override the guess later.
+
+  Name (bold if {reserved}) | Type
+  --------------------------|------
+  % for field in validation_fields.builtins():
+  ${ bold(field.variable) } :question: | ${ field.field_type_guess } |
+  % endfor
+  % for field in validation_fields.custom():
+  ${ bold(field.variable) if field.reserved else field.variable } |  ${ field.field_type_guess } | 
+  % endfor
+  % for field in validation_fields.signatures():
+  ${ bold(field.variable) if field.reserved else field.variable } | signature  |
+  % endfor
+    
+  #### Preview  
+  Look over the PDF preview of your file below. Make sure that the
+  fonts, spacing, and styles look about right. Note: the conditional logic
+  and text your user enters can change the formatting. You will also
+  see the placeholder variable names unchanged in this preview.
+  
+  For safety, we recommend that you use the standard [Microsoft Core Fonts
+  for the Web](https://en.wikipedia.org/wiki/Core_fonts_for_the_Web), including
+  Arial and Times New Roman, as the standard fonts in Word templates.
+  
+  If spacing or other formatting looks wrong, try editing your file in
+  [LibreOffice](https://www.libreoffice.org/) and get it looking right
+  there.
+  
+  % for document in template_upload:  
+  ${ collapse_template(document.preview_template) }
+
+  % endfor
+
+fields:
+  - no label: mixed_fields_checkup_status
+    datatype: checkboxes
+    choices:
+      - All of my fields are listed in the table above: all_fields_present
+      - There are no unexpected fields in the table: no_unexpected_fields
+      - All the reserved fields are bolded as I expected: correct_reserved_fields    
+      - The fonts and styles in the preview look okay: fonts_okay
+        help: |
+          Note: use the Microsoft Core Fonts for the Web to be safe.
+    minlength: 4
+    validation messages:
+      minlength: |
+        You must select all of the checkboxes to keep going.
+    none of the above: False
+terms:
+  - reserved: |
+      Means there is a built-in question for this field.
+css: |
+  <style>
+  .question-confirm-docx-fields div.container {
+    max-width: 2000px;
+  }  
+  </style>
+---
+template: template_upload[i].preview_template
+subject: |
+  Preview ${ template_upload[i].filename }
+content: |
+  % if template_upload[i].mimetype == "application/pdf":
+  ${ template_upload[i].pdf_field_preview }
+  % else:
+  ${ pdf_concatenate(template_upload) }
+  % endif
+---
+attachment:
+  variable name: template_upload[i].pdf_field_preview
+  editable: False
+  pdf template file:
+    code: |
+      template_upload[i]
+  code: |
+    reflect_fields(template_upload[i].get_pdf_fields())

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -280,15 +280,24 @@ fields:
 ---
 id: file upload screen
 question: |
-  Upload your template file
+  Upload one or more template files
 subquestion: |
-  Learn more about [working with 
-  PDFs](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/pdfs),
-  including fixing broken PDFs.
+  You can upload PDF files, DOCX files, or a mix of the two.
 
-  Select a PDF or Word template: 
+  Before you upload it, your document should be prepared with labeled fields
+  that follow our [labelling
+  conventions](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/label_variables).
+
+  In some cases, we can automatically process a PDF file that hasn't been
+  labeled yet.
+
+  * [Working with 
+  PDFs](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/pdfs)
+  * [Working with DOCX files](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/docx)
+  
 fields:   
-  - no label: template_upload
+  - Select your PDF or DOCX files: template_upload
+    label above field: True
     datatype: files
     accept: |
       "application/pdf, application/vnd.openxmlformats-officedocument.wordprocessingml.document"
@@ -2201,7 +2210,7 @@ fields:
       - All of my fields are listed in the table above: all_fields_present
       - There are no unexpected fields in the table: no_unexpected_fields
       - All the reserved fields are bolded as I expected: correct_reserved_fields    
-      - The fonts and styles in the preview look okay: fonts_okay
+      - The fonts and styles in the preview look okay OR I am comfortable fixing them later: fonts_okay
         help: |
           Note: use the Microsoft Core Fonts for the Web to be safe.
     minlength: 4
@@ -2236,4 +2245,4 @@ attachment:
     code: |
       template_upload[i]
   code: |
-    reflect_fields(template_upload[i].get_pdf_fields())
+    reflect_fields(template_upload[i].get_pdf_fields(), placeholder_signature)

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -682,7 +682,7 @@ fields:
       The list of names below look like names for people, based on
       how you use them in your document.
     show if:
-      code: |        
+      code: |
         len(all_fields.get_person_candidates(custom_only=True)) > 0
   - Which variable names represent people?: people_variables
     datatype: checkboxes

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -382,11 +382,12 @@ code: |
 modules:
   - .field_grouping
 ---
-scan for variables: False
-sets: process_im_feeling_lucky
+only sets: 
+  - process_im_feeling_lucky
 code: |
   yes_normalize_fields = False
   yes_recognize_form_fields = False
+  interview_type = "regular"
   if has_safe_pdf_in_url: # limit when this block can run
     # Set interview defaults based on the PDF passed in the URL args
     interview.jurisdiction_choices = get_matching_deps("jurisdiction",interview.state)    
@@ -401,10 +402,13 @@ code: |
     interview.typical_role = "unknown"
 
     all_fields.gathered
+    person_candidates = all_fields.get_person_candidates()
     all_fields.mark_people_as_builtins(all_fields.get_person_candidates())
 
     for person in person_candidates:
       people_quantities[person] = "any"
+
+    process_people_variables = True      
     
     for index, field in enumerate(all_fields.elements):
       field.field_type = field.field_type_guess if hasattr(field, 'field_type_guess') else 'text'

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -49,7 +49,6 @@ imports:
 ---
 features:
   question help button: True
-  # labels above fields: True
   question back button: True
   css: 
     - styles.css  
@@ -76,7 +75,7 @@ include:
 ---
 objects:  
   - interview: DAInterview.using(template_path='data/sources/output_patterns.yml')
-  - fields: DAFieldList.using(auto_gather=False)
+  - all_fields: DAFieldList.using(auto_gather=False)
   - questions: DAQuestionList.using(complete_attribute='complete')
   - interview_download: DAFile
   - interview_package_download: DAFile
@@ -117,7 +116,7 @@ code: |
         validate_mixed_documents
  
   if have_template_to_load:  
-    fields.gathered
+    all_fields.gathered
   # Display Weaver question screens   
   interview.jurisdiction_choices 
   if generate_download_screen:      
@@ -227,7 +226,7 @@ code: |
   set_custom_people_map( people_variables.true_values() )  
 
   if len(people_variables.true_values()):
-    fields.mark_people_as_builtins(people_variables.true_values())
+    all_fields.mark_people_as_builtins(people_variables.true_values())
   process_people_variables = True
 ---
 continue button field: weaver_intro
@@ -349,26 +348,26 @@ imports:
   - os
 ---
 code: |
-  for template in template_upload:
-    if template.filename.endswith("pdf"):
-      formfyxer.parse_form(template.path(), title=os.path.basename(template.path()), jur="MA", normalize=1,rewrite=1)
-      template.commit()
+  for document in template_upload:
+    if document.filename.endswith("pdf"):
+      formfyxer.parse_form(document.path(), title=os.path.basename(document.path()), jur="MA", normalize=1,rewrite=1)
+      document.commit()
   process_field_normalization = True
 ---
 objects:
   - temp_new_pdf: DAFile.using(filename=os.path.basename(template_upload[0].path()))
 ---
 code: |
-  for template in template_upload:
-    if template.filename.endswith("pdf"):
+  for document in template_upload:
+    if document.filename.endswith("pdf"):
       temp_new_pdf.initialize()
-      formfyxer.auto_add_fields(template.path(), temp_new_pdf.path())
+      formfyxer.auto_add_fields(document.path(), temp_new_pdf.path())
   
       # also normalize field names after newly recognizing them
-      formfyxer.parse_form(temp_new_pdf.path(), title=template.filename, jur="MA", normalize=1, rewrite=1)
+      formfyxer.parse_form(temp_new_pdf.path(), title=document.filename, jur="MA", normalize=1, rewrite=1)
   
       temp_new_pdf.commit()
-      template.copy_into(temp_new_pdf)
+      document.copy_into(temp_new_pdf)
   process_field_recognition = True
 ---
 modules:
@@ -392,26 +391,26 @@ code: |
 
     interview.typical_role = "unknown"
 
-    fields.gathered
-    fields.mark_people_as_builtins(fields.get_person_candidates())
+    all_fields.gathered
+    all_fields.mark_people_as_builtins(all_fields.get_person_candidates())
 
     for person in person_candidates:
       people_quantities[person] = "any"
     
-    for index, field in enumerate(fields.elements):
+    for index, field in enumerate(all_fields.elements):
       field.field_type = field.field_type_guess if hasattr(field, 'field_type_guess') else 'text'
       field.label = field.variable_name_guess
     # choose_field_types
     # review_fields_after_labeling
     
     questions.auto_gather = False
-    field_grouping = cluster_screens( [field.variable for field in fields] )
+    field_grouping = cluster_screens( [field.variable for field in all_fields] )
     for group in field_grouping:
       new_screen = questions.appendObject()
       new_screen.is_informational_screen = new_screen.has_mandatory_field = False
       new_screen.question_text = next(iter(field_grouping[group]),'').capitalize().replace('_', ' ')
       new_screen.subquestion_text = ''
-      new_screen.field_list = [field for field in fields if field.variable in field_grouping[group]]          
+      new_screen.field_list = [field for field in all_fields if field.variable in field_grouping[group]]          
     
     questions.gathered = True
     interview.court_related = ask_people_quantity_question = choose_field_types = show_screen_order = review_fields_to_add_template = review_fields_after_labeling = True
@@ -671,11 +670,11 @@ fields:
       how you use them in your document.
     show if:
       code: |        
-        len(fields.get_person_candidates(custom_only=True)) > 0
+        len(all_fields.get_person_candidates(custom_only=True)) > 0
   - Which variable names represent people?: people_variables
     datatype: checkboxes
     code: |
-      fields.get_person_candidates(custom_only=True)
+      all_fields.get_person_candidates(custom_only=True)
     help: |
       "person" variables will get things like addresses, multi-part
       names, and proper questions handled automatically. Using them
@@ -789,14 +788,14 @@ code: |
     else:
       force_ask("exit_unknown_file_type")
 
-  fields.clear()
-  fields.add_fields_from_file(template_upload)
-  fields.gathered = True
+  all_fields.clear()
+  all_fields.add_fields_from_file(template_upload)
+  all_fields.gathered = True
 
-  if not len(fields) > 0:
+  if not len(all_fields) > 0:
     force_ask('empty_pdf')
   
-  bad_fields = get_variable_name_warnings(fields)
+  bad_fields = get_variable_name_warnings(all_fields)
   if len(bad_fields) > 0:
     force_ask('non_descriptive_field_name')
 ---
@@ -847,7 +846,7 @@ buttons:
 ---
 code: |
   if have_template_to_load: 
-    built_in_people_vars_used = fields.get_person_candidates(custom_only=False) - fields.get_person_candidates(custom_only=True)
+    built_in_people_vars_used = all_fields.get_person_candidates(custom_only=False) - all_fields.get_person_candidates(custom_only=True)
   else:
     built_in_people_vars_used = []
 ---
@@ -993,7 +992,7 @@ code: |
 
   field_question_tmp = [ 
     field.user_ask_about_field()
-    for field in fields.custom()
+    for field in all_fields.custom()
   ]
   field_question = [item for item in chain.from_iterable(field_question_tmp)]
 
@@ -1026,25 +1025,22 @@ fields:
   - code: field_question
   - note: |
       **Built-in questions this form triggers**[BR]
-      % if len(fields.builtins()) > 1:
-      These fields are not listed above because a built-in question already handles them: ${ comma_and_list(fields.builtins()) }.
-      % elif have_template_to_load:
-      This field is not listed above because a built-in question already handles
-      it: ${ comma_and_list(fields.builtins()) }.
+      % if len(all_fields.builtins()) > 0:
+      These fields are not listed above because a built-in question already handles them: `${ comma_and_list(all_fields.builtins()) }`.
       % endif
-      % if len(fields.signatures()):
+      % if len(all_fields.signatures()):
       
       These signature fields are not listed because they cannot be asked
-      on the same screen as any other variable: ${ comma_and_list(fields.signatures()) }
+      on the same screen as any other variable: `${ comma_and_list(all_fields.signatures()) }`
       % endif      
       
       You will have a chance to change the order of these fields later in
       this interview.
     show if:
       code: |
-        len(fields.builtins()) or len(fields.signatures())
+        len(all_fields.builtins()) or len(all_fields.signatures())
 validation code: |
-  for field in fields.custom():
+  for field in all_fields.custom():
     if field.field_type == "code":
         expression = f"{field.final_display_var} = {field.code}"
         if not is_valid_python(expression):
@@ -1079,20 +1075,20 @@ subquestion: |
   Click the button below if you want to add an extra field to your
   interview. This will not add it to your template file.
 
-  ${ fields.add_action() }
+  ${ all_fields.add_action() }
 continue button field: review_fields_after_labeling  
 ---
 template: review_fields_to_add_template
 subject: |
   Review fields
 content: |
-  ${ fields.review_table }
+  ${ all_fields.review_table }
 ---
 code: |
-  fields.there_is_another = False
+  all_fields.there_is_another = False
 ---
-table: fields.review_table
-rows: fields + fields.builtins()
+table: all_fields.review_table
+rows: all_fields + all_fields.builtins()
 columns:
   - On-screen label: |
       row_item.label if hasattr(row_item, 'label') else '(n/a)'
@@ -1123,12 +1119,12 @@ code: |
   x.needs_continue_button_field = False
 ---
 code: |
-  questions.there_are_any = len(fields) > 0
+  questions.there_are_any = len(all_fields) > 0
 ---
 code: |
   # We keep adding questions until ALL of the fields have been
   # assigned.
-  questions.there_is_another = len(questions.all_fields_used(all_fields=fields.custom())) < len(fields.custom())
+  questions.there_is_another = len(questions.all_fields_used(all_fields=all_fields.custom())) < len(all_fields.custom())
 ---
 id: create a draft of screen i
 question: |
@@ -1152,9 +1148,9 @@ fields:
     datatype: object_checkboxes
     # We show all of the fields, but exclude the ones present
     # anywhere in the list of questions we already drafted
-    exclude: questions.all_fields_used(all_fields=fields.custom())
+    exclude: questions.all_fields_used(all_fields=all_fields.custom())
     none of the above: False
-    choices: fields.custom()
+    choices: all_fields.custom()
     object labeler: labeller_bold_plus_label
   - Override the default logic flow by adding a "continue button field": questions[i].has_mandatory_field
     datatype: noyes
@@ -1179,24 +1175,24 @@ code: |
 ---
 code: |
   # This was handled differently in the original wizard Jonathan made. Backfilling this attribute
-  fields[i].has_label = True
+  all_fields[i].has_label = True
 ---
 code: |
   # Used for adding a new field
-  fields[i].field_type_guess = fields[i].field_type
-  fields[i].raw_field_names = [fields[i].variable]
-  fields[i].source_document_type = "docx" # don't process the variable name
+  all_fields[i].field_type_guess = all_fields[i].field_type
+  all_fields[i].raw_field_names = [all_fields[i].variable]
+  all_fields[i].source_document_type = "docx" # don't process the variable name
 ---
 code: |
   # Use screen_reordered to reflect the user adjusted table order  
   for question in screen_reordered:    
-    if question not in fields.builtins() and question not in fields.signatures():
+    if question not in all_fields.builtins() and question not in all_fields.signatures():
 		  question.type = "question"
 		  interview.blocks.append(question)
   add_question_screens = True
 ---
 code: |
-  for field in fields.custom():
+  for field in all_fields.custom():
     if field.field_type == "code":
       code_block = interview.blocks.appendObject()
       code_block.template_key = "code"
@@ -1284,14 +1280,14 @@ code: |
   # Note that some built-in fields are not unique screens. This could
   # mess up the count
   unique_fields = set()
-  for field in fields.builtins():
+  for field in all_fields.builtins():
     # Don't add the users[0].signature field to this list
     if field.final_display_var == "users[0].signature":
       continue
     if not field.final_display_var in unique_fields:
       unique_fields.add(field.final_display_var)
       screen_order.append(field)
-  for field in fields.signatures():
+  for field in all_fields.signatures():
     screen_order.append(field)
   screen_order.gathered = True
   set_initial_screen_order = True
@@ -1325,35 +1321,35 @@ code: |
   # editing lists created with object_checkboxes
   questions[i].field_list.there_is_another = False
 ---
-continue button field: fields[i].edit_field
+continue button field: all_fields[i].edit_field
 question: |
-  % if hasattr(fields[i], 'final_display_var'):
-  Edit field ${ bold(fields[i].final_display_var) }
+  % if hasattr(all_fields[i], 'final_display_var'):
+  Edit field ${ bold(all_fields[i].final_display_var) }
   % else:
   Add new field
   % endif
 subquestion: |
-  % if not hasattr(fields[i], 'final_display_var'):
+  % if not hasattr(all_fields[i], 'final_display_var'):
   You can use this screen to add a draft of a new field that will
   be asked about in your interview.
   % endif
 
-  % if not hasattr(fields[i], 'final_display_var') and have_template_to_load:
+  % if not hasattr(all_fields[i], 'final_display_var') and have_template_to_load:
   When you add a new field, it will not automatically be included
   in your template. You can use this feature to add fields that are used to
   calculate a value, for example.
   % endif
 fields:
-  - Docassemble variable name: fields[i].final_display_var
+  - Docassemble variable name: all_fields[i].final_display_var
     hint: lower_case_format 
     show if:
       code: |
-        not hasattr(fields[i], 'label')
+        not hasattr(all_fields[i], 'label')
     validate: |
       lambda y: y.isidentifier() or validation_error("Use a valid Python variable name, without spaces and starting with a letter.")          
-  - On-screen field label: fields[i].label
+  - On-screen field label: all_fields[i].label
     hint: Label to go with the input variable 
-  - Field type: fields[i].field_type
+  - Field type: all_fields[i].field_type
     choices:
       - text
       - area
@@ -1365,15 +1361,15 @@ fields:
       - email
       - multiple choice radio
       - multiple choice checkboxes
-  - Options (one per line): fields[i].choices
+  - Options (one per line): all_fields[i].choices
     datatype: area
     js show if: |
-      val('fields[i].field_type') === 'multiple choice radio' || val('fields[i].field_type') === 'multiple choice checkboxes'
+      val('all_fields[i].field_type') === 'multiple choice radio' || val('all_fields[i].field_type') === 'multiple choice checkboxes'
     hint: |
       Like 'Descriptive name: key_name', or just 'Descriptive name'
 validation code: |
-  if not hasattr(fields[i], 'variable'):
-    fields[i].variable = fields[i].final_display_var
+  if not hasattr(all_fields[i], 'variable'):
+    all_fields[i].variable = all_fields[i].final_display_var
 continue button label: Save
 back button label: Cancel
 ---
@@ -1468,7 +1464,7 @@ code: |
         logic_list.append(question.field_list[0].trigger_gather())
     else:
       # it's a built-in field OR a signature, not a question block
-      if not (question in fields.builtins() and question.trigger_gather().endswith('.signature')):
+      if not (question in all_fields.builtins() and question.trigger_gather().endswith('.signature')):
         logic_list.append(question.trigger_gather())      
         # set the saved answer name so it includes the user's name in saved
         # answer list
@@ -1481,10 +1477,10 @@ code: |
     logic_list.append("saved_report_data")
     
   built_in_signatures = set()
-  for field in fields.builtins():
+  for field in all_fields.builtins():
     if field.trigger_gather().endswith('.signature'):
       built_in_signatures.add(field.trigger_gather())
-  # TODO for field in fields.signatures():    
+  # TODO for field in all_fields.signatures():    
   
   # 2. Build interview-specific question order
   code_block =  interview.blocks.appendObject() # 'interview order code block'
@@ -1515,18 +1511,18 @@ code: |
   signature_fields_block = interview.blocks.appendObject()
   signature_fields_block.template_key = 'signature fields'
   signature_fields_block.data = {
-    "signature_fields": fields.signatures(),
+    "signature_fields": all_fields.signatures(),
     "built_in_signatures": built_in_signatures
   }
   add_signature_trigger = True
 ---
 need:
-  - fields
+  - all_fields
   - interview_label
 code: |
   review_block = interview.blocks.appendObject()
   review_block.template_key = "review"  
-  field_list = fields
+  field_list = all_fields
   parent_collections = field_list.find_parent_collections()
   review_block.data = {
     "field_list": field_list,
@@ -1837,7 +1833,7 @@ code: |
     file1.attachment_varname = attachment_variable_name    
     file1.type = "pdf" if template_upload[0].mimetype == "application/pdf" else "docx"
     file1.description = interview.title
-    file1.fields = fields
+    file1.fields = all_fields
     file1.has_addendum = bool(len(addendum_fields))
   else:
     for document in template_upload:
@@ -1846,8 +1842,8 @@ code: |
       temp_file.output_filename = base_name(document.filename)
       temp_file.attachment_varname = space_to_underscore(base_name(document.filename))
       temp_file.type = "pdf" if document.mimetype == "application/pdf" else "docx"
-      temp_file.description = document.filename.replace("_", " ")
-      temp_file.fields = fields.matching_pdf_fields_from_file(document)
+      temp_file.description = base_name(document.filename).capitalize().replace("_", " ")
+      temp_file.fields = all_fields.matching_pdf_fields_from_file(document)
       temp_file.has_addendum = bool(len(addendum_fields))
 
   # TODO: it would be possible to merge the "bundles" list with the
@@ -1900,7 +1896,7 @@ code: |
   add_attachment = True
 ---
 code: |
-  addendum_fields = [field for field in fields if hasattr(field, 'send_to_addendum') and field.send_to_addendum]
+  addendum_fields = [field for field in all_fields if hasattr(field, 'send_to_addendum') and field.send_to_addendum]
 ---
 code: |
   addendum_block = interview.blocks.appendObject()
@@ -2111,7 +2107,7 @@ code: |
 only sets: no_template_default_values
 code: |
   if not have_template_to_load:
-    fields.gathered = True
+    all_fields.gathered = True
   interview.original_form = 'NA'  
   interview.typical_role = 'anonymous'
   interview_label_draft = interview.short_title
@@ -2124,7 +2120,7 @@ code: |
   interview_save_data_block = interview.blocks.appendObject()
   interview_save_data_block.template_key = 'save data'
   interview_save_data_block.data = {
-    "fields": fields, 
+    "fields": all_fields, 
     "interview_label": interview_label
   }
   add_save_data_block = True

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -1847,7 +1847,7 @@ code: |
       temp_file.attachment_varname = space_to_underscore(base_name(document.filename))
       temp_file.type = document.extension
       temp_file.description = document.filename.replace("_", " ")
-      temp_file.fields = fields
+      temp_file.fields = fields.matching_pdf_fields_from_file(document)
       temp_file.has_addendum = bool(len(addendum_fields))
 
   # TODO: it would be possible to merge the "bundles" list with the

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -2224,7 +2224,7 @@ subject: |
   Preview ${ template_upload[i].filename }
 content: |
   % if template_upload[i].mimetype == "application/pdf":
-  ${ template_upload[i].pdf_field_preview }
+  ${ pdf_concatenate(overlay_pdf(template_upload[i].pdf_field_preview, quality_check_overlay.path()), filename="do_not_use.pdf") }  
   % else:
   ${ pdf_concatenate(template_upload[i]) }
   % endif

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -1535,10 +1535,9 @@ need:
 code: |
   review_block = interview.blocks.appendObject()
   review_block.template_key = "review"  
-  field_list = all_fields
-  parent_collections = field_list.find_parent_collections()
+  parent_collections = all_fields.find_parent_collections()
   review_block.data = {
-    "field_list": field_list,
+    "field_list": all_fields,
     "parent_collections": parent_collections,
     "block_id": interview_label + ' review screen',
     "event": "review_" + interview_label

--- a/docassemble/ALWeaver/data/questions/docx_field_tester.yml
+++ b/docassemble/ALWeaver/data/questions/docx_field_tester.yml
@@ -165,13 +165,11 @@ objects:
 need:
   - docx_validation_fields
 code: |
-  docx_validation_fields.clear()
   people_list = fields.get_person_candidates(custom_only=True)
+  docx_validation_fields = fields.copy_deep("docx_validation_fields")
 
-  for field in fields:
-    new_field = docx_validation_fields.appendObject()
-    new_field.fill_in_docx_attributes(field.variable)
-    new_field.reserved = is_reserved_docx_label(field.variable) or field.variable in people_list
+  for field in docx_validation_fields:
+    field.reserved = is_reserved_docx_label(field.variable) or field.variable in people_list
     
   docx_validation_fields.mark_people_as_builtins(people_list)
 

--- a/docassemble/ALWeaver/data/questions/docx_field_tester.yml
+++ b/docassemble/ALWeaver/data/questions/docx_field_tester.yml
@@ -148,8 +148,8 @@ only sets:
   - validation_fields
   - validation_people_list
 code: |
-  validation_people_list = fields.get_person_candidates(custom_only=True)
-  validation_fields = fields.copy_deep("validation_fields")
+  validation_people_list = all_fields.get_person_candidates(custom_only=True)
+  validation_fields = all_fields.copy_deep("validation_fields")
 
   for field in validation_fields:
     if field.source_document_type == "docx":

--- a/docassemble/ALWeaver/data/questions/docx_field_tester.yml
+++ b/docassemble/ALWeaver/data/questions/docx_field_tester.yml
@@ -125,7 +125,7 @@ fields:
       - All of my fields are listed in the table above: all_fields_present
       - There are no unexpected fields in the table: no_unexpected_fields
       - All the reserved fields are bolded as I expected: correct_reserved_fields    
-      - The fonts and styles in the preview look okay: fonts_okay
+      - The fonts and styles in the preview look okay OR I am comfortable fixing them later: fonts_okay
         help: |
           Note: use the Microsoft Core Fonts for the Web to be safe.
     minlength: 4

--- a/docassemble/ALWeaver/data/questions/docx_field_tester.yml
+++ b/docassemble/ALWeaver/data/questions/docx_field_tester.yml
@@ -96,11 +96,14 @@ subquestion: |
 
   Name (bold if {reserved}) | Type
   --------------------------|------
-  % for field in docx_validation_fields:
-  ${ bold(field.variable) if field.reserved else field.variable} |  ${ field.field_type_guess }| 
+  % for field in docx_validation_fields.builtins():
+  ${ bold(field.variable) } :question: | ${ field.field_type_guess } |
   % endfor
-  % for field in docx_custom_people:
-  ${ bold(field.variable) } :question: | ${ field.field_type_guess }
+  % for field in docx_validation_fields.custom():
+  ${ bold(field.variable) if field.reserved else field.variable } |  ${ field.field_type_guess } | 
+  % endfor
+  % for field in docx_validation_fields.signatures():
+  ${ bold(field.variable) if field.reserved else field.variable } | signature  |
   % endfor
   
   % if len(docx_custom_people) > 0:
@@ -163,12 +166,13 @@ need:
   - docx_validation_fields
 code: |
   docx_validation_fields.clear()
-  for field in all_fields:
+  people_list = fields.get_person_candidates(custom_only=True)
+
+  for field in fields:
     new_field = docx_validation_fields.appendObject()
-    new_field.fill_in_docx_attributes(field)
-    new_field.reserved = is_reserved_docx_label(field) or field in possible_base
+    new_field.fill_in_docx_attributes(field.variable)
+    new_field.reserved = is_reserved_docx_label(field.variable) or field.variable in people_list
     
-  possible_base = list(get_person_variables(all_fields, custom_only=True))
-  process_custom_people(possible_base, docx_validation_fields, docx_custom_people)  
+  docx_validation_fields.mark_people_as_builtins(people_list)
 
   update_docx_validation_fields = True  

--- a/docassemble/ALWeaver/data/questions/docx_field_tester.yml
+++ b/docassemble/ALWeaver/data/questions/docx_field_tester.yml
@@ -9,23 +9,11 @@ fields:
     datatype: file
 ---
 code: |
-  jinja_errors = get_jinja_errors(template_upload)
-  if jinja_errors:
-    jinja_exception
-  if contains_mako:
-    mako_syntax_in_docx  
-  verify_docx_fields
-  
+  verify_docx_fields 
   validate_docx = True
 ---
 code: |
-  mako_matches = get_mako_matches(template_upload[0])
-  contains_mako = len(mako_matches)
----
-need: 
-  - update_docx_validation_fields
-code: |
-  no_recognized_docx_fields = not (any(field for field in docx_validation_fields if field.reserved) or len(docx_custom_people))
+  no_recognized_docx_fields = not (any(field for field in validation_fields if field.reserved) or len(validation_people_list))
 ---
 id: Did you intend to use Mako syntax
 question: |
@@ -70,8 +58,6 @@ subquestion: |
   and for [Jinja2](https://jinja.palletsprojects.com/en/3.0.x/) to learn more.
 ---
 id: confirm-docx-fields
-need: 
-  - update_docx_validation_fields
 continue button field: verify_docx_fields
 question: |
   Validate your template
@@ -96,17 +82,17 @@ subquestion: |
 
   Name (bold if {reserved}) | Type
   --------------------------|------
-  % for field in docx_validation_fields.builtins():
+  % for field in validation_fields.builtins():
   ${ bold(field.variable) } :question: | ${ field.field_type_guess } |
   % endfor
-  % for field in docx_validation_fields.custom():
+  % for field in validation_fields.custom():
   ${ bold(field.variable) if field.reserved else field.variable } |  ${ field.field_type_guess } | 
   % endfor
-  % for field in docx_validation_fields.signatures():
+  % for field in validation_fields.signatures():
   ${ bold(field.variable) if field.reserved else field.variable } | signature  |
   % endfor
   
-  % if len(docx_custom_people) > 0:
+  % if len(validation_people_list) > 0:
   :question: Indicates that we think this field could be handled by 
   questions in our question library, so you don't have to write your own 
   questions for it! You can choose whether to use our default questions later.
@@ -141,7 +127,7 @@ fields:
     validation messages:
       minlength: |
         You must select all of the checkboxes to keep going.
-    none of the above: False    
+    none of the above: False
 terms:
   - reserved: |
       Means there is a built-in question for this field.
@@ -158,19 +144,17 @@ subject: |
 content: |
   ${ pdf_concatenate(template_upload) }
 ---
-objects:
-  - docx_validation_fields: DAFieldList.using(gathered=True)
-  - docx_custom_people: DAFieldList.using(gathered=True)
----
-need:
-  - docx_validation_fields
+only sets:
+  - validation_fields
+  - validation_people_list
 code: |
-  people_list = fields.get_person_candidates(custom_only=True)
-  docx_validation_fields = fields.copy_deep("docx_validation_fields")
+  validation_people_list = fields.get_person_candidates(custom_only=True)
+  validation_fields = fields.copy_deep("validation_fields")
 
-  for field in docx_validation_fields:
-    field.reserved = is_reserved_docx_label(field.variable) or field.variable in people_list
+  for field in validation_fields:
+    if field.source_document_type == "docx":
+      field.reserved = is_reserved_docx_label(field.variable) or field.variable in people_list
+    elif field.source_document_type == "pdf":
+      field.reserved = is_reserved_label(field.variable)
     
-  docx_validation_fields.mark_people_as_builtins(people_list)
-
-  update_docx_validation_fields = True  
+  validation_fields.mark_people_as_builtins(people_list)

--- a/docassemble/ALWeaver/data/questions/docx_field_tester.yml
+++ b/docassemble/ALWeaver/data/questions/docx_field_tester.yml
@@ -64,8 +64,8 @@ question: |
 subquestion: |
   #### Fields
   
-  All of the fields in your DOCX file are listed in the table below.
-  Confirm that the table looks right.
+  All of the fields in your DOCX ${ template_upload.as_noun("file") } are listed
+  in the table below. Confirm that the table looks right.
   
   A **bold** name means that this field is **reserved**.
   Reserved fields are fields that will be handled with a question that
@@ -99,20 +99,25 @@ subquestion: |
   % endif
   
   #### Preview  
-  Look over the PDF preview of your file below. Make sure that the
-  fonts, spacing, and styles look about right. Note: the conditional logic
-  and text your user enters can change the formatting. You will also
-  see the placeholder variable names unchanged in this preview.
+  Look over the PDF preview of your file below. Make sure that the fonts,
+  spacing, and styles look about right. Note: the conditional logic and text
+  your user enters can change the formatting by moving text to a new line. You
+  will also see the placeholder variable names unchanged in this preview.
   
-  For safety, we recommend that you use the standard [Microsoft Core Fonts
-  for the Web](https://en.wikipedia.org/wiki/Core_fonts_for_the_Web), including
-  Arial and Times New Roman, as the standard fonts in Word templates.
+  In DOCX templates, for safety, we recommend that you use the standard
+  [Microsoft Core Fonts for the
+  Web](https://en.wikipedia.org/wiki/Core_fonts_for_the_Web), including Arial
+  and Times New Roman, as the standard fonts. It is possible to install additional
+  fonts but it may be complex.
   
-  If spacing or other formatting looks wrong, try editing your file in
-  [LibreOffice](https://www.libreoffice.org/) and get it looking right
-  there.
+  If spacing or other formatting looks wrong, try editing your DOCX files in
+  [LibreOffice](https://www.libreoffice.org/) and get it looking right there.
   
-  ${ collapse_template(preview_docx_file) }
+  % for document in template_upload:  
+  ${ collapse_template(document.preview_template) }
+
+  % endfor
+
 fields:
   - no label: docx_fields_checkup_status
     datatype: checkboxes

--- a/docassemble/ALWeaver/data/questions/generator-test.yml
+++ b/docassemble/ALWeaver/data/questions/generator-test.yml
@@ -1,3 +1,4 @@
+
 # Get output from tests.
 modules:
   - .test_map_names

--- a/docassemble/ALWeaver/data/questions/pdf_field_tester.yml
+++ b/docassemble/ALWeaver/data/questions/pdf_field_tester.yml
@@ -96,7 +96,7 @@ subquestion: |
   Name (bold if {reserved}) | Type | {Internal DA name} | Max length
   -----------|------------|-------------------|-----------
   % for field in fields:
-  ${":exclamation-triangle: " if ' ' in field.variables else ''} ${":exclamation-circle: " if len(remove_multiple_appearance_indicator(varname(field.variable))) == 0 else ''} ${'**' + str(field.variable) + '**' if is_reserved_label(field.variable) or field.variable in possible_custom else field.variable} ${ ':question:' if field.variable in possible_custom else ''} | ${ field.field_type_guess } | ${map_raw_to_final_display(field.variable) if not (map_raw_to_final_display(field.variable) == field.variable) else ''} | ${ field.maxlength if hasattr(field, "maxlength") else 'n/a' }
+  ${":exclamation-triangle: " if ' ' in field.variable else ''} ${":exclamation-circle: " if len(remove_multiple_appearance_indicator(varname(field.variable))) == 0 else ''} ${'**' + str(field.variable) + '**' if is_reserved_label(field.variable) or field.variable in possible_custom else field.variable} ${ ':question:' if field.variable in possible_custom else ''} | ${ field.field_type_guess } | ${map_raw_to_final_display(field.variable) if not (map_raw_to_final_display(field.variable) == field.variable) else ''} | ${ field.maxlength if hasattr(field, "maxlength") else 'n/a' }
   % endfor
   
   % if 'space' in warnings:

--- a/docassemble/ALWeaver/data/questions/pdf_field_tester.yml
+++ b/docassemble/ALWeaver/data/questions/pdf_field_tester.yml
@@ -10,11 +10,11 @@ images:
   green_light: green_light.png
 ---
 code: |
-  fields.gathered
-  people_list = fields.get_person_candidates(custom_only=True)
+  all_fields.gathered
+  people_list = all_fields.get_person_candidates(custom_only=True)
   possible_custom = [
     field.variable 
-    for field in fields
+    for field in all_fields
     if is_reserved_label(field.variable, reserved_prefixes=people_list)
   ]
 ---
@@ -22,8 +22,8 @@ event: empty_pdf
 question: You uploaded an empty PDF
 subquestion: |
   The PDF you uploaded (${ template_upload[0].filename }) does not have any 
-  fillable fields. To make a new interview with the Weaver, we need to have a 
-  document that has fillable fields.
+  fillable all_fields. To make a new interview with the Weaver, we need to have a 
+  document that has fillable all_fields.
   
   If you saved a DOCX file as a PDF, you will need to add fillable fields in a 
   tool like [Adobe Acrobat](https://acrobat.adobe.com). 
@@ -64,7 +64,7 @@ buttons:
 ---
 code: |
   warnings_temp = set()
-  for field in fields:
+  for field in all_fields:
     if ' ' in field.variable:
       warnings_temp.add('space')
     if hasattr(field, "field_type_not_handled") and field.field_type_not_handled:
@@ -73,7 +73,7 @@ code: |
   del warnings_temp
 ---
 code: |
-  no_recognized_pdf_fields = not (any(field for field in fields if is_reserved_label(field.variable)) or len(possible_custom) > 0)
+  no_recognized_pdf_fields = not (any(field for field in all_fields if is_reserved_label(field.variable)) or len(possible_custom) > 0)
 ---
 id: confirm-pdf-fields
 question: |
@@ -94,7 +94,7 @@ subquestion: |
 
   Name (bold if {reserved}) | Type | {Internal DA name} | Max length
   -----------|------------|-------------------|-----------
-  % for field in fields:
+  % for field in all_fields:
   ${":exclamation-triangle: " if ' ' in field.variable else ''} ${":exclamation-circle: " if len(remove_multiple_appearance_indicator(varname(field.variable))) == 0 else ''} ${'**' + str(field.variable) + '**' if is_reserved_label(field.variable) or field.variable in possible_custom else field.variable} ${ ':question:' if field.variable in possible_custom else ''} | ${ field.field_type_guess } | ${map_raw_to_final_display(field.variable) if not (map_raw_to_final_display(field.variable) == field.variable) else ''} | ${ field.maxlength if hasattr(field, "maxlength") else 'n/a' }
   % endfor
   
@@ -152,7 +152,7 @@ validation code: |
 help:
   label: Debug Info
   content: |
-    % for field in fields:
+    % for field in all_fields:
     * ${field}
     % endfor
 terms:
@@ -176,10 +176,10 @@ right: |
   _Limitations_: we do not have a way to show you the labels for
   checkbox fields yet.
   
-  ${ action_button_html(url_ask(["display_rename_field_choices", "renamed_fields", {"recompute": ["fields", "field_preview_pdf"]} ]), label="Rename fields") }
+  ${ action_button_html(url_ask(["display_rename_field_choices", "renamed_fields", {"recompute": ["all_fields", "field_preview_pdf"]} ]), label="Rename fields") }
 ---
 code: |
-  pdf_fields = [{field.variable: map_raw_to_final_display(field.variable)} for field in fields]
+  pdf_fields = [{field.variable: map_raw_to_final_display(field.variable)} for field in all_fields]
 ---
 objects:
   - quality_check_overlay: DAStaticFile.using(filename='quality_check_overlay.pdf')
@@ -213,7 +213,7 @@ validation code: |
   if not all_look_good['no_unusual_size_text']:
     text_mst = "<ul><li>You didn't confirm 'No unusually sized text'. Check the font sizes of those fields, and if the field is set to allow multiple lines.</li></ul>"
   if not all_look_good['signature_filled_in']:
-    signature_msg = "<ul><li>You didn't confirm 'All signature fields are filled in with the signature image.' Ensure that these are <a href=\"https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/pdfs#add-labels-and-fields\">properly set</a> to be signature fields.</li></ul>"  
+    signature_msg = "<ul><li>You didn't confirm 'All signature fields are filled in with the signature image.' Ensure that these are <a href=\"https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/pdfs#add-labels-and-fields\">properly set</a> to be signature all_fields.</li></ul>"  
   msg = checkboxes_msg + text_mst + signature_msg
   if len(msg) > 0:
     validation_error(msg, field="all_look_good['all_checkboxes_checked']")   

--- a/docassemble/ALWeaver/data/questions/pdf_field_tester.yml
+++ b/docassemble/ALWeaver/data/questions/pdf_field_tester.yml
@@ -10,12 +10,11 @@ images:
   green_light: green_light.png
 ---
 code: |
+  fields.gathered
   try:
-    checkbox_fields = [field[0] for field in all_fields if len(field) > 4 and field[4] == '/Btn']
-    signature_fields_test = [field[0] for field in all_fields if len(field) >4 and field[4] == '/Sig']
-    possible_base = get_person_variables(all_fields, custom_only=True)
-    possible_custom = [field[0] for field in all_fields
-        if any([field[0].startswith(base) for base in possible_base])]
+    people_list = fields.get_person_candidates(custom_only=True)
+    possible_custom = [field.variable for field in fields
+        if is_reserved_label(field.variable, reserved_prefixes=people_list)]
   except ParsingException as ex:
     parsing_ex = ex
     force_ask('parsing_exception')
@@ -66,8 +65,8 @@ buttons:
 ---
 code: |
   warnings_temp = set()
-  for field in all_fields:
-    if ' ' in field[0]:
+  for field in fields:
+    if ' ' in field.variable:
       warnings_temp.add('space')
     if field[4] not in ['/Sig','/Btn','/Tx']:
       warnings_temp.add('not handled')
@@ -75,7 +74,7 @@ code: |
   del warnings_temp
 ---
 code: |
-  no_recognized_pdf_fields = not (any(field for field in all_fields if is_reserved_label(field[0])) or len(possible_custom) > 0)
+  no_recognized_pdf_fields = not (any(field for field in fields if is_reserved_label(field.variable)) or len(possible_custom) > 0)
 ---
 id: confirm-pdf-fields
 question: |
@@ -96,25 +95,9 @@ subquestion: |
 
   Name (bold if {reserved}) | Type | {Internal DA name} | Max length
   -----------|------------|-------------------|-----------
-  % for field in all_fields:
-  ${":exclamation-triangle: " if ' ' in field[0] else ''} ${":exclamation-circle: " if len(remove_multiple_appearance_indicator(varname(field[0]))) == 0 else ''} ${'**' + str(field[0]) + '**' if is_reserved_label(field[0]) or field[0] in possible_custom else field[0]} ${ ':question:' if field[0] in possible_custom else ''} | ${ pdf_field_type_str(field) } (${field[4]}) | ${map_raw_to_final_display(field[0]) if not (map_raw_to_final_display(field[0]) == field[0]) else ''} | ${ get_character_limit(field) if get_character_limit(field) else 'n/a' }
+  % for field in fields:
+  ${":exclamation-triangle: " if ' ' in field.variables else ''} ${":exclamation-circle: " if len(remove_multiple_appearance_indicator(varname(field.variable))) == 0 else ''} ${'**' + str(field.variable) + '**' if is_reserved_label(field.variable) or field.variable in possible_custom else field.variable} ${ ':question:' if field.variable in possible_custom else ''} | ${ field.field_type_guess } | ${map_raw_to_final_display(field.variable) if not (map_raw_to_final_display(field.variable) == field.variable) else ''} | ${ field.maxlength if hasattr(field, "maxlength") else 'n/a' }
   % endfor
-
-  % if len(signature_fields_test) > 0:
-  The following are signature fields: 
-  
-  % for sig in signature_fields_test:
-  * ${ sig }
-  % endfor
-  % endif  
-
-  % if len(checkbox_fields) > 0:
-  The following are checkbox fields: 
-  
-  % for chk in checkbox_fields:
-  * ${ chk }
-  % endfor
-  % endif
   
   % if 'space' in warnings:
   :exclamation-triangle: Indicates that the field name has a space in it.
@@ -170,7 +153,7 @@ validation code: |
 help:
   label: Debug Info
   content: |
-    % for field in all_fields:
+    % for field in fields:
     * ${field}
     % endfor
 terms:
@@ -194,13 +177,10 @@ right: |
   _Limitations_: we do not have a way to show you the labels for
   checkbox fields yet.
   
-  ${ action_button_html(url_ask(["display_rename_field_choices", "renamed_fields", {"recompute": ["all_fields", "field_preview_pdf"]} ]), label="Rename fields") }
+  ${ action_button_html(url_ask(["display_rename_field_choices", "renamed_fields", {"recompute": ["fields", "field_preview_pdf"]} ]), label="Rename fields") }
 ---
 code: |
-  signatures = [{field: placeholder_signature} for field in signature_fields_test]
-  checkboxes = [{field: 'Yes'} for field in checkbox_fields]
-  other_fields = [{field[0]: map_raw_to_final_display(field[0])} for field in all_fields if not field[0] in signatures and not field[0] in checkbox_fields]
-  pdf_fields = other_fields + checkboxes + signatures
+  pdf_fields = [{field.variable: map_raw_to_final_display(field.variable)} for field in fields]
 ---
 objects:
   - quality_check_overlay: DAStaticFile.using(filename='quality_check_overlay.pdf')

--- a/docassemble/ALWeaver/data/questions/pdf_field_tester.yml
+++ b/docassemble/ALWeaver/data/questions/pdf_field_tester.yml
@@ -68,7 +68,7 @@ code: |
   for field in fields:
     if ' ' in field.variable:
       warnings_temp.add('space')
-    if field[4] not in ['/Sig','/Btn','/Tx']:
+    if hasattr(field, "field_type_not_handled") and field.field_type_not_handled:
       warnings_temp.add('not handled')
   warnings = warnings_temp
   del warnings_temp

--- a/docassemble/ALWeaver/data/questions/pdf_field_tester.yml
+++ b/docassemble/ALWeaver/data/questions/pdf_field_tester.yml
@@ -178,9 +178,6 @@ right: |
   
   ${ action_button_html(url_ask(["display_rename_field_choices", "renamed_fields", {"recompute": ["all_fields", "field_preview_pdf"]} ]), label="Rename fields") }
 ---
-code: |
-  pdf_fields = [{field.variable: map_raw_to_final_display(field.variable)} for field in all_fields]
----
 objects:
   - quality_check_overlay: DAStaticFile.using(filename='quality_check_overlay.pdf')
 ---
@@ -192,7 +189,10 @@ subquestion: |
   
   All signature fields should be filled in with this image: ${placeholder_signature}
 
-  ${ pdf_concatenate(overlay_pdf(my_pdf, quality_check_overlay.path()), filename="do_not_use.pdf") }  
+  % for document in template_upload:  
+  ${ collapse_template(document.preview_template) }
+
+  % endfor
   
 fields:
   - note: |
@@ -255,14 +255,6 @@ code: |
   rename_pdf_fields(template_upload[0].path(), rename_fields)
   
   renamed_fields = True
----
-attachment:
-  variable name: my_pdf
-  pdf template file:
-    code: |
-      template_upload
-  code: |
-    pdf_fields
 ---
 attachment:
   variable name: field_preview_pdf

--- a/docassemble/ALWeaver/data/questions/pdf_field_tester.yml
+++ b/docassemble/ALWeaver/data/questions/pdf_field_tester.yml
@@ -11,13 +11,12 @@ images:
 ---
 code: |
   fields.gathered
-  try:
-    people_list = fields.get_person_candidates(custom_only=True)
-    possible_custom = [field.variable for field in fields
-        if is_reserved_label(field.variable, reserved_prefixes=people_list)]
-  except ParsingException as ex:
-    parsing_ex = ex
-    force_ask('parsing_exception')
+  people_list = fields.get_person_candidates(custom_only=True)
+  possible_custom = [
+    field.variable 
+    for field in fields
+    if is_reserved_label(field.variable, reserved_prefixes=people_list)
+  ]
 ---
 event: empty_pdf
 question: You uploaded an empty PDF

--- a/docassemble/ALWeaver/data/questions/pdf_field_tester.yml
+++ b/docassemble/ALWeaver/data/questions/pdf_field_tester.yml
@@ -201,8 +201,11 @@ fields:
     datatype: checkboxes
     choices:
       - All the checkboxes are checked: all_checkboxes_checked
-      - No unusually sized text: no_unusual_size_text
-      - All signature fields are filled in with the signature image: signature_filled_in    
+      - The fonts and styles in the preview look okay OR I am comfortable fixing them later: no_unusual_size_text
+        help: |
+          While you may prefer to fix font size now, it will not change your experience
+          with the Weaver. You can upload the fixed template to the Playground later.
+      - All signature fields are filled in with the signature image: signature_filled_in
     none of the above: False    
 validation code: |
   checkboxes_msg = ''
@@ -263,7 +266,7 @@ attachment:
     code: |
       template_upload
   code: |
-    reflect_fields(template_upload[0].get_pdf_fields())
+    reflect_fields(template_upload[0].get_pdf_fields(), placeholder_signature)
 ---
 code: |
   from pdfminer.pdfparser import PDFSyntaxError

--- a/docassemble/ALWeaver/field_grouping.py
+++ b/docassemble/ALWeaver/field_grouping.py
@@ -6,19 +6,22 @@ from numpy import unique
 from numpy import where
 from sklearn.cluster import AffinityPropagation
 from sklearn.metrics.pairwise import cosine_similarity
-from typing import Dict
+from typing import Dict, Tuple, List
+from docassemble.base.util import DAFile
 
 __all__ = ["reflect_fields", "reCase", "cluster_screens", "rename_pdf_fields"]
 
 
-def reflect_fields(fields):
+def reflect_fields(pdf_field_tuples: List[Tuple], image_placeholder: DAFile = None) -> List[Dict[str, str]]:
     """Return a mapping between the field names and either the same name, or "yes"
     if the field is a checkbox value, in order to visually capture the location of
     labeled fields on the PDF."""
     mapping = []
-    for field in fields:
+    for field in pdf_field_tuples:
         if field[4] == "/Btn":
             mapping.append({field[0]: "Yes"})
+        if field[4] == '/Sig' and image_placeholder:
+            mapping.append({field[0]: image_placeholder})
         else:
             mapping.append({field[0]: field[0]})
     return mapping

--- a/docassemble/ALWeaver/field_grouping.py
+++ b/docassemble/ALWeaver/field_grouping.py
@@ -12,7 +12,9 @@ from docassemble.base.util import DAFile
 __all__ = ["reflect_fields", "reCase", "cluster_screens", "rename_pdf_fields"]
 
 
-def reflect_fields(pdf_field_tuples: List[Tuple], image_placeholder: DAFile = None) -> List[Dict[str, str]]:
+def reflect_fields(
+    pdf_field_tuples: List[Tuple], image_placeholder: DAFile = None
+) -> List[Dict[str, str]]:
     """Return a mapping between the field names and either the same name, or "yes"
     if the field is a checkbox value, in order to visually capture the location of
     labeled fields on the PDF."""
@@ -20,7 +22,7 @@ def reflect_fields(pdf_field_tuples: List[Tuple], image_placeholder: DAFile = No
     for field in pdf_field_tuples:
         if field[4] == "/Btn":
             mapping.append({field[0]: "Yes"})
-        if field[4] == '/Sig' and image_placeholder:
+        elif field[4] == "/Sig" and image_placeholder:
             mapping.append({field[0]: image_placeholder})
         else:
             mapping.append({field[0]: field[0]})

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -450,11 +450,11 @@ class DAField(DAObject):
         elif self.variable.endswith("_amount"):
             self.field_type_guess = "currency"
         elif self.variable.endswith("_value"):
-            self.field_type_guess = "currency"            
+            self.field_type_guess = "currency"
         else:
             self.field_type_guess = "text"
-        
-        if pdf_field_tuple[4] not in ['/Sig','/Btn','/Tx']:
+
+        if pdf_field_tuple[4] not in ["/Sig", "/Btn", "/Tx"]:
             self.field_type_unhandled = True
 
     def mark_as_paired_yesno(self, paired_field_names: List[str]):
@@ -1046,7 +1046,7 @@ class DAFieldList(DAList):
             for var_and_type, fields in parent_coll_map.items()
         ]
 
-    def add_fields_from_file(self, the_file:Union[DAFile, DAFileList]) -> None:
+    def add_fields_from_file(self, the_file: Union[DAFile, DAFileList]) -> None:
         """
         Given a DAFile or DAFileList, process the raw fields in each file
         and add to the current list. Deduplication happens after each additional
@@ -1063,7 +1063,9 @@ class DAFieldList(DAList):
         elif the_file.filename.lower().endswith("docx"):
             document_type = "docx"
         else:
-            raise Exception(f"{f.filename} doesn't appear to be a PDF or DOCX file. Check the filename extension.")
+            raise Exception(
+                f"{f.filename} doesn't appear to be a PDF or DOCX file. Check the filename extension."
+            )
 
         if document_type == "pdf":
             for pdf_field_tuple in all_fields:
@@ -1074,11 +1076,11 @@ class DAFieldList(DAList):
                 # Built-in fields and signatures don't get custom questions written
                 if is_reserved_label(pdf_field_name):
                     new_field.group = DAFieldGroup.BUILT_IN
-                elif len(pdf_field_tuple) > 4 and pdf_field_tuple[4] == '/Sig':
+                elif len(pdf_field_tuple) > 4 and pdf_field_tuple[4] == "/Sig":
                     new_field.group = DAFieldGroup.SIGNATURE
                 else:
                     new_field.group = DAFieldGroup.CUSTOM
-                
+
                 # This function determines what type of variable
                 # we're dealing with
                 new_field.fill_in_pdf_attributes(pdf_field_tuple)
@@ -1089,16 +1091,17 @@ class DAFieldList(DAList):
                 new_field.source_document_type = "docx"
                 if is_reserved_docx_label(field):
                     new_field.group = DAFieldGroup.BUILT_IN
-                elif field.endswith('.signature'):
+                elif field.endswith(".signature"):
                     new_field.group = DAFieldGroup.SIGNATURE
-                else:                
+                else:
                     new_field.group = DAFieldGroup.CUSTOM
                 new_field.fill_in_docx_attributes(field)
 
         self.consolidate_duplicate_fields(document_type)
         self.consolidate_yesnos()
 
-    def get_person_candidates(self,
+    def get_person_candidates(
+        self,
         undefined_person_prefixes=generator_constants.UNDEFINED_PERSON_PREFIXES,
         people_suffixes=generator_constants.PEOPLE_SUFFIXES,
         people_suffixes_map=generator_constants.PEOPLE_SUFFIXES_MAP,
@@ -1110,7 +1113,7 @@ class DAFieldList(DAList):
         Identify the field names that appear to represent people in the list of
         string fields pulled from docx/PDF. Exclude people we know
         are singular Persons (such as trial_court).
-        """    
+        """
         people_vars = reserved_person_pluralizers_map.values()
         people = set()
         for field in self:
@@ -1127,7 +1130,9 @@ class DAFieldList(DAList):
                 people.add(field_to_check)
             elif (field_to_check) in undefined_person_prefixes:
                 pass  # Do not ask how many there will be about a singluar person
-            elif file_type == "docx" and ("[" in field_to_check or "." in field_to_check):
+            elif file_type == "docx" and (
+                "[" in field_to_check or "." in field_to_check
+            ):
                 # Check for a valid Python identifier before brackets or .
                 match_with_brackets_or_attribute = r"([A-Za-z_]\w*)((\[.*)|(\..*))"
                 matches = re.match(match_with_brackets_or_attribute, field_to_check)
@@ -1169,26 +1174,31 @@ class DAFieldList(DAList):
         else:
             return people - (set(reserved_pluralizers_map.values()) - set(people_vars))
 
-
-    def mark_people_as_builtins(self, people_list:List[str], people_suffixes: List[str] = (
-        generator_constants.PEOPLE_SUFFIXES + generator_constants.DOCX_ONLY_SUFFIXES
-    )) -> None:
+    def mark_people_as_builtins(
+        self,
+        people_list: List[str],
+        people_suffixes: List[str] = (
+            generator_constants.PEOPLE_SUFFIXES + generator_constants.DOCX_ONLY_SUFFIXES
+        ),
+    ) -> None:
         """Scan the list of fields and see if any of them should be renamed
         or marked as built-ins given the list of new, custom prefixes."""
         for field in self:
-            if field.source_document_type == "pdf":           
+            if field.source_document_type == "pdf":
                 if is_reserved_label(field.variable, reserved_prefixes=people_list):
                     field.group = DAFieldGroup.BUILT_IN
                     # Try checking to see if the custom prefix + predefined suffixes
                     # result in a new variable name
                     new_potential_name = map_raw_to_final_display(
-                        field.variable, document_type=field.source_document_type, reserved_prefixes=people_list
+                        field.variable,
+                        document_type=field.source_document_type,
+                        reserved_prefixes=people_list,
                     )
                     if new_potential_name != field.variable:
                         field.final_display_var = new_potential_name
-            elif is_reserved_docx_label(field.variable,
-                    reserved_pluralizers_map = dict(enumerate(people_list))
-                ):
+            elif is_reserved_docx_label(
+                field.variable, reserved_pluralizers_map=dict(enumerate(people_list))
+            ):
                 field.group = DAFieldGroup.BUILT_IN
 
         # This treats all fields as PDF fields, which should be a reasonable
@@ -1198,16 +1208,17 @@ class DAFieldList(DAList):
     def builtins(self):
         """Returns "built-in" fields, including ones the user indicated contain
         custom person-prefixes"""
-        return self.filter(group = DAFieldGroup.BUILT_IN)
+        return self.filter(group=DAFieldGroup.BUILT_IN)
 
     def signatures(self):
         """Returns all signature fields in list"""
-        return self.filter(group = DAFieldGroup.SIGNATURE)
+        return self.filter(group=DAFieldGroup.SIGNATURE)
 
     def custom(self):
         """Returns the fields that can be assigned to screens and which will require
         custom labels"""
-        return self.filter(group = DAFieldGroup.CUSTOM)
+        return self.filter(group=DAFieldGroup.CUSTOM)
+
 
 class DAQuestion(DABlock):
     """
@@ -1353,6 +1364,7 @@ def get_fields(the_file):
     docx_data = docx2python(the_file.path())  # Will error with invalid value
     text = docx_data.text
     return get_docx_variables(text)
+
 
 def get_docx_variables(text: str) -> set:
     """
@@ -1702,6 +1714,7 @@ def pdf_field_type_str(field):
 # Recognizing errors with PDF and DOCX files and variable names
 ######################################
 
+
 def is_valid_python(code: str) -> bool:
     try:
         ast.parse(code)
@@ -1721,50 +1734,62 @@ def bad_name_reason(field: DAField):
     else:
         # log(field[0], "console")
         python_var = map_raw_to_final_display(
-            remove_multiple_appearance_indicator(varname(field.variable)), document_type="pdf"
+            remove_multiple_appearance_indicator(varname(field.variable)),
+            document_type="pdf",
         )
         if len(python_var) == 0:
             return f"{ field.variable }, the { field.field_type_guess } field, should be in [snake case](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/naming#pdf-variables--snake_case) and use alphabetical characters"
         return None
 
+
 def get_pdf_validation_errors(f: DAFile):
     try:
         fields = DAFieldList()
-        fields.add_fields_from_file(f)        
+        fields.add_fields_from_file(f)
     except ParsingException as ex:
         return ("parsing_exception", ex)
     except (PDFSyntaxError, PdfReadError):
         return ("invalid_pdf", "Invalid PDF")
     except PSEOF:
-        return ("pseof", "File appears incomplete (PSEOF error). Is this a valid PDF file?")
+        return (
+            "pseof",
+            "File appears incomplete (PSEOF error). Is this a valid PDF file?",
+        )
     except:
         return ("unknown", "Unknown error reading PDF file. Is this a valid PDF?")
     try:
         pdf_concatenate(f, f)
     except:
-        return ("concatenation_error", "Unknown error concatenating PDF file to itself. The file may be invalid.")
+        return (
+            "concatenation_error",
+            "Unknown error concatenating PDF file to itself. The file may be invalid.",
+        )
+
 
 def get_docx_validation_errors(f: DAFile):
     try:
         fields = DAFieldList()
-        fields.add_fields_from_file(f)        
+        fields.add_fields_from_file(f)
     except (BadZipFile, KeyError):
         return ("bad_docx", "Error opening DOCX. Is this a valid DOCX file?")
-    
+
     try:
         pdf_concatenate(f)
     except:
-        return ("unable_to_convert_to_pdf", "Unable to convert to PDF. Is this is a valid DOCX file?")
+        return (
+            "unable_to_convert_to_pdf",
+            "Unable to convert to PDF. Is this is a valid DOCX file?",
+        )
 
 
 def get_variable_name_warnings(fields):
-    return list(filter(
-        lambda elem: elem is not None,
-        map(bad_name_reason, fields)))
+    return list(filter(lambda elem: elem is not None, map(bad_name_reason, fields)))
+
 
 ############################
 # Create a Docassemble .zip package
 ############################
+
 
 def create_package_zip(
     pkgname: str,

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -443,9 +443,12 @@ class DAField(DAObject):
         elif self.variable.endswith("_amount"):
             self.field_type_guess = "currency"
         elif self.variable.endswith("_value"):
-            self.field_type_guess = "currency"
+            self.field_type_guess = "currency"            
         else:
             self.field_type_guess = "text"
+        
+        if pdf_field_tuple[4] not in ['/Sig','/Btn','/Tx']:
+            self.field_type_unhandled = True
 
     def mark_as_paired_yesno(self, paired_field_names: List[str]):
         """Marks this field as actually representing multiple template fields:

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -1477,7 +1477,7 @@ def map_raw_to_final_display(
         return label
 
     # Break up label into its parts: prefix, digit, the rest
-    all_prefixes = reserved_prefixes + list(custom_people_plurals_map.values())
+    all_prefixes = list(reserved_prefixes) + list(custom_people_plurals_map.values())
     label_groups = get_reserved_label_parts(all_prefixes, label)
 
     # If no matches to automateable labels were found,

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -1117,12 +1117,12 @@ class DAFieldList(DAList):
         """
         Helper function for generating an attachment block in Docassemble YAML
         file.
-        
+
         Provided a DAFile, will return either the intersection of fields that
         are contained in both the DAFile and the DAFieldList, or if the file is a
         DOCX, immediately returns an empty list.
         """
-        matches:list = []
+        matches: list = []
         if not document.mimetype == "application/pdf":
             return matches
         document_fields = get_fields(document)
@@ -1131,7 +1131,6 @@ class DAFieldList(DAList):
             if set(field.raw_field_names).intersection(document_fields):
                 matches.append(field)
         return matches
-
 
     def get_person_candidates(
         self,

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -1116,7 +1116,7 @@ class DAFieldList(DAList):
         file.
         
         Provided a DAFile, will return either the intersection of fields that
-        are contained in both the DAFile and the DAFieldList. If the file is a
+        are contained in both the DAFile and the DAFieldList, or if the file is a
         DOCX, immediately returns an empty list.
         """
         matches:list = []

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -872,6 +872,9 @@ class DAField(DAObject):
             return prefix, "object"
         return var_with_attribute, "primitive"
 
+    def __str__(self) -> str:
+        return self.variable
+
 
 class ParentCollection(object):
     """A ParentCollection is "highest" level of data structure containing some DAField.
@@ -896,8 +899,8 @@ class ParentCollection(object):
         self.var_type = var_type
         # this base var is more complex than a simple primitive type
         if self.var_type != "primitive":
-            for f in self.fields:
-                plain_att, disp_att, settable_att = f._get_attributes()
+            for field in self.fields:
+                plain_att, disp_att, settable_att = field._get_attributes()
                 if plain_att:
                     self.attribute_map[plain_att] = (disp_att, settable_att)
 
@@ -1054,13 +1057,13 @@ class DAFieldList(DAList):
 
     def add_fields_from_file(self, the_file: Union[DAFile, DAFileList]) -> None:
         """
-        Given a DAFile or DAFileList, process the raw fields in each file
-        and add to the current list. Deduplication happens after each additional
-        field is added.
+        Given a DAFile or DAFileList, process the raw fields in each file and
+        add to the current list. Deduplication happens after every field is
+        added.
         """
         if isinstance(the_file, DAFileList):
-            for f in the_file:
-                self.add_fields_from_file(f)
+            for document in the_file:
+                self.add_fields_from_file(document)
             return None
 
         all_fields = get_fields(the_file)
@@ -1070,7 +1073,7 @@ class DAFieldList(DAList):
             document_type = "docx"
         else:
             raise Exception(
-                f"{f.filename} doesn't appear to be a PDF or DOCX file. Check the filename extension."
+                f"{the_file.filename} doesn't appear to be a PDF or DOCX file. Check the filename extension."
             )
 
         if document_type == "pdf":
@@ -1382,7 +1385,7 @@ def docx_variable_fix(variable: str) -> str:
     return variable
 
 
-def get_fields(the_file):
+def get_fields(the_file: Union[DAFile, DAFileList]):
     """Get the list of fields needed inside a template file (PDF or Docx Jinja
     tags). This will include attributes referenced. Assumes a file that
     has a valid and exiting filepath."""

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -1110,6 +1110,26 @@ class DAFieldList(DAList):
         self.consolidate_duplicate_fields(document_type)
         self.consolidate_yesnos()
 
+    def matching_pdf_fields_from_file(self, document: DAFile) -> List[str]:
+        """
+        Helper function for generating an attachment block in Docassemble YAML
+        file.
+        
+        Provided a DAFile, will return either the intersection of fields that
+        are contained in both the DAFile and the DAFieldList. If the file is a
+        DOCX, immediately returns an empty list.
+        """
+        matches:list = []
+        if not document.mimetype == "application/pdf":
+            return matches
+        document_fields = get_fields(document)
+        document_fields = [item[0] for item in document_fields]
+        for field in self:
+            if set(field.raw_field_names).intersection(document_fields):
+                matches.append(field)
+        return matches
+
+
     def get_person_candidates(
         self,
         undefined_person_prefixes=generator_constants.UNDEFINED_PERSON_PREFIXES,

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -660,19 +660,15 @@ class DAField(DAObject):
 
         return content.rstrip("\n")
 
-    def user_ask_about_field(self, index):
+    def user_ask_about_field(self):
         field_questions = []
         settable_var = self.get_settable_var()
         if hasattr(self, "paired_yesno") and self.paired_yesno:
-            field_title = "{} (will be expanded to include _yes and _no)".format(
-                self.final_display_var
-            )
+            field_title = f"{ self.final_display_var } (will be expanded to include _yes and _no)"
         elif len(self.raw_field_names) > 1:
-            field_title = "{} (will be expanded to all instances)".format(settable_var)
+            field_title = f"{ settable_var } (will be expanded to all instances)"
         elif self.raw_field_names[0] != settable_var:
-            field_title = "{} (will be renamed to {})".format(
-                settable_var, self.raw_field_names[0]
-            )
+            field_title = f"{ settable_var } (will be renamed to { self.raw_field_names[0] })"
         else:
             field_title = self.final_display_var
 
@@ -680,14 +676,14 @@ class DAField(DAObject):
         field_questions.append(
             {
                 "label": "On-screen label",
-                "field": "fields[" + str(index) + "].label",
+                "field": self.attr_name("label"),
                 "default": self.variable_name_guess,
             }
         )
         field_questions.append(
             {
                 "label": "Field Type",
-                "field": f"fields[{index}].field_type",
+                "field": self.attr_name("field_type"),
                 "choices": [
                     "text",
                     "area",
@@ -717,17 +713,17 @@ class DAField(DAObject):
         field_questions.append(
             {
                 "label": f"Complete the expression, `{self.final_display_var} = `",
-                "field": f"fields[{index}].code",
-                "show if": {"variable": f"fields[{index}].field_type", "is": "code"},
+                "field": self.attr_name("code"),
+                "show if": {"variable": self.attr_name("field_type"), "is": "code"},
                 "help": f"Enter a valid Python expression, such as `'Hello World'` or `users[0].birthdate.plus(days=10)`. This will create a code block like `{self.final_display_var} = expression`",
             }
         )
         field_questions.append(
             {
                 "label": "Options (one per line)",
-                "field": f"fields[{index}].choices",
+                "field": self.attr_name("choices"),
                 "datatype": "area",
-                "js show if": f"['multiple choice dropdown','multiple choice combobox','multiselect', 'multiple choice radio', 'multiple choice checkboxes'].includes(val('fields[{index}].field_type'))",
+                "js show if": f"['multiple choice dropdown','multiple choice combobox','multiselect', 'multiple choice radio', 'multiple choice checkboxes'].includes(val('{ self.attr_name('field_type') }'))",
                 "hint": "Like 'Descriptive name: key_name', or just 'Descriptive name'",
             }
         )
@@ -735,9 +731,9 @@ class DAField(DAObject):
             field_questions.append(
                 {
                     "label": "Send overflow text to addendum",
-                    "field": f"fields[{index}].send_to_addendum",
+                    "field": self.attr_name("send_to_addendum"),
                     "datatype": "yesno",
-                    "js show if": f"val('fields[{index}].field_type') === 'area' ",
+                    "js show if": f"val('{ self.attr_name('field_type') }') === 'area' ",
                     "help": "Check the box to send text that doesn't fit in the PDF to an additional page, instead of limiting the input length.",
                 }
             )
@@ -1208,16 +1204,29 @@ class DAFieldList(DAList):
     def builtins(self):
         """Returns "built-in" fields, including ones the user indicated contain
         custom person-prefixes"""
-        return self.filter(group=DAFieldGroup.BUILT_IN)
+        # Can't use .filter() because that would create new intrinsicNames
+        return [
+            item
+            for item in self.elements
+            if item.group == DAFieldGroup.BUILT_IN
+        ]
 
     def signatures(self):
         """Returns all signature fields in list"""
-        return self.filter(group=DAFieldGroup.SIGNATURE)
+        return [
+            item
+            for item in self.elements
+            if item.group == DAFieldGroup.SIGNATURE
+        ]
 
     def custom(self):
         """Returns the fields that can be assigned to screens and which will require
         custom labels"""
-        return self.filter(group=DAFieldGroup.CUSTOM)
+        return [
+            item
+            for item in self.elements
+            if item.group == DAFieldGroup.CUSTOM
+        ]
 
 
 class DAQuestion(DABlock):

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -1045,6 +1045,7 @@ class DAFieldList(DAList):
         if isinstance(the_file, DAFileList):
             for f in the_file:
                 self.add_fields_from_file(f)
+            return None
 
         all_fields = get_fields(the_file)
         if the_file.filename.lower().endswith("pdf"):

--- a/docassemble/ALWeaver/validate_docx_files.py
+++ b/docassemble/ALWeaver/validate_docx_files.py
@@ -11,6 +11,7 @@ from docassemble.base.parse import (
     registered_jinja_filters,
     builtin_jinja_filters,
 )
+
 from typing import Optional, Iterable
 import re
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -33,3 +33,6 @@ ignore_missing_imports=true
 
 [mypy-ruamel]
 ignore_missing_imports=true
+
+[mypy-PyPDF2.*]
+ignore_missing_imports=true

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.ALWeaver',
       url='https://docassemble.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['PyYAML>=5.1.2', 'beautifulsoup4>=4.11.1', 'docassemble.ALToolbox>=0.4.2', 'docassemble.AssemblyLine>=2.11.2', 'docx2python>=1.27.1', 'formfyxer>=0.0.9', 'more-itertools>=8.6.0', 'numpy>=1.0.4', 'pikepdf>=5.1.1', 'sklearn>=0.0', 'spacy>=3.2.0'],
+      install_requires=['PyYAML>=5.1.2', 'beautifulsoup4>=4.11.1', 'docassemble.ALToolbox>=0.4.2', 'docassemble.AssemblyLine>=2.11.3', 'docx2python>=1.27.1', 'formfyxer>=0.0.9', 'more-itertools>=8.6.0', 'numpy>=1.0.4', 'pikepdf>=5.1.1', 'sklearn>=0.0', 'spacy>=3.2.0'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/ALWeaver/', package='docassemble.ALWeaver'),
      )


### PR DESCRIPTION
I think this is ready for review a little earlier than expected (replaces #631). This PR allows you to automate multiple (related) forms in one Weaver session. Each template is added to the output's bundle and a separate attachment block is added for each file, but the user experience is a single interview. There is no special feature that lets you separate out the documents once the interview is generated.

A lot of code was touched to reach this result.

- Some field handling code that had to deal with both PDF-style tuples and DOCX-style string fields was removed. Instead, the fields are put into a single list of DAFields. The source document type is marked for use when necessary.
- Much code in the YAML was abstracted and placed into the interview_generator.py file
- Some functions in the interview_generator.py file were moved into the DAFieldList class
- Some confusing abstractions were simplified--e.g., instead of 3 separate lists to track signatures, custom fields, and "built-ins" there is one list with an attribute of each DAField and some helper methods
- Some names were cleaned up. More consistently, I use `document` instead of `f` or `the_file` or other possibly confusing terms. Instead of calling the list of fields `fields` I renamed to `all_fields` (which was also used before) to make search easier. (`fields` has several meanings in the YAML)
- Some cleanup of validation to handle multiple source files, and some code moved to the module file
- Validation screens had to be modified to handle multiple files. I also now use the human-readable field type and removed some redundant code. There's still room to improve validation screens though--we now have 3: one for DOCX, PDF, and mixed file upload types.
- Upload validation now uses the .fix_up() method to validate PDFs. This is faster than `pdf_concatenate` and has the side effect of letting us fix invalid xref tables and some other PDF issues automatically.

I believe this is a good list of what to test:

- [ ] Get a valid YAML output when you automate one PDF
- [ ] Get a valid YAML output when you automate one DOCX
- [ ] Get a valid YAML output when you automate multiple PDFs
- [ ] Get a valid YAML output when you automate multiple DOCX files
- [ ] Get a valid YAML output when you automate mixed PDF and DOCX templates
- [ ] Invalid DOCX and PDF files generate a human-readable error
- [ ] At least one interview you generate from the list above (preferably mixed PDF and DOCX) can be imported and run in the playground after generation
- [ ] "Custom" people work correctly for PDF and DOCX templates
- [ ] The PDF normalizing functions work as expected
- [ ] @purplesky2016's new survey options still work 
- [ ] I'm feeling lucky still works. You can modify this URL to point to your playground to test I'm feeling lucky: `https://apps-dev.suffolklitlab.org/interview?i=docassemble.playground10WeaverMultipleTemplates%3Aassembly_line.yml&new_session=1&form_to_use=https://courtformsonline.org/forms/9174d60bba63599e1506732cb93e52b9.pdf&title=ADM-121+%7C++Attorney+Fees+Billing+Form&jur=AK&nsmi=[]`

I have tested each item at least once manually but since we do not have unit tests for this behavior, would prefer an additional manual test.

Some test files that might be useful:

## Valid files

[01 - Funky Filename ---.docx](https://github.com/SuffolkLITLab/docassemble-ALWeaver/files/8856034/01.-.Funky.Filename.---.docx)
[civil_docketing_statement_polished_repaired.pdf](https://github.com/SuffolkLITLab/docassemble-ALWeaver/files/8856035/civil_docketing_statement_polished_repaired.pdf)
[Fax_cover_sheet.pdf](https://github.com/SuffolkLITLab/docassemble-ALWeaver/files/8856036/Fax_cover_sheet.pdf)
[made_up_variables.docx](https://github.com/SuffolkLITLab/docassemble-ALWeaver/files/8856037/made_up_variables.docx)
[sample_word_template.docx](https://github.com/SuffolkLITLab/docassemble-ALWeaver/files/8856038/sample_word_template.docx)
[single_field.docx](https://github.com/SuffolkLITLab/docassemble-ALWeaver/files/8856039/single_field.docx)
[test_amount_value.docx](https://github.com/SuffolkLITLab/docassemble-ALWeaver/files/8856040/test_amount_value.docx)
[Test_custom_names.docx](https://github.com/SuffolkLITLab/docassemble-ALWeaver/files/8856041/Test_custom_names.docx)
[test_docket_numbers.docx](https://github.com/SuffolkLITLab/docassemble-ALWeaver/files/8856042/test_docket_numbers.docx)
[test_pdf_fields.pdf](https://github.com/SuffolkLITLab/docassemble-ALWeaver/files/8856043/test_pdf_fields.pdf)

## Invalid files
[Fax_cover_sheet_corrupt.pdf](https://github.com/SuffolkLITLab/docassemble-ALWeaver/files/8856046/Fax_cover_sheet_corrupt.pdf)
[invalid_xref_table.pdf](https://github.com/SuffolkLITLab/docassemble-ALWeaver/files/8856047/invalid_xref_table.pdf) (this file should actually work now)
[not_a_pdf.pdf](https://github.com/SuffolkLITLab/docassemble-ALWeaver/files/8856048/not_a_pdf.pdf)
[single_field_corrupted.docx](https://github.com/SuffolkLITLab/docassemble-ALWeaver/files/8856049/single_field_corrupted.docx)
[valid_docx_with_mako.docx](https://github.com/SuffolkLITLab/docassemble-ALWeaver/files/8856050/valid_docx_with_mako.docx)
[valid_word_invalid_jinja.docx](https://github.com/SuffolkLITLab/docassemble-ALWeaver/files/8856051/valid_word_invalid_jinja.docx)


## Fixes

Fix https://github.com/SuffolkLITLab/docassemble-ALWeaver/issues/484
Fix https://github.com/SuffolkLITLab/docassemble-ALWeaver/issues/629
Fix #637
progress on https://github.com/SuffolkLITLab/docassemble-ALWeaver/issues/628
possible progress on https://github.com/SuffolkLITLab/docassemble-ALWeaver/issues/559
progress on #558
