### PR TITLE
Define new signatures for output interviews

### DIFF
--- a/docassemble/ALWeaver/data/questions/review_screen.yml
+++ b/docassemble/ALWeaver/data/questions/review_screen.yml
@@ -94,7 +94,7 @@ code: |
 
   mock_signature_screen = DAObject(
     question_text = "Please sign below",
-    subquestion_text = "[           ]",
+    subquestion_text = "[_____________]",
     field_list = [],
     card_footer_text = "Signature screen"
   )

--- a/docassemble/ALWeaver/data/templates/output.mako
+++ b/docassemble/ALWeaver/data/templates/output.mako
@@ -229,6 +229,12 @@ continue button field: ${ interview.interview_label }_preview_question
 code: |
   signature_fields = ${ str(list(interview.all_fields.built_in_signature_triggers()) + [field.trigger_gather(interview.all_fields.custom_people_plurals) for field in interview.all_fields.signatures()] ) }
 % endif
+% for custom_signature in interview.all_fields.custom_signatures():
+---
+question: |
+  ${custom_signature.variable.replace("_", " ").capitalize()}, sign below
+signature: ${ custom_signature }
+% endfor
 % for field in interview.all_fields.skip_fields():
 ---
 code: |

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -1074,6 +1074,21 @@ class DAFieldList(DAList):
             if hasattr(item, "group") and item.group == DAFieldGroup.SIGNATURE
         ]
 
+    def custom_signatures(self) -> List[DAField]:
+        """Returns signatures that aren't builtin and aren't a part of people.
+        These signatures need new signature blocks in the resulting interview."""
+        return [
+            item
+            for item in self.elements
+            if (
+                hasattr(item, "group")
+                and item.group == DAFieldGroup.SIGNATURE
+                and not item.trigger_gather(
+                    custom_plurals=self.custom_people_plurals.values()
+                ).endswith(".signature")
+            )
+        ]
+
     def custom(self) -> List[DAField]:
         """Returns the fields that can be assigned to screens and which will require
         custom labels"""


### PR DESCRIPTION
Fixes #763, and has slightly better display of signatures on the final screen.

Missing from this PR: the review screen shows all signatures as "built-in" screens, which isn't true after this change. Couldn't find a good way to edit that that didn't seem hacky, so I'll make a new issue.