### PR TITLE
Add namechange questions

### DIFF
--- a/docassemble/ALWeaver/data/questions/template_validation.yml
+++ b/docassemble/ALWeaver/data/questions/template_validation.yml
@@ -388,7 +388,7 @@ help:
   label: Debug Info
   content: |
     % for field in interview.all_fields:
-    * ${field}
+    * ${field} | ${ field.final_display_var } | ${ field.trigger_gather() }
     % endfor
 terms:
   - reserved: |

--- a/docassemble/ALWeaver/data/templates/output.mako
+++ b/docassemble/ALWeaver/data/templates/output.mako
@@ -410,3 +410,49 @@ code: |
 <%doc>
     End optional blocks related to attachments (if generating a file as output)
 </%doc>
+<%doc>
+  HACK: add the name change questions directly to the Weaver output for now. See https://github.com/SuffolkLITLab/docassemble-AssemblyLine/pull/668#discussion_r1149774674
+  We need a more generalized way to do this in the future but this can get us through LIT Con
+</%doc>
+% if showifdef("add_name_change_questions"):
+---
+id: consent of parent 1
+question: |
+  Do you consent to ${ children[0].preferred_name }'s name change?
+fields:
+  - I consent: users[0].consented_to_name_change
+    datatype: yesnoradio
+---
+id: consent of parent 1
+question: |
+  Does ${ users[1] } consent to ${ children[0].preferred_name }'s name change?
+fields:
+  - ${ users[1] } consents: users[0].consented_to_name_change
+    datatype: yesnoradio
+---
+id: consent of parent 1 attached
+question: |
+  Is your consent attached?
+fields:
+  - My consent is attached: users[0].parent_consent_attached
+    datatype: yesnoradio
+  - Why not?: users[0].no_consent_attached_explanation
+    datatype: area
+    rows: 2
+    show if:
+      variable: users[0].parent_consent_attached
+      is: False
+---
+id: consent of parent 2 attached
+question: |
+  Is ${ users[1] }'s consent attached?
+fields:
+  - ${ users[1] }'s consent is attached: users[0].parent_consent_attached
+    datatype: yesnoradio
+  - Why not?: users[1].no_consent_attached_explanation
+    datatype: area
+    rows: 2
+    show if:
+      variable: users[1].parent_consent_attached
+      is: False
+% endif

--- a/docassemble/ALWeaver/generator_constants.py
+++ b/docassemble/ALWeaver/generator_constants.py
@@ -213,6 +213,45 @@ generator_constants.PEOPLE_SUFFIXES_MAP = {
     "_mailing_address_city_state_zip": ".mailing_address.line_two()",
     "_mailing_address_line_two": ".mailing_address.line_two()",
     "_mailing_address": ".mailing_address",
+    "_preferred_name": ".preferred_name",
+    "_preferred_name_full": ".preferred_name",
+    "_preferred_name_first": ".preferred_name.first",
+    "_preferred_name_middle": ".preferred_name.middle",
+    "_preferred_name_last": ".preferred_name.last",
+    "_preferred_name_suffix": ".preferred_name.suffix",
+    "_previous_names1": ".previous_names[0]", # HACK for LIT Con 2023: we don't have a way to say an attribute is a list yet. 
+    "_previous_names1_full": ".previous_names[0]",
+    "_previous_names1_first": ".previous_names[0].first",
+    "_previous_names1_middle": ".previous_names[0].middle",
+    "_previous_names1_last": ".previous_names[0].last",
+    "_previous_names1_suffix": ".previous_names[0].suffix",
+    "_previous_names2": ".previous_names[1]",
+    "_previous_names2_full": ".previous_names[1]",
+    "_previous_names2_first": ".previous_names[1].first",
+    "_previous_names2_middle": ".previous_names[1].middle",
+    "_previous_names2_last": ".previous_names[1].last",
+    "_previous_names2_suffix": ".previous_names[1].suffix",
+    "_previous_names3": ".previous_names[2]",
+    "_previous_names3_full": ".previous_names[2]",
+    "_previous_names3_first": ".previous_names[2].first",
+    "_previous_names3_middle": ".previous_names[2].middle",
+    "_previous_names3_last": ".previous_names[2].last",
+    "_previous_names3_suffix": ".previous_names[2].suffix",
+    "_previous_names4": ".previous_names[3]",
+    "_previous_names4_full": ".previous_names[3]",
+    "_previous_names4_first": ".previous_names[3].first",
+    "_previous_names4_middle": ".previous_names[3].middle",
+    "_previous_names4_last": ".previous_names[3].last",
+    "_previous_names4_suffix": ".previous_names[3].suffix",
+    "_previous_names5": ".previous_names[4]",
+    "_previous_names5_full": ".previous_names[4]",
+    "_previous_names5_first": ".previous_names[4].first",
+    "_previous_names5_middle": ".previous_names[4].middle",
+    "_previous_names5_last": ".previous_names[4].last",
+    "_previous_names5_suffix": ".previous_names[4].suffix",
+    "_consented_to_name_change": ".consented_to_name_change", # HACK for LITCon 2023: these are name-change specific
+    "_parent_consent_attached": ".parent_consent_attached",
+    "_no_consent_attached_explanation": ".no_consent_attached_explanation",
 }
 
 generator_constants.PEOPLE_SUFFIXES = list(
@@ -258,6 +297,7 @@ generator_constants.DISPLAY_SUFFIX_TO_SETTABLE_SUFFIX = {
     "\.mailing_address.on_one_line\(\)$": ".mailing_address.address",
     "\.name.middle_initial\(\)$": ".name.first",
     "\.phone_numbers\(\)$": ".phone_number",
+    "\.preferred_name$": ".preferred_name.first",
 }
 
 # Test needed: Jinja `{{ parents[0].name_of_dog }}` should remain the same,
@@ -278,3 +318,4 @@ generator_constants.COURT_CHOICES = [
     "Juvenile Court",
     "Land Court",
 ]
+

--- a/docassemble/ALWeaver/generator_constants.py
+++ b/docassemble/ALWeaver/generator_constants.py
@@ -139,6 +139,9 @@ generator_constants.RESERVED_PERSON_PLURALIZERS_MAP = {
     "decedent": "decedents",
     "interested_party": "interested_parties",
     "adoptee": "adoptees",
+    # Special for name change forms (maybe HACK)
+    "users[0].previous_names": "users[0].previous_names",
+    "children[0].previous_names": "children[0].previous_names",
 }
 
 generator_constants.RESERVED_PRIMITIVE_PLURALIZERS_MAP = {

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -498,7 +498,8 @@ class DAField(DAObject):
         if has_plural_prefix or has_singular_prefix:
             first_attribute = var_parts[0][1]
             if has_plural_prefix and (
-                first_attribute == "" or first_attribute == ".name"
+                # HACK LITCon 2023 - hardcode previous_names list
+                first_attribute == "" or first_attribute == ".name" or first_attribute in [".previous_names[0]", ".previous_names[1]", ".previous_names[2]", ".previous_names[3]", ".previous_names[4]"]
             ):
                 return prefix + GATHER_CALL
             elif first_attribute == ".address" or first_attribute == ".mailing_address":

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -468,7 +468,20 @@ class DAField(DAObject):
         Args:
           custom_plurals: a list of variables strs that users have marked as being lists of people
         """
+                
         GATHER_CALL = ".gather()"
+        # HACK LITCon 2023 TODO
+        # preferred_name and previous_names won't work w/ current structure of generator_constants
+        if self.final_display_var.endswith(".preferred_name"):
+            return self.final_display_var + ".first"
+        if self.final_display_var.endswith(".preferred_name.first"):
+            return self.final_display_var
+        if self.final_display_var.endswith("previous_names"):
+            return self.final_display_var + GATHER_CALL
+        if re.search("previous_names\[\d\]$", self.final_display_var):
+            return self.final_display_var[:-len("[0]")] + GATHER_CALL
+        # NOTE: this only works through previous_names[9]
+        
         if not custom_plurals:
             custom_plurals = []
         if self.final_display_var in reserved_whole_words:


### PR DESCRIPTION
This is a little hacky but there's not a clean way to add support for these two variables types in generator_constants yet:

- objects that are predefined at the class level but have an undefined attribute, like name.first
- nested lists

Makes me wonder if we can really use a declarative DSL to handle all of the various kinds of objects we want to handle in various ways--maybe it will never be flexible enough?

Alternatively -- we need a special table of "trigger variables" rather than the very complex way we guess them based on the current classification of variables in generator_constants.py

I think hack is the right choice until we can come up with a broader refactor. Either way, these two new variables have a general use so we should figure out how to permanently support them.