### PR TITLE
Output pattern roundup

### DIFF
--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -370,8 +370,12 @@ fields:
       package, the main YAML file, and give a unique label to variables inside
       your document.
   - Link to original form: interview.original_form
-    hint: http://masslegalhelp.org/my_form
+    help: |
+      Include a link to a page where your user can download the blank form, if
+      that exists.
     required: False
+    validate: |
+      lambda y: (not y or is_url(y)) or validation_error("Write a valid URL, like: https://masslegalhelp.org/my_form")
 ---
 code: |
   interview.default_country_code = 'US'

--- a/docassemble/ALWeaver/data/templates/output.mako
+++ b/docassemble/ALWeaver/data/templates/output.mako
@@ -362,33 +362,36 @@ objects:
 # Each attachment defines a key in an ALDocument. We use `i` as the placeholder here so the same template is 
 # used for "preview" and "final" keys, and logic in the template checks the value of 
 # `i` to show or hide the user's signature
-attachments:
-  - name: Post-interview-Instructions
-    filename: ${ interview.interview_label }_next_steps
-    docx template file: ${ interview.interview_label }_next_steps.docx
-    variable name: ${ interview.interview_label }_Post_interview_instructions[i]
-  % for document in interview.uploaded_templates:
-    % if len(interview.uploaded_templates) == 1:
-  - name: ${ interview.interview_label.replace('_',' ') }
-    filename: ${ interview.interview_label }
-    variable name: ${ interview.interview_label }_attachment[i]
-    % else:
-  - name: ${ base_name(document.filename).replace('_',' ') }
-    filename: ${ base_name(document.filename) }
-    variable name: ${ varname(base_name(document.filename)) }[i]
-    % endif
-    % if document.mimetype == "application/pdf":
-    skip undefined: True
-    pdf template file: ${ document.filename }
-    fields:
-      % for field in interview.all_fields.matching_pdf_fields_from_file(document):
-${ attachment_yaml(field, attachment_name=varname(base_name(document.filename))) }\
-      % endfor
-    % else:
-    skip undefined: True
-    docx template file: ${ document.filename }
-    % endif
-  % endfor
+attachment:
+  name: Post-interview-Instructions
+  filename: ${ interview.interview_label }_next_steps
+  docx template file: ${ interview.interview_label }_next_steps.docx
+  variable name: ${ interview.interview_label }_Post_interview_instructions[i]
+  skip undefined: True
+% for document in interview.uploaded_templates:
+---
+attachment:
+% if len(interview.uploaded_templates) == 1:
+  name: ${ interview.interview_label.replace('_',' ') }
+  filename: ${ interview.interview_label }
+  variable name: ${ interview.interview_label }_attachment[i]
+% else:
+  name: ${ base_name(document.filename).replace('_',' ') }
+  filename: ${ base_name(document.filename) }
+  variable name: ${ varname(base_name(document.filename)) }[i]
+% endif
+% if document.mimetype == "application/pdf":
+  skip undefined: True
+  pdf template file: ${ document.filename }
+  fields:
+    % for field in interview.all_fields.matching_pdf_fields_from_file(document):
+    ${ attachment_yaml(field, attachment_name=varname(base_name(document.filename))) }\
+    % endfor
+% else:
+  skip undefined: True
+  docx template file: ${ document.filename }
+% endif
+% endfor
 % if interview.all_fields.has_addendum_fields():
 ---
 code: |

--- a/docassemble/ALWeaver/data/templates/output.mako
+++ b/docassemble/ALWeaver/data/templates/output.mako
@@ -37,8 +37,10 @@ data:
     ${ oneline(interview.short_title) }
   description: |-
 ${ indent(interview.description, by=4) }
+  % if interview.original_form:
   original_form: >-
 ${ indent(interview.original_form, by=4) }
+  % endif
   % if len(interview.allowed_courts.true_values()) < 1:
   allowed courts: []
   % else:

--- a/docassemble/ALWeaver/data/templates/output.mako
+++ b/docassemble/ALWeaver/data/templates/output.mako
@@ -343,12 +343,12 @@ code: |
 ---
 # ALDocument objects specify the metadata for each template
 objects:
-  - ${ interview.interview_label }_Post_interview_instructions: ALDocument.using(title="Instructions", filename="${ interview.interview_label }_next_steps.docx", enabled=True, has_addendum=False, default_overflow_message=AL_DEFAULT_OVERFLOW_MESSAGE)
+  - ${ interview.interview_label }_Post_interview_instructions: ALDocument.using(title="Instructions", filename="${ interview.interview_label }_next_steps.docx", enabled=True, has_addendum=False)
   % if len(interview.uploaded_templates) == 1:
-  - ${ interview.interview_label }_attachment: ALDocument.using(title="${ interview.title }", filename="${ interview.interview_label }", enabled=True, has_addendum=${ interview.all_fields.has_addendum_fields() }, default_overflow_message=AL_DEFAULT_OVERFLOW_MESSAGE)
+  - ${ interview.interview_label }_attachment: ALDocument.using(title="${ interview.title }", filename="${ interview.interview_label }", enabled=True, has_addendum=${ interview.all_fields.has_addendum_fields() }, ${ "default_overflow_message=AL_DEFAULT_OVERFLOW_MESSAGE" if interview.all_fields.has_addendum_fields() else ''})
   % else:
   % for document in interview.uploaded_templates:
-  - ${ varname(base_name(document.filename)) }: ALDocument.using(title="${ base_name(document.filename).capitalize().replace("_", " ") }", filename="${ base_name(document.filename) }", enabled=True, has_addendum=${ interview.all_fields.has_addendum_fields() }, default_overflow_message=AL_DEFAULT_OVERFLOW_MESSAGE)
+  - ${ varname(base_name(document.filename)) }: ALDocument.using(title="${ base_name(document.filename).capitalize().replace("_", " ") }", filename="${ base_name(document.filename) }", enabled=True, has_addendum=${ interview.all_fields.has_addendum_fields() }, ${ "default_overflow_message=AL_DEFAULT_OVERFLOW_MESSAGE" if interview.all_fields.has_addendum_fields() else ''})
   % endfor
   % endif
 ---
@@ -387,7 +387,7 @@ attachment:
   pdf template file: ${ document.filename }
   fields:
     % for field in interview.all_fields.matching_pdf_fields_from_file(document):
-    ${ attachment_yaml(field, attachment_name=varname(base_name(document.filename))) }\
+${ attachment_yaml(field, attachment_name=varname(base_name(document.filename))) }\
     % endfor
 % else:
   skip undefined: True

--- a/docassemble/ALWeaver/data/templates/output_defs.mako
+++ b/docassemble/ALWeaver/data/templates/output_defs.mako
@@ -148,7 +148,7 @@ confirm: True\
       % endif 
     % else: # all other variable types including text
       % if hasattr(field, "send_to_addendum") and field.send_to_addendum and attachment_name:
-      - "${ raw_name }": <%text>${</%text> attachment_name.safe_value("${ field.final_display_var }") }
+      - "${ raw_name }": <%text>${</%text> ${ attachment_name }.safe_value("${ field.final_display_var }") }
       % else:
       - "${ raw_name }": <%text>${</%text> ${ field.final_display_var } }
       % endif

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -39,6 +39,7 @@ import ast
 from enum import Enum
 from itertools import zip_longest, chain
 import more_itertools
+from urllib.parse import urlparse
 
 
 mako.runtime.UNDEFINED = DAEmpty()
@@ -80,6 +81,7 @@ __all__ = [
     "to_yaml_file",
     "using_string",
     "varname",
+    "is_url",
 ]
 
 always_defined = set(
@@ -1748,6 +1750,17 @@ def get_pdf_variable_name_matches(document: Union[DAFile, str]) -> Set[Tuple[str
             # ParsingExceptions are fine, because we aren't really parsing a PDF
             pass
     return res
+
+
+def is_url(url:str) -> bool:
+    """
+    Returns True if and only if the input string is in the format of a valid URL
+    """
+    try:
+        result = urlparse(url)
+        return all([result.scheme, result.netloc])
+    except ValueError:
+        return False
 
 
 ############################


### PR DESCRIPTION
Improve Weaver's safety - use skip undefined and separate attachment blocks for instructions.

Fixed an undiscovered bug with Addendum code

Misc. cleanups to output YAML

Fix #721 
Fix #720 
Fix #719 
Fix #728 