### PR TITLE
Improvements to default statistics collected

### DIFF
--- a/docassemble/ALWeaver/data/sources/output_patterns.yml
+++ b/docassemble/ALWeaver/data/sources/output_patterns.yml
@@ -134,6 +134,7 @@ main order: |
     ${ interview_label }_intro
     interview_order_${ interview_label }
     % if generate_download:
+    # Store anonymous data for analytics / statistics
     store_variables_snapshot(
         persistent=True,
         data={

--- a/docassemble/ALWeaver/data/sources/output_patterns.yml
+++ b/docassemble/ALWeaver/data/sources/output_patterns.yml
@@ -134,9 +134,13 @@ main order: |
     ${ interview_label }_intro
     interview_order_${ interview_label }
     % if generate_download:
-    signature_date    
-    # Save anonymized interview statistics (customize the saved data below)
-    store_variables_snapshot(data={'zip': users[0].address.zip})    
+    store_variables_snapshot(
+        persistent=True,
+        data={
+            "zip": showifdef("users[0].address.zip"),
+            "reached_interview_end": True,
+        },
+    )
     ${ interview_label }_preview_question
     basic_questions_signature_flow    
       % for signature_field in signatures:


### PR DESCRIPTION
- Don't trigger the users[0].address.zip attribute
- Add the "reached_interview_end" flag as a default statistic

Fix #610