### PR TITLE
Idempotency & multiple session module issue fixed

### DIFF
--- a/docassemble/ALWeaver/custom_values.py
+++ b/docassemble/ALWeaver/custom_values.py
@@ -6,17 +6,6 @@ from packaging.version import Version
 from more_itertools import unique_everseen
 
 
-################# To refactor - I don't think these are used but they are mentioned in interview_generator.py
-class CustomValues(object):
-    people_plurals_map: Dict[str, str]
-    org_specific_config: Any
-
-
-custom_values = CustomValues()
-custom_values.people_plurals_map = {}
-custom_values.org_specific_config = None
-########################## End to refactor
-
 __all__ = [
     "get_possible_deps_as_choices",
     "get_pypi_deps_from_choices",

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -285,9 +285,6 @@ validation code: |
         validation_error("Unable to convert DOCX file to PDF. It may be an invalid file.")
 ---
 code: |
-  # TODO: refactor to use the new config system
-  set_custom_people_map( people_variables.true_values() )  
-
   if len(people_variables.true_values()):
     interview.all_fields.mark_people_as_builtins(people_variables.true_values())
   process_people_variables = True

--- a/docassemble/ALWeaver/data/templates/output.mako
+++ b/docassemble/ALWeaver/data/templates/output.mako
@@ -150,7 +150,7 @@ code: |
   ${ interview.interview_label }_preview_question
   basic_questions_signature_flow    
   % for signature_field in interview.all_fields.signatures():
-  ${ signature_field.trigger_gather() }
+  ${ signature_field.trigger_gather(interview.all_fields.custom_people_plurals) }
   % endfor
   % endif
   ${ interview.interview_label }_download
@@ -227,7 +227,7 @@ continue button field: ${ interview.interview_label }_preview_question
 % if generate_download_screen:
 ---
 code: |
-  signature_fields = ${ str(list(interview.all_fields.built_in_signature_triggers()) + [field.trigger_gather() for field in interview.all_fields.signatures()] ) }
+  signature_fields = ${ str(list(interview.all_fields.built_in_signature_triggers()) + [field.trigger_gather(interview.all_fields.custom_people_plurals) for field in interview.all_fields.signatures()] ) }
 % endif
 % for field in interview.all_fields.skip_fields():
 ---

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -453,7 +453,7 @@ class DAField(DAObject):
 
     def trigger_gather(
         self,
-        custom_plurals: Iterable[str],
+        custom_plurals: Optional[Iterable[str]]=None,
         reserved_whole_words=generator_constants.RESERVED_WHOLE_WORDS,
         undefined_person_prefixes=generator_constants.UNDEFINED_PERSON_PREFIXES,
         reserved_pluralizers_map=generator_constants.RESERVED_PLURALIZERS_MAP,

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -254,8 +254,9 @@ class DAField(DAObject):
         else:
             self.field_type_guess = "text"
 
-    def fill_in_pdf_attributes(self, pdf_field_tuple: Any,
-        custom_plurals: Dict[str, str]) -> None:
+    def fill_in_pdf_attributes(
+        self, pdf_field_tuple: Any, custom_plurals: Dict[str, str]
+    ) -> None:
         """Let's guess the type of each field from the name / info from PDF"""
         if not custom_plurals:
             custom_plurals = {}
@@ -266,7 +267,9 @@ class DAField(DAObject):
             varname(self.raw_field_names[0])
         )
         # the variable, in python: i.e., users[1].name.first
-        self.final_display_var = map_raw_to_final_display(self.variable, custom_people_plurals_map=custom_plurals)
+        self.final_display_var = map_raw_to_final_display(
+            self.variable, custom_people_plurals_map=custom_plurals
+        )
 
         variable_name_guess = self.variable.replace("_", " ").capitalize()
         self.has_label = True
@@ -453,7 +456,7 @@ class DAField(DAObject):
 
     def trigger_gather(
         self,
-        custom_plurals: Optional[Iterable[str]]=None,
+        custom_plurals: Optional[Iterable[str]] = None,
         reserved_whole_words=generator_constants.RESERVED_WHOLE_WORDS,
         undefined_person_prefixes=generator_constants.UNDEFINED_PERSON_PREFIXES,
         reserved_pluralizers_map=generator_constants.RESERVED_PLURALIZERS_MAP,
@@ -461,7 +464,7 @@ class DAField(DAObject):
         """Turn the docassemble variable string into an expression
         that makes DA ask a question for it. This is mostly
         calling `gather()` for lists
-        
+
         Args:
           custom_plurals: a list of variables strs that users have marked as being lists of people
         """
@@ -488,8 +491,7 @@ class DAField(DAObject):
         # The prefix, ensuring no key or index
         prefix = re.sub(r"\[.+\]", "", var_parts[0][0])
         has_plural_prefix = (
-            prefix in reserved_pluralizers_map.values()
-            or prefix in custom_plurals
+            prefix in reserved_pluralizers_map.values() or prefix in custom_plurals
         )
         has_singular_prefix = prefix in undefined_person_prefixes
 
@@ -572,8 +574,7 @@ class DAField(DAObject):
         prefix = re.sub(r"\[.+\]", "", indexed_var)
 
         has_plural_prefix = (
-            prefix in reserved_pluralizers_map.values()
-            or prefix in custom_plurals
+            prefix in reserved_pluralizers_map.values() or prefix in custom_plurals
         )
         if has_plural_prefix:
             return prefix, "list"
@@ -598,7 +599,13 @@ class ParentCollection(object):
     The parent collection is useful for review screens, where we want to group related fields
     """
 
-    def __init__(self, var_name: str, var_type: str, fields: List[DAField], custom_plurals:Iterable[str]):
+    def __init__(
+        self,
+        var_name: str,
+        var_type: str,
+        fields: List[DAField],
+        custom_plurals: Iterable[str],
+    ):
         """Constructor:
         @param var_name: the name of this parent collection variable
         @param var_type: the type of this parent collection variable. Can be 'list', 'object', or 'primitive'
@@ -650,7 +657,9 @@ confirm: True
 
     def full_display(self) -> str:
         settable_var = self.fields[0].get_settable_var()
-        parent_var = DAField._get_parent_variable(settable_var, custom_plurals=self.custom_plurals)[0]
+        parent_var = DAField._get_parent_variable(
+            settable_var, custom_plurals=self.custom_plurals
+        )[0]
         # NOTE: we rely on the "stock" full_display map here
         return substitute_suffix(parent_var)
 
@@ -663,7 +672,9 @@ class DAFieldList(DAList):
         self.object_type = DAField
         self.auto_gather = False
         self.complete_attribute = "complete"
-        self.initializeAttribute("custom_people_plurals", DADict.using(auto_gather=False, gathered=True))
+        self.initializeAttribute(
+            "custom_people_plurals", DADict.using(auto_gather=False, gathered=True)
+        )
 
     def __str__(self) -> str:
         return docassemble.base.functions.comma_and_list(
@@ -737,11 +748,19 @@ class DAFieldList(DAList):
         """Gets all of the individual ParentCollections from the DAFields in this list."""
         parent_coll_map = defaultdict(list)
         for field in self.elements:
-            parent_var_and_type = DAField._get_parent_variable(field.final_display_var, custom_plurals=self.custom_people_plurals.values())
+            parent_var_and_type = DAField._get_parent_variable(
+                field.final_display_var,
+                custom_plurals=self.custom_people_plurals.values(),
+            )
             parent_coll_map[parent_var_and_type].append(field)
 
         return [
-            ParentCollection(var_and_type[0], var_and_type[1], fields, self.custom_people_plurals.values())
+            ParentCollection(
+                var_and_type[0],
+                var_and_type[1],
+                fields,
+                self.custom_people_plurals.values(),
+            )
             for var_and_type, fields in parent_coll_map.items()
         ]
 
@@ -805,7 +824,9 @@ class DAFieldList(DAList):
 
                 # This function determines what type of variable
                 # we're dealing with
-                new_field.fill_in_pdf_attributes(pdf_field_tuple, self.custom_people_plurals)
+                new_field.fill_in_pdf_attributes(
+                    pdf_field_tuple, self.custom_people_plurals
+                )
                 if new_field.group == DAFieldGroup.BUILT_IN:
                     new_field.label = new_field.variable_name_guess
         else:
@@ -881,8 +902,8 @@ class DAFieldList(DAList):
             file_type = field.source_document_type
             if file_type == "pdf":
                 # map_raw_to_final_display will only transform names that are built-in to the constants
-                field_to_check = map_raw_to_final_display(field.variable, 
-                        custom_people_plurals_map=self.custom_people_plurals
+                field_to_check = map_raw_to_final_display(
+                    field.variable, custom_people_plurals_map=self.custom_people_plurals
                 )
             else:
                 field_to_check = field.variable
@@ -942,7 +963,9 @@ class DAFieldList(DAList):
             generator_constants.PEOPLE_SUFFIXES + generator_constants.DOCX_ONLY_SUFFIXES
         ),
     ) -> None:
-        self.custom_people_plurals = {var_name: var_name for var_name in list(people_list)}
+        self.custom_people_plurals = {
+            var_name: var_name for var_name in list(people_list)
+        }
         """Scan the list of fields and see if any of them should be renamed
         or marked as built-ins given the list of new, custom prefixes."""
         for field in self:
@@ -956,7 +979,7 @@ class DAFieldList(DAList):
                         field.variable,
                         document_type=field.source_document_type,
                         reserved_prefixes=people_list,
-                        custom_people_plurals_map=self.custom_people_plurals
+                        custom_people_plurals_map=self.custom_people_plurals,
                     )
                     if new_potential_name != field.variable:
                         field.final_display_var = new_potential_name
@@ -1009,7 +1032,9 @@ class DAFieldList(DAList):
         return [
             field.trigger_gather(custom_plurals=self.custom_people_plurals.values())
             for field in self.builtins()
-            if field.trigger_gather(custom_plurals=self.custom_people_plurals.values()).endswith(".signature")
+            if field.trigger_gather(
+                custom_plurals=self.custom_people_plurals.values()
+            ).endswith(".signature")
         ]
 
     def signatures(self) -> List[DAField]:
@@ -1165,10 +1190,16 @@ class DAQuestionList(DAList):
                 if question.needs_continue_button_field:
                     logic_list.append(varname(question.question_text))
                 else:
-                    logic_list.append(question.field_list[0].trigger_gather(custom_plurals=all_fields.custom_people_plurals.values()))
+                    logic_list.append(
+                        question.field_list[0].trigger_gather(
+                            custom_plurals=all_fields.custom_people_plurals.values()
+                        )
+                    )
             else:
                 # it's a built-in field OR a signature, not a question block
-                trigger_gather = question.trigger_gather(custom_plurals=all_fields.custom_people_plurals.values())
+                trigger_gather = question.trigger_gather(
+                    custom_plurals=all_fields.custom_people_plurals.values()
+                )
                 if not (
                     question in all_fields.builtins()
                     and trigger_gather.endswith(".signature")
@@ -1616,7 +1647,7 @@ def map_raw_to_final_display(
     label: str,
     document_type: str = "pdf",
     reserved_whole_words=generator_constants.RESERVED_WHOLE_WORDS,
-    custom_people_plurals_map:Optional[Dict[str, str]]=None,
+    custom_people_plurals_map: Optional[Dict[str, str]] = None,
     reserved_prefixes=generator_constants.RESERVED_PREFIXES,
     undefined_person_prefixes=generator_constants.UNDEFINED_PERSON_PREFIXES,
     reserved_pluralizers_map=generator_constants.RESERVED_PLURALIZERS_MAP,

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -1,4 +1,4 @@
-from .custom_values import custom_values, get_matching_deps
+from .custom_values import get_matching_deps
 from .generator_constants import generator_constants
 from .validate_template_files import matching_reserved_names
 from collections import defaultdict
@@ -81,7 +81,6 @@ __all__ = [
     "pdf_field_type_str",
     "reflect_fields",
     "remove_multiple_appearance_indicator",
-    "set_custom_people_map",
     "to_yaml_file",
     "using_string",
     "varname",
@@ -255,8 +254,11 @@ class DAField(DAObject):
         else:
             self.field_type_guess = "text"
 
-    def fill_in_pdf_attributes(self, pdf_field_tuple: Any) -> None:
+    def fill_in_pdf_attributes(self, pdf_field_tuple: Any,
+        custom_plurals: Dict[str, str]) -> None:
         """Let's guess the type of each field from the name / info from PDF"""
+        if not custom_plurals:
+            custom_plurals = {}
         # The raw name of the field from the PDF: must go in attachment block
         self.raw_field_names = [pdf_field_tuple[0]]
         # turns field_name into a valid python identifier: must be one per field
@@ -264,7 +266,7 @@ class DAField(DAObject):
             varname(self.raw_field_names[0])
         )
         # the variable, in python: i.e., users[1].name.first
-        self.final_display_var = map_raw_to_final_display(self.variable)
+        self.final_display_var = map_raw_to_final_display(self.variable, custom_people_plurals_map=custom_plurals)
 
         variable_name_guess = self.variable.replace("_", " ").capitalize()
         self.has_label = True
@@ -451,21 +453,27 @@ class DAField(DAObject):
 
     def trigger_gather(
         self,
-        custom_people_plurals_map=custom_values.people_plurals_map,
+        custom_plurals: Iterable[str],
         reserved_whole_words=generator_constants.RESERVED_WHOLE_WORDS,
         undefined_person_prefixes=generator_constants.UNDEFINED_PERSON_PREFIXES,
         reserved_pluralizers_map=generator_constants.RESERVED_PLURALIZERS_MAP,
     ):
         """Turn the docassemble variable string into an expression
         that makes DA ask a question for it. This is mostly
-        calling `gather()` for lists"""
+        calling `gather()` for lists
+        
+        Args:
+          custom_plurals: a list of variables strs that users have marked as being lists of people
+        """
         GATHER_CALL = ".gather()"
+        if not custom_plurals:
+            custom_plurals = []
         if self.final_display_var in reserved_whole_words:
             return self.final_display_var
 
         if (
             self.final_display_var in reserved_pluralizers_map.values()
-            or self.final_display_var in custom_people_plurals_map.values()
+            or self.final_display_var in custom_plurals
         ):
             return self.final_display_var + GATHER_CALL
 
@@ -481,7 +489,7 @@ class DAField(DAObject):
         prefix = re.sub(r"\[.+\]", "", var_parts[0][0])
         has_plural_prefix = (
             prefix in reserved_pluralizers_map.values()
-            or prefix in custom_people_plurals_map.values()
+            or prefix in custom_plurals
         )
         has_singular_prefix = prefix in undefined_person_prefixes
 
@@ -543,7 +551,7 @@ class DAField(DAObject):
     @staticmethod
     def _get_parent_variable(
         var_with_attribute: str,
-        custom_people_plurals_map=custom_values.people_plurals_map,
+        custom_plurals: Iterable[str],
         undefined_person_prefixes=generator_constants.UNDEFINED_PERSON_PREFIXES,
         reserved_pluralizers_map=generator_constants.RESERVED_PLURALIZERS_MAP,
     ) -> Tuple[str, str]:
@@ -551,6 +559,8 @@ class DAField(DAObject):
         as what type the object is
         For example, `users[0].name` and `users[1].name.last` will both return `users`.
         """
+        if not custom_plurals:
+            custom_plurals = []
         var_parts = re.findall(r"([^.]+)(\.[^.]*)?", var_with_attribute)
         if not var_parts:
             return var_with_attribute, "not var"
@@ -563,11 +573,12 @@ class DAField(DAObject):
 
         has_plural_prefix = (
             prefix in reserved_pluralizers_map.values()
-            or prefix in custom_people_plurals_map.values()
+            or prefix in custom_plurals
         )
-        has_singular_prefix = prefix in undefined_person_prefixes
         if has_plural_prefix:
             return prefix, "list"
+
+        has_singular_prefix = prefix in undefined_person_prefixes
         if has_singular_prefix:
             return prefix, "object"
         return var_with_attribute, "primitive"
@@ -587,7 +598,7 @@ class ParentCollection(object):
     The parent collection is useful for review screens, where we want to group related fields
     """
 
-    def __init__(self, var_name: str, var_type: str, fields: List[DAField]):
+    def __init__(self, var_name: str, var_type: str, fields: List[DAField], custom_plurals:Iterable[str]):
         """Constructor:
         @param var_name: the name of this parent collection variable
         @param var_type: the type of this parent collection variable. Can be 'list', 'object', or 'primitive'
@@ -597,6 +608,7 @@ class ParentCollection(object):
         self.fields = fields
         self.attribute_map = {}
         self.var_type = var_type
+        self.custom_plurals = custom_plurals
         # this base var is more complex than a simple primitive type
         if self.var_type != "primitive":
             for field in self.fields:
@@ -638,7 +650,7 @@ confirm: True
 
     def full_display(self) -> str:
         settable_var = self.fields[0].get_settable_var()
-        parent_var = DAField._get_parent_variable(settable_var)[0]
+        parent_var = DAField._get_parent_variable(settable_var, custom_plurals=self.custom_plurals)[0]
         # NOTE: we rely on the "stock" full_display map here
         return substitute_suffix(parent_var)
 
@@ -651,6 +663,7 @@ class DAFieldList(DAList):
         self.object_type = DAField
         self.auto_gather = False
         self.complete_attribute = "complete"
+        self.initializeAttribute("custom_people_plurals", DADict.using(auto_gather=False, gathered=True))
 
     def __str__(self) -> str:
         return docassemble.base.functions.comma_and_list(
@@ -724,11 +737,11 @@ class DAFieldList(DAList):
         """Gets all of the individual ParentCollections from the DAFields in this list."""
         parent_coll_map = defaultdict(list)
         for field in self.elements:
-            parent_var_and_type = DAField._get_parent_variable(field.final_display_var)
+            parent_var_and_type = DAField._get_parent_variable(field.final_display_var, custom_plurals=self.custom_people_plurals.values())
             parent_coll_map[parent_var_and_type].append(field)
 
         return [
-            ParentCollection(var_and_type[0], var_and_type[1], fields)
+            ParentCollection(var_and_type[0], var_and_type[1], fields, self.custom_people_plurals.values())
             for var_and_type, fields in parent_coll_map.items()
         ]
 
@@ -779,7 +792,7 @@ class DAFieldList(DAList):
                     ):
                         continue
 
-                new_field = self.appendObject()
+                new_field: DAField = self.appendObject()
                 new_field.source_document_type = "pdf"
 
                 # Built-in fields and signatures don't get custom questions written
@@ -792,7 +805,7 @@ class DAFieldList(DAList):
 
                 # This function determines what type of variable
                 # we're dealing with
-                new_field.fill_in_pdf_attributes(pdf_field_tuple)
+                new_field.fill_in_pdf_attributes(pdf_field_tuple, self.custom_people_plurals)
                 if new_field.group == DAFieldGroup.BUILT_IN:
                     new_field.label = new_field.variable_name_guess
         else:
@@ -865,12 +878,13 @@ class DAFieldList(DAList):
         people = set()
         for field in self:
             # fields are currently tuples for PDF and strings for docx
-            if field.source_document_type == "pdf":
-                file_type = "pdf"
+            file_type = field.source_document_type
+            if file_type == "pdf":
                 # map_raw_to_final_display will only transform names that are built-in to the constants
-                field_to_check = map_raw_to_final_display(field.variable)
+                field_to_check = map_raw_to_final_display(field.variable, 
+                        custom_people_plurals_map=self.custom_people_plurals
+                )
             else:
-                file_type = "docx"
                 field_to_check = field.variable
             # Exact match
             if (field_to_check) in people_vars:
@@ -928,6 +942,7 @@ class DAFieldList(DAList):
             generator_constants.PEOPLE_SUFFIXES + generator_constants.DOCX_ONLY_SUFFIXES
         ),
     ) -> None:
+        self.custom_people_plurals = {var_name: var_name for var_name in list(people_list)}
         """Scan the list of fields and see if any of them should be renamed
         or marked as built-ins given the list of new, custom prefixes."""
         for field in self:
@@ -941,6 +956,7 @@ class DAFieldList(DAList):
                         field.variable,
                         document_type=field.source_document_type,
                         reserved_prefixes=people_list,
+                        custom_people_plurals_map=self.custom_people_plurals
                     )
                     if new_potential_name != field.variable:
                         field.final_display_var = new_potential_name
@@ -991,9 +1007,9 @@ class DAFieldList(DAList):
 
     def built_in_signature_triggers(self) -> List[str]:
         return [
-            field.trigger_gather()
+            field.trigger_gather(custom_plurals=self.custom_people_plurals.values())
             for field in self.builtins()
-            if field.trigger_gather().endswith(".signature")
+            if field.trigger_gather(custom_plurals=self.custom_people_plurals.values()).endswith(".signature")
         ]
 
     def signatures(self) -> List[DAField]:
@@ -1108,19 +1124,17 @@ class DAQuestionList(DAList):
 
     def interview_order_list(
         self,
-        all_fields,
-        screens: Optional[List["DAQuestion"]] = None,
+        all_fields: DAFieldList,
+        screens: Optional[List[Union["DAQuestion", "DAField"]]] = None,
         sections: Optional[List] = None,
         set_progress=True,
     ) -> List[str]:
         """
         Creates a list of fields for use in creating an interview order block.
-        Fairly opinionated/tied to current expectations of AssemblyLine:
-
-        1.
+        Fairly opinionated/tied to current expectations of AssemblyLine.
         """
         if not screens:
-            screens = self
+            screens = list(self)
 
         logic_list = []
 
@@ -1151,19 +1165,20 @@ class DAQuestionList(DAList):
                 if question.needs_continue_button_field:
                     logic_list.append(varname(question.question_text))
                 else:
-                    logic_list.append(question.field_list[0].trigger_gather())
+                    logic_list.append(question.field_list[0].trigger_gather(custom_plurals=all_fields.custom_people_plurals.values()))
             else:
                 # it's a built-in field OR a signature, not a question block
+                trigger_gather = question.trigger_gather(custom_plurals=all_fields.custom_people_plurals.values())
                 if not (
                     question in all_fields.builtins()
-                    and question.trigger_gather().endswith(".signature")
+                    and trigger_gather.endswith(".signature")
                 ):
-                    logic_list.append(question.trigger_gather())
+                    logic_list.append(trigger_gather)
                     # set the saved answer name so it includes the user's name in saved
                     # answer list
                     # NOTE: this is redundant now that we have a custom interview list, but leaving for now
                     if (
-                        question.trigger_gather() == "users.gather()"
+                        trigger_gather == "users.gather()"
                         and not saved_answer_name_flag
                     ):
                         logic_list.append("set_parts(subtitle=str(users))")
@@ -1601,7 +1616,7 @@ def map_raw_to_final_display(
     label: str,
     document_type: str = "pdf",
     reserved_whole_words=generator_constants.RESERVED_WHOLE_WORDS,
-    custom_people_plurals_map=custom_values.people_plurals_map,
+    custom_people_plurals_map:Optional[Dict[str, str]]=None,
     reserved_prefixes=generator_constants.RESERVED_PREFIXES,
     undefined_person_prefixes=generator_constants.UNDEFINED_PERSON_PREFIXES,
     reserved_pluralizers_map=generator_constants.RESERVED_PLURALIZERS_MAP,
@@ -1610,6 +1625,8 @@ def map_raw_to_final_display(
     """For a given set of specific cases, transform a
     PDF field name into a standardized object name
     that will be the value for the attachment field."""
+    if not custom_people_plurals_map:
+        custom_people_plurals_map = {}
     if document_type.lower() == "docx" or "." in label:
         return label  # don't transform DOCX variables
 
@@ -1796,15 +1813,6 @@ def get_reserved_label_parts(prefixes: list, label: str):
     like user1_something, etc.
     """
     return re.search(r"^(" + "|".join(prefixes) + ")(\d*)(.*)", label)
-
-
-# TODO: this doesn't have a purpose yet. Need to refactor to
-# use the new config system
-def set_custom_people_map(people_var_names: Dict[str, str]):
-    """Sets the map of custom people created by the developer."""
-    for var_name in people_var_names:
-        custom_values.people_plurals_map[var_name] = var_name
-    return custom_values.people_plurals_map
 
 
 def using_string(params: dict, elements_as_variable_list: bool = False) -> str:

--- a/docassemble/ALWeaver/test_fill_in_field_attributes.py
+++ b/docassemble/ALWeaver/test_fill_in_field_attributes.py
@@ -6,7 +6,7 @@ class test_fill_in_pdf_attributes(unittest.TestCase):
     def test_simple_pdf_field(self):
         pdf_field_tuple = ("field_name", "default text", 0, [10, 10, 100, 30], "/Tx")
         new_field = DAField()
-        new_field.fill_in_pdf_attributes(pdf_field_tuple)
+        new_field.fill_in_pdf_attributes(pdf_field_tuple, {})
         self.assertEqual(new_field.variable, "field_name")
         self.assertEqual(new_field.final_display_var, "field_name")
         self.assertEqual(new_field.has_label, True)
@@ -16,7 +16,7 @@ class test_fill_in_pdf_attributes(unittest.TestCase):
     def test_date_field(self):
         pdf_field_tuple = ("birth_date", "", 0, [10, 10, 100, 30], "/Tx")
         new_field = DAField()
-        new_field.fill_in_pdf_attributes(pdf_field_tuple)
+        new_field.fill_in_pdf_attributes(pdf_field_tuple, {})
         self.assertEqual(new_field.variable, "birth_date")
         self.assertEqual(new_field.final_display_var, "birth_date")
         self.assertEqual(new_field.has_label, True)
@@ -26,7 +26,7 @@ class test_fill_in_pdf_attributes(unittest.TestCase):
     def test_yes_text_field(self):
         pdf_field_tuple = ("has_ssn_yes", "", 0, [10, 10, 100, 30], "/Tx")
         new_field = DAField()
-        new_field.fill_in_pdf_attributes(pdf_field_tuple)
+        new_field.fill_in_pdf_attributes(pdf_field_tuple, {})
         self.assertEqual(new_field.variable, "has_ssn_yes")
         self.assertEqual(new_field.final_display_var, "has_ssn_yes")
         self.assertEqual(new_field.has_label, True)
@@ -36,7 +36,7 @@ class test_fill_in_pdf_attributes(unittest.TestCase):
     def test_no_text_field(self):
         pdf_field_tuple = ("has_ssn_no", "", 0, [10, 10, 100, 30], "/Tx")
         new_field = DAField()
-        new_field.fill_in_pdf_attributes(pdf_field_tuple)
+        new_field.fill_in_pdf_attributes(pdf_field_tuple, {})
         self.assertEqual(new_field.variable, "has_ssn_no")
         self.assertEqual(new_field.final_display_var, "has_ssn_no")
         self.assertEqual(new_field.has_label, True)
@@ -46,7 +46,7 @@ class test_fill_in_pdf_attributes(unittest.TestCase):
     def test_yesno_btn_field(self):
         pdf_field_tuple = ("has_ssn", "", 0, [10, 10, 100, 30], "/Btn")
         new_field = DAField()
-        new_field.fill_in_pdf_attributes(pdf_field_tuple)
+        new_field.fill_in_pdf_attributes(pdf_field_tuple, {})
         self.assertEqual(new_field.variable, "has_ssn")
         self.assertEqual(new_field.final_display_var, "has_ssn")
         self.assertEqual(new_field.has_label, True)
@@ -56,7 +56,7 @@ class test_fill_in_pdf_attributes(unittest.TestCase):
     def test_sig_field(self):
         pdf_field_tuple = ("signature", "", 0, [10, 10, 100, 30], "/Sig")
         new_field = DAField()
-        new_field.fill_in_pdf_attributes(pdf_field_tuple)
+        new_field.fill_in_pdf_attributes(pdf_field_tuple, {})
         self.assertEqual(new_field.variable, "signature")
         self.assertEqual(new_field.final_display_var, "signature")
         self.assertEqual(new_field.has_label, True)
@@ -74,7 +74,7 @@ class test_fill_in_pdf_attributes(unittest.TestCase):
             "Choice3",
         )
         new_field = DAField()
-        new_field.fill_in_pdf_attributes(pdf_field_tuple)
+        new_field.fill_in_pdf_attributes(pdf_field_tuple, {})
         self.assertEqual(new_field.variable, "Group1")
         self.assertEqual(new_field.final_display_var, "Group1")
         self.assertEqual(new_field.has_label, True)

--- a/docassemble/ALWeaver/test_pdf_files.py
+++ b/docassemble/ALWeaver/test_pdf_files.py
@@ -45,7 +45,9 @@ class test_pdfs(unittest.TestCase):
         )
 
     def test_person_candidates(self):
-        push_button_pdf = Path(__file__).parent / "data/sources/test_civil_docketing_statement.pdf"
+        push_button_pdf = (
+            Path(__file__).parent / "data/sources/test_civil_docketing_statement.pdf"
+        )
         docassemble.base.functions.this_thread.current_question = type("", (), {})
         docassemble.base.functions.this_thread.current_question.package = "ALWeaver"
         da_pdf = MockDAStaticFile(
@@ -60,8 +62,6 @@ class test_pdfs(unittest.TestCase):
         fields.add_fields_from_file(da_pdf)
         fields.gathered = True
         self.assertIn("decision_maker", fields.get_person_candidates(custom_only=True))
-
-
 
 
 if __name__ == "__main__":

--- a/docassemble/ALWeaver/test_pdf_files.py
+++ b/docassemble/ALWeaver/test_pdf_files.py
@@ -44,6 +44,25 @@ class test_pdfs(unittest.TestCase):
             len(bad_fields), 0, f"Bad fields in test_push_button.pdf: {bad_fields}"
         )
 
+    def test_person_candidates(self):
+        push_button_pdf = Path(__file__).parent / "data/sources/test_civil_docketing_statement.pdf"
+        docassemble.base.functions.this_thread.current_question = type("", (), {})
+        docassemble.base.functions.this_thread.current_question.package = "ALWeaver"
+        da_pdf = MockDAStaticFile(
+            full_path=str(push_button_pdf), extension="pdf", mimetype="application/pdf"
+        )
+        fields = DAFieldList()
+        fields.add_fields_from_file(da_pdf)
+        fields.gathered = True
+        self.assertIn("decision_maker", fields.get_person_candidates(custom_only=True))
+        fields.mark_people_as_builtins(["decision_maker"])
+        fields = DAFieldList()
+        fields.add_fields_from_file(da_pdf)
+        fields.gathered = True
+        self.assertIn("decision_maker", fields.get_person_candidates(custom_only=True))
+
+
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Remove `custom_values`, and replace it with DAFieldList.custom_people_plurals,
passing it through to all of the functions necessary.

Fixes #559.

Tested with multiple simultaneous sessions, and manually going through and making sure the final interview handles the custom plural person variables right.