### PR TITLE
No pypdf2

### DIFF
--- a/docassemble/ALWeaver/data/questions/template_validation.yml
+++ b/docassemble/ALWeaver/data/questions/template_validation.yml
@@ -476,33 +476,15 @@ attachment:
 ---
 code: |
   from pdfminer.pdfparser import PDFSyntaxError
-  from PyPDF2.utils import PdfReadError
   
   try:
     pdf_concatenate(interview.uploaded_templates)
   except PDFSyntaxError:
     # Handle PDF read error
     force_ask('exit_invalid_pdf')
-  except PdfReadError:
-    force_ask('exit_xref_table')
   except:
     pass # Continue on to safer checks with get_pdf_fields
   validate_pdf = True
----
-event: exit_xref_table
-question: |
-  This PDF is not valid
-subquestion: |
-  There was a problem reading this PDF.
-  
-  Sometimes you can fix this problem by using 
-  [documate.org/pdf](https://www.documate.org/pdf) or by using 
-  [qpdf](http://qpdf.sourceforge.net/).
-  
-  [Read 
-  more](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/pdfs#corrupted-or-locked-pdfs).
-buttons:
-  - Restart: restart
 ---
 ###################### DOCX validation stuff #############################
 ---

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -26,7 +26,6 @@ from itertools import zip_longest, chain
 from pdfminer.pdfparser import PDFSyntaxError
 from pdfminer.psparser import PSEOF
 from pikepdf import Pdf
-from PyPDF2.utils import PdfReadError
 from typing import Any, Dict, List, Optional, Set, Tuple, Union, Iterable
 from urllib.parse import urlparse
 from zipfile import BadZipFile
@@ -1858,7 +1857,7 @@ def get_pdf_validation_errors(document: DAFile) -> Optional[ValidationError]:
         fields.add_fields_from_file(document)
     except ParsingException as ex:
         return ("parsing_exception", ex)
-    except (PDFSyntaxError, PdfReadError):
+    except (PDFSyntaxError):
         return ("invalid_pdf", "Invalid PDF")
     except PSEOF:
         return (


### PR DESCRIPTION
Docassemble no longer includes PyPDF2 by default, and doesn't use it to throw errors. That means our code that catches PyPDF2 errors is stale, and can be removed.

I went through all of the PDFS in https://github.com/SuffolkLITLab/docassemble-ALWeaver/pull/437 and tested each; none of them make different errors than they do on main.