### PR TITLE
Better radio defaults

### DIFF
--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -436,7 +436,7 @@ class DAField(DAObject):
                 "field": self.attr_name("choices"),
                 "datatype": "area",
                 "js show if": f"['multiple choice dropdown','multiple choice combobox','multiselect', 'multiple choice radio', 'multiple choice checkboxes'].includes(val('{ self.attr_name('field_type') }'))",
-                "default": "\n".join(self.choice_options)
+                "default": "\n".join([f"{opt.capitalize().replace('_', ' ')}: {opt}" for opt in self.choice_options])
                 if hasattr(self, "choice_options")
                 else None,
                 "hint": "Like 'Descriptive name: key_name', or just 'Descriptive name'",

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -439,7 +439,8 @@ class DAField(DAObject):
                 "default": "\n".join([f"{opt.capitalize().replace('_', ' ')}: {opt}" for opt in self.choice_options])
                 if hasattr(self, "choice_options")
                 else None,
-                "hint": "Like 'Descriptive name: key_name', or just 'Descriptive name'",
+                "help": "Like `Descriptive name: key_name`, or just `Descriptive name`",
+                "hint": "Descriptive name: key_name",
             }
         )
         if hasattr(self, "maxlength"):

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -436,7 +436,12 @@ class DAField(DAObject):
                 "field": self.attr_name("choices"),
                 "datatype": "area",
                 "js show if": f"['multiple choice dropdown','multiple choice combobox','multiselect', 'multiple choice radio', 'multiple choice checkboxes'].includes(val('{ self.attr_name('field_type') }'))",
-                "default": "\n".join([f"{opt.capitalize().replace('_', ' ')}: {opt}" for opt in self.choice_options])
+                "default": "\n".join(
+                    [
+                        f"{opt.capitalize().replace('_', ' ')}: {opt}"
+                        for opt in self.choice_options
+                    ]
+                )
                 if hasattr(self, "choice_options")
                 else None,
                 "help": "Like `Descriptive name: key_name`, or just `Descriptive name`",


### PR DESCRIPTION
Fixes #781. Defaults to having simple description text separate from the key for radio buttons, moves the hint text to the help, and adds a simpler hint text (which isn't really great UX anyway since it disappears, but eh).