### PR TITLE
Update python test action

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -8,15 +8,5 @@ jobs:
   test-weaver:
     runs-on: ubuntu-latest
     name: Run unit tests + mypy
-    env:
-      ISUNITTEST: true
     steps:
-      - run: sudo apt-get update && sudo apt-get -y install libcurl4-openssl-dev build-essential python3-dev libldap2-dev libsasl2-dev slapd ldap-utils tox lcov valgrind libzbar0
-      - name: Checkout
-        uses: actions/checkout@v2
-      - run: pip3 install virtualenv 
-      - run: virtualenv -p python3.9 .venv
-      - run: .venv/bin/pip install -r docassemble/ALWeaver/requirements.txt
-      - run: .venv/bin/pip install --editable .
-      - run: .venv/bin/python3 -m mypy .
-      - run: .venv/bin/python3 -m unittest discover
+      - uses: SuffolkLITLab/ALActions/pythontests@main

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.ALWeaver',
       url='https://docassemble.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['PyYAML>=5.1.2', 'beautifulsoup4>=4.11.1', 'docassemble.ALToolbox>=0.4.2', 'docassemble.AssemblyLine>=2.11.3', 'docx2python>=1.27.1', 'formfyxer>=0.0.9', 'more-itertools>=8.6.0', 'numpy>=1.0.4', 'pikepdf>=5.1.1', 'sklearn>=0.0', 'spacy>=3.2.0'],
+      install_requires=['PyYAML>=5.1.2', 'beautifulsoup4>=4.11.1', 'docassemble.ALToolbox>=0.4.2', 'docassemble.AssemblyLine>=2.11.3', 'docx2python>=1.27.1', 'formfyxer>=0.0.9', 'more-itertools>=8.6.0', 'numpy>=1.0.4', 'pikepdf>=5.1.1', 'scikit-learn>=0.0', 'spacy>=3.2.0'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/ALWeaver/', package='docassemble.ALWeaver'),
      )


### PR DESCRIPTION
* use action logic from ALActions/pythontests
* use `scikit-learn` instead of `sklearn`: https://github.com/scikit-learn/sklearn-pypi-package

Might do a quick install test (that Kiln wouldn't cover) since I am changing setup.py.