### PR TITLE
Radio buttons in weaver

### DIFF
--- a/docassemble/ALWeaver/data/questions/template_validation.yml
+++ b/docassemble/ALWeaver/data/questions/template_validation.yml
@@ -406,13 +406,13 @@ fields:
   - Confirm the fields are filled in correctly: all_look_good
     datatype: checkboxes
     choices:
-      - All the checkboxes are checked: all_checkboxes_checked
+      - All the checkboxes are checked and at least one radio button in each group is selected: all_checkboxes_checked
       - The fonts and styles in the preview look okay OR I am comfortable fixing them later: no_unusual_size_text
         help: |
           While you may prefer to fix font size now, it will not change your experience
           with the Weaver. You can upload the fixed template to the Playground later.
       - All signature fields are filled in with the signature image: signature_filled_in
-    none of the above: False    
+    none of the above: False
 validation code: |
   checkboxes_msg = ''
   text_mst = ''

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -280,7 +280,14 @@ class DAField(DAObject):
             )
             self.variable_name_guess = name_no_suffix.replace("_", " ").capitalize()
         elif pdf_field_tuple[4] == "/Btn":
-            if str(self.export_value.lower()) in ['yes', 'true', 'on', 'no', 'false', 'off']:
+            if str(self.export_value.lower()) in [
+                "yes",
+                "true",
+                "on",
+                "no",
+                "false",
+                "off",
+            ]:
                 self.field_type_guess = "yesno"
             else:
                 self.field_type_guess = "multiple choice radio"
@@ -419,7 +426,9 @@ class DAField(DAObject):
                 "field": self.attr_name("choices"),
                 "datatype": "area",
                 "js show if": f"['multiple choice dropdown','multiple choice combobox','multiselect', 'multiple choice radio', 'multiple choice checkboxes'].includes(val('{ self.attr_name('field_type') }'))",
-                "default": "\n".join(self.choice_options) if hasattr(self, "choice_options") else None,
+                "default": "\n".join(self.choice_options)
+                if hasattr(self, "choice_options")
+                else None,
                 "hint": "Like 'Descriptive name: key_name', or just 'Descriptive name'",
             }
         )
@@ -685,7 +694,6 @@ class DAFieldList(DAList):
 
         self.delitem(*mark_to_remove)
         self.there_are_any = len(self.elements) > 0
-
 
     def consolidate_duplicate_fields(self, document_type: str = "pdf") -> None:
         """Removes all duplicate fields from a PDF (docx's are handled elsewhere) that really just
@@ -1964,10 +1972,12 @@ def reflect_fields(
     mapping = []
     for field in pdf_field_tuples:
         if field[4] == "/Btn":
-            if str(field[5]).lower() in ['yes', 'on', 'true']:
+            if str(field[5]).lower() in ["yes", "on", "true"]:
                 mapping.append({field[0]: "Yes"})
             else:
-                if field[0] not in [next(iter(field_val.keys())) for field_val in mapping]:
+                if field[0] not in [
+                    next(iter(field_val.keys())) for field_val in mapping
+                ]:
                     mapping.append({field[0]: field[5]})
         elif field[4] == "/Sig" and image_placeholder:
             mapping.append({field[0]: image_placeholder})

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -267,6 +267,7 @@ class DAField(DAObject):
         self.maxlength = get_character_limit(pdf_field_tuple)
         self.variable_name_guess = variable_name_guess
 
+        self.export_value = pdf_field_tuple[5]
         if self.variable.endswith("_date"):
             self.field_type_guess = "date"
             self.variable_name_guess = "Date of " + self.variable[:-5].replace("_", " ")
@@ -279,7 +280,11 @@ class DAField(DAObject):
             )
             self.variable_name_guess = name_no_suffix.replace("_", " ").capitalize()
         elif pdf_field_tuple[4] == "/Btn":
-            self.field_type_guess = "yesno"
+            if str(self.export_value.lower()) in ['yes', 'true', 'on', 'no', 'false', 'off']:
+                self.field_type_guess = "yesno"
+            else:
+                self.field_type_guess = "multiple choice radio"
+                self.choice_options = [self.export_value]
         elif pdf_field_tuple[4] == "/Sig":
             self.field_type_guess = "signature"
         elif self.maxlength and self.maxlength > 100:
@@ -414,6 +419,7 @@ class DAField(DAObject):
                 "field": self.attr_name("choices"),
                 "datatype": "area",
                 "js show if": f"['multiple choice dropdown','multiple choice combobox','multiselect', 'multiple choice radio', 'multiple choice checkboxes'].includes(val('{ self.attr_name('field_type') }'))",
+                "default": "\n".join(self.choice_options) if hasattr(self, "choice_options") else None,
                 "hint": "Like 'Descriptive name: key_name', or just 'Descriptive name'",
             }
         )
@@ -660,6 +666,27 @@ class DAFieldList(DAList):
         self.delitem(*mark_to_remove)
         self.there_are_any = len(self.elements) > 0
 
+    def consolidate_radios(self) -> None:
+        """Combines separate radio buttons into a single variable"""
+        radio_map: Dict[str, Any] = defaultdict(list)
+        mark_to_remove: List[int] = []
+        for idx, field in enumerate(self.elements):
+            if field.field_type_guess != "multiple choice radio":
+                continue
+
+            if len(radio_map[field.variable_name_guess]) > 0:
+                radio_map[field.variable_name_guess][0].choice_options.append(
+                    field.export_value
+                )
+            radio_map[field.variable_name_guess].append(field)
+
+            if len(radio_map[field.variable_name_guess]) > 1:
+                mark_to_remove.append(idx)
+
+        self.delitem(*mark_to_remove)
+        self.there_are_any = len(self.elements) > 0
+
+
     def consolidate_duplicate_fields(self, document_type: str = "pdf") -> None:
         """Removes all duplicate fields from a PDF (docx's are handled elsewhere) that really just
         represent a single variable, leaving one remaining field that writes all of the original vars
@@ -771,6 +798,7 @@ class DAFieldList(DAList):
                 if new_field.group in [DAFieldGroup.BUILT_IN, DAFieldGroup.RESERVED]:
                     new_field.label = new_field.variable_name_guess
 
+        self.consolidate_radios()
         self.consolidate_duplicate_fields(document_type)
         self.consolidate_yesnos()
 
@@ -1936,7 +1964,11 @@ def reflect_fields(
     mapping = []
     for field in pdf_field_tuples:
         if field[4] == "/Btn":
-            mapping.append({field[0]: "Yes"})
+            if str(field[5]).lower() in ['yes', 'on', 'true']:
+                mapping.append({field[0]: "Yes"})
+            else:
+                if field[0] not in [next(iter(field_val.keys())) for field_val in mapping]:
+                    mapping.append({field[0]: field[5]})
         elif field[4] == "/Sig" and image_placeholder:
             mapping.append({field[0]: image_placeholder})
         else:

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -267,7 +267,7 @@ class DAField(DAObject):
         self.maxlength = get_character_limit(pdf_field_tuple)
         self.variable_name_guess = variable_name_guess
 
-        self.export_value = pdf_field_tuple[5]
+        self.export_value = pdf_field_tuple[5] if len(pdf_field_tuple) >= 6 else ""
         if self.variable.endswith("_date"):
             self.field_type_guess = "date"
             self.variable_name_guess = "Date of " + self.variable[:-5].replace("_", " ")
@@ -287,6 +287,7 @@ class DAField(DAObject):
                 "no",
                 "false",
                 "off",
+                ""
             ]:
                 self.field_type_guess = "yesno"
             else:
@@ -1972,13 +1973,14 @@ def reflect_fields(
     mapping = []
     for field in pdf_field_tuples:
         if field[4] == "/Btn":
-            if str(field[5]).lower() in ["yes", "on", "true"]:
+            export_val = field[5] if len(field) >= 6 else ""
+            if str(export_val).lower() in ["yes", "on", "true", ""]:
                 mapping.append({field[0]: "Yes"})
             else:
                 if field[0] not in [
                     next(iter(field_val.keys())) for field_val in mapping
                 ]:
-                    mapping.append({field[0]: field[5]})
+                    mapping.append({field[0]: export_val})
         elif field[4] == "/Sig" and image_placeholder:
             mapping.append({field[0]: image_placeholder})
         else:

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -287,7 +287,7 @@ class DAField(DAObject):
                 "no",
                 "false",
                 "off",
-                ""
+                "",
             ]:
                 self.field_type_guess = "yesno"
             else:

--- a/docassemble/ALWeaver/test_fill_in_field_attributes.py
+++ b/docassemble/ALWeaver/test_fill_in_field_attributes.py
@@ -65,7 +65,14 @@ class test_fill_in_pdf_attributes(unittest.TestCase):
 
     def test_multiple_choice(self):
         # From an Adobe-Acrobat made radio button field
-        pdf_field_tuple = ("Group1", "No", 1, [162.9, 631.3, 180.9, 649.3], "/Btn", 'Choice3')
+        pdf_field_tuple = (
+            "Group1",
+            "No",
+            1,
+            [162.9, 631.3, 180.9, 649.3],
+            "/Btn",
+            "Choice3",
+        )
         new_field = DAField()
         new_field.fill_in_pdf_attributes(pdf_field_tuple)
         self.assertEqual(new_field.variable, "Group1")
@@ -73,7 +80,6 @@ class test_fill_in_pdf_attributes(unittest.TestCase):
         self.assertEqual(new_field.has_label, True)
         self.assertEqual(new_field.field_type_guess, "multiple choice radio")
         self.assertEqual(new_field.variable_name_guess, "Group1")
-
 
 
 if __name__ == "__main__":

--- a/docassemble/ALWeaver/test_fill_in_field_attributes.py
+++ b/docassemble/ALWeaver/test_fill_in_field_attributes.py
@@ -63,6 +63,18 @@ class test_fill_in_pdf_attributes(unittest.TestCase):
         self.assertEqual(new_field.field_type_guess, "signature")
         self.assertEqual(new_field.variable_name_guess, "Signature")
 
+    def test_multiple_choice(self):
+        # From an Adobe-Acrobat made radio button field
+        pdf_field_tuple = ("Group1", "No", 1, [162.9, 631.3, 180.9, 649.3], "/Btn", 'Choice3')
+        new_field = DAField()
+        new_field.fill_in_pdf_attributes(pdf_field_tuple)
+        self.assertEqual(new_field.variable, "Group1")
+        self.assertEqual(new_field.final_display_var, "Group1")
+        self.assertEqual(new_field.has_label, True)
+        self.assertEqual(new_field.field_type_guess, "multiple choice radio")
+        self.assertEqual(new_field.variable_name_guess, "Group1")
+
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
* fills in the first radio button in each group of buttons
  when asking the user to make sure we filled in value correctly
* recognizes radio buttons by their export value not being "yes" or "on"
* consolidates the duplicate entries that we get from the PDF reader
   into a single DAField
* default their input type to multiple choice radios,
  and gives their default values for choices

Fix https://github.com/SuffolkLITLab/docassemble-ALWeaver/issues/75.

Tested with [ExampleAdobePDF.pdf](https://github.com/SuffolkLITLab/docassemble-ALWeaver/files/10829211/ExampleAdobePDF.pdf)

can also make sure to test with:

* [radios.pdf](https://github.com/SuffolkLITLab/docassemble-ALWeaver/files/10829216/radios.pdf)
* [pdf-radio-buttons.pdf](https://github.com/SuffolkLITLab/docassemble-ALWeaver/files/10829217/pdf-radio-buttons.pdf)
* [pdf-radio-buttons2.pdf](https://github.com/SuffolkLITLab/docassemble-ALWeaver/files/10829219/pdf-radio-buttons2.pdf)

which were all of the PDFs that I tested https://github.com/jhpyle/docassemble/pull/619 on. Other PDFs to test with are welcome
