### PR TITLE
Make custom button work again

### DIFF
--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -1126,7 +1126,7 @@ fields:
       code: |
         hasattr(interview.all_fields[i], "maxlength")
   - label: |
-      Complete the Python expression: `${ interview.all_fields[i].final_display_var } =`
+      Complete the Python expression: `${ interview.all_fields[i].final_display_var if hasattr(interview.all_fields[i], 'final_display_var') else "x" } =`
     field: interview.all_fields[i].code
     datatype: area
     show if:


### PR DESCRIPTION
Labels are computed before the screen is shown, and this one part was missed in https://github.com/SuffolkLITLab/docassemble-ALWeaver/commit/87581a85d561bce8cd9acd640f960847a86be56e.