### PR TITLE
Let a DOCX template contain a zero-based index

### DIFF
--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -764,7 +764,7 @@ code: |
       mako_matches = get_mako_matches(document)
       if mako_matches:
         mako_syntax_in_docx
-      pdf_variable_name_in_docx_matches = get_pdf_variable_name_matches(document)
+      pdf_variable_name_in_docx_matches = get_pdf_variable_name_matches(document, document_type="docx")
       if pdf_variable_name_in_docx_matches:
         warn_pdf_variable_names_in_docx
     else:

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -764,7 +764,7 @@ code: |
       mako_matches = get_mako_matches(document)
       if mako_matches:
         mako_syntax_in_docx
-      pdf_variable_name_in_docx_matches = get_pdf_variable_name_matches(document, document_type="docx")
+      pdf_variable_name_in_docx_matches = get_pdf_variable_name_matches(document)
       if pdf_variable_name_in_docx_matches:
         warn_pdf_variable_names_in_docx
     else:

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -1675,7 +1675,7 @@ def get_variable_name_warnings(fields):
     return list(filter(lambda elem: elem is not None, map(bad_name_reason, fields)))
 
 
-def get_pdf_variable_name_matches(document: Union[DAFile, str]) -> Set[Tuple[str, str]]:
+def get_pdf_variable_name_matches(document: Union[DAFile, str], document_type="docx") -> Set[Tuple[str, str]]:
     if isinstance(document, DAFile):
         docx_data = docx2python(document.path())
     else:
@@ -1684,7 +1684,7 @@ def get_pdf_variable_name_matches(document: Union[DAFile, str]) -> Set[Tuple[str
     fields = get_docx_variables(text)
     res = set()
     for field in fields:
-        possible_new_field = map_raw_to_final_display(field)
+        possible_new_field = map_raw_to_final_display(field, document_type=document_type)
         if possible_new_field != field:
             res.add((field, possible_new_field))
     return res

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -1675,7 +1675,11 @@ def get_variable_name_warnings(fields):
     return list(filter(lambda elem: elem is not None, map(bad_name_reason, fields)))
 
 
-def get_pdf_variable_name_matches(document: Union[DAFile, str], document_type="docx") -> Set[Tuple[str, str]]:
+def get_pdf_variable_name_matches(document: Union[DAFile, str]) -> Set[Tuple[str, str]]:
+    """
+    Identify any variable names that look like they are intended to be for a PDF
+    in a DOCX template.
+    """
     if isinstance(document, DAFile):
         docx_data = docx2python(document.path())
     else:
@@ -1684,7 +1688,7 @@ def get_pdf_variable_name_matches(document: Union[DAFile, str], document_type="d
     fields = get_docx_variables(text)
     res = set()
     for field in fields:
-        possible_new_field = map_raw_to_final_display(field, document_type=document_type)
+        possible_new_field = map_raw_to_final_display(field, document_type="docx")
         if possible_new_field != field:
             res.add((field, possible_new_field))
     return res


### PR DESCRIPTION
We had a nice feature to catch the use of PDF variable name syntax in DOCX template, but we weren't properly passing the document type in some cases, leading to exceptions that should only apply to PDFs being raised.

This just adds the DOCX filetype in some places that was required but missing.

Example DOCX that should work but didn't before: 
[93A demand letter - partially labeled.docx](https://github.com/SuffolkLITLab/docassemble-ALWeaver/files/9758217/93A.demand.letter.-.partially.labeled.docx)