### PR TITLE
Warn when DOCX contains PDF names

### DIFF
--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -806,6 +806,9 @@ code: |
       mako_matches = get_mako_matches(document)
       if mako_matches:
         mako_syntax_in_docx
+      pdf_variable_name_in_docx_matches = get_pdf_variable_name_matches(document)
+      if pdf_variable_name_in_docx_matches:
+        warn_pdf_variable_names_in_docx
     else:
       force_ask("exit_unknown_file_type")
 

--- a/docassemble/ALWeaver/data/questions/docx_field_tester.yml
+++ b/docassemble/ALWeaver/data/questions/docx_field_tester.yml
@@ -42,7 +42,31 @@ buttons:
   - I understand, let me continue: 
       code: |
         mako_syntax_in_docx = True
-  - Restart: exit
+  - Restart: restart
+---
+id: did you intend to use PDF variable names
+question: |
+  Did you intend to use variables that match a PDF variable name?
+subquestion: |
+  Your DOCX template looks like it is using a variable name that is 
+  normally only used in a PDF. You may want to stop here and fix your template 
+  by replacing the PDF variable name with the DOCX equivalent.
+
+  These are the lines that look like they contain PDF variable names:
+
+  % for match in pdf_variable_name_in_docx_matches:
+  * ${ match }
+  % endfor
+
+  Check out [the labeling
+  documentation](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/label_variables)
+  and pay attention to the columns labeled `Docassemble / DOCX form`.
+sets: warn_pdf_variable_names_in_docx
+buttons: 
+  - I understand, let me continue: 
+      code: |
+        warn_pdf_variable_names_in_docx = True
+  - Restart: restart
 ---
 id: jinja_exception
 event: jinja_exception

--- a/docassemble/ALWeaver/data/questions/docx_field_tester.yml
+++ b/docassemble/ALWeaver/data/questions/docx_field_tester.yml
@@ -55,7 +55,7 @@ subquestion: |
   These are the lines that look like they contain PDF variable names:
 
   % for match in pdf_variable_name_in_docx_matches:
-  * ${ match }
+  * `${ match[0] }`, did you mean `${ match[1] }`?
   % endfor
 
   Check out [the labeling

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -78,6 +78,7 @@ __all__ = [
     "get_pdf_validation_errors",
     "get_docx_validation_errors",
     "get_variable_name_warnings",
+    "get_pdf_variable_name_matches",
 ]
 
 always_defined = set(
@@ -1820,6 +1821,14 @@ def get_docx_validation_errors(document: DAFile):
 def get_variable_name_warnings(fields):
     return list(filter(lambda elem: elem is not None, map(bad_name_reason, fields)))
 
+
+def get_pdf_variable_name_matches(document: DAFile) -> Set[str]:
+    fields = document.get_docx_variables()
+    res = set()
+    for field in fields:
+        if map_raw_to_final_display(field) != field:
+            res.add(field)
+    return res
 
 ############################
 # Create a Docassemble .zip package

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -1822,12 +1822,13 @@ def get_variable_name_warnings(fields):
     return list(filter(lambda elem: elem is not None, map(bad_name_reason, fields)))
 
 
-def get_pdf_variable_name_matches(document: DAFile) -> Set[str]:
+def get_pdf_variable_name_matches(document: DAFile) -> Set[Tuple[str, str]]:
     fields = document.get_docx_variables()
     res = set()
     for field in fields:
-        if map_raw_to_final_display(field) != field:
-            res.add(field)
+        possible_new_field = map_raw_to_final_display(field)
+        if possible_new_field != field:
+            res.add((field, possible_new_field))
     return res
 
 ############################


### PR DESCRIPTION
Fix #634 

This PR checks DOCX files to see if any variable names would be transformed if they were contained in a PDF. If so, it warns the developer that they may have used the wrong form of the variable name in the DOCX.

Test file: 
[pdf_variables_in_docx.docx](https://github.com/SuffolkLITLab/docassemble-ALWeaver/files/9065730/pdf_variables_in_docx.docx)

Should have 2 matches.
