### PR TITLE
One fewer pdf_concatenate to sit through

### DIFF
--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -39,7 +39,6 @@ code: |
           process_field_normalization
         initial_get_fields
         validate_field_names
-        validate_pdf
         if no_recognized_pdf_fields:
           warn_no_recognized_al_labels
         fields_checkup_status

--- a/docassemble/ALWeaver/data/questions/template_validation.yml
+++ b/docassemble/ALWeaver/data/questions/template_validation.yml
@@ -474,18 +474,6 @@ attachment:
   code: |
     reflect_fields(interview.uploaded_templates[0].get_pdf_fields(), placeholder_signature)
 ---
-code: |
-  from pdfminer.pdfparser import PDFSyntaxError
-  
-  try:
-    pdf_concatenate(interview.uploaded_templates)
-  except PDFSyntaxError:
-    # Handle PDF read error
-    force_ask('exit_invalid_pdf')
-  except:
-    pass # Continue on to safer checks with get_pdf_fields
-  validate_pdf = True
----
 ###################### DOCX validation stuff #############################
 ---
 code: |


### PR DESCRIPTION
This particular `pdf_concatenate` is now redundant, and can be removed. 