### PR TITLE
Correct logic for finding PDF field bbox

### DIFF
--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -156,7 +156,7 @@ def get_character_limit(pdf_field_tuple, char_width=6, row_height=12) -> Optiona
     3: vertical end
     """
     # Make sure it's the right kind of tuple
-    if len(pdf_field_tuple) < 3 or (pdf_field_tuple[3] and len(pdf_field_tuple[3]) < 4):
+    if len(pdf_field_tuple) < 4 or not pdf_field_tuple[3] or len(pdf_field_tuple[3]) < 4:
         return None  # we can't really guess
 
     # Did a little testing for typical field width/number of chars with both w and e.


### PR DESCRIPTION
Our code in get_character_limit had an off by one error, and had some bad nesting of conditionals when checking for the PDF bounding box in the tuple. Breaks when the bounding box info is just an empty list.

The PDF that revealed the issue:

[RFA-complaint-downsized.pdf](https://github.com/SuffolkLITLab/docassemble-ALWeaver/files/10962249/RFA-complaint-downsized.pdf)
