### PR TITLE
Avoid  name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 docassemble/assemblylinewizard/docassemble*
 .history/
 .vscode/
+.hypothesis/
 *.egg-info
 
 # alkiln testing
@@ -16,6 +17,9 @@ npm-debug.log
 *_lang_*.feature
 *_report_*
 _al_test_project_name*
+alkiln-*
+cucumber-report.txt
+runtime_config.json
 # package.json is for local development only
 package.json
 package-lock.json

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -629,6 +629,9 @@ class DAField(DAObject):
     def __str__(self) -> str:
         return self.variable
 
+    def __repr__(self) -> str:
+        return f"{self.variable} ({self.raw_field_names}, {self.final_display_var})"
+
 
 class ParentCollection(object):
     """A ParentCollection is "highest" level of data structure containing some DAField.
@@ -957,9 +960,9 @@ class DAFieldList(DAList):
             else:
                 field_to_check = field.variable
             # Exact match
-            if (field_to_check) in people_vars:
+            if field_to_check in people_vars:
                 people.add(field_to_check)
-            elif (field_to_check) in undefined_person_prefixes:
+            elif field_to_check in undefined_person_prefixes:
                 pass  # Do not ask how many there will be about a singluar person
             elif file_type == "docx" and (
                 "[" in field_to_check or "." in field_to_check
@@ -987,7 +990,6 @@ class DAFieldList(DAList):
                             people.add(matches.groups()[0])
             elif file_type == "pdf":
                 # If it's a PDF name that wasn't transformed by map_raw_to_final_display, do one last check
-                # In this branch and all subbranches strip trailing numbers
                 # regex to check for matching suffixes, and catch things like mailing_address_address
                 # instead of just _address_address, if the longer one matches
                 matches = re.match(match_pdf_person_suffixes, field_to_check)
@@ -996,6 +998,7 @@ class DAFieldList(DAList):
                         # Skip pre-defined but singular objects since they are not "people" that
                         # need to turn into lists.
                         # currently this is only trial_court
+                        # strip trailing numbers so we end up with just the people object, i.e. `users`
                         people.add(re.sub(r"\d+$", "", matches.groups()[0]))
         if custom_only:
             return people - set(reserved_pluralizers_map.values())
@@ -1004,10 +1007,7 @@ class DAFieldList(DAList):
 
     def mark_people_as_builtins(
         self,
-        people_list: Iterable[str],
-        people_suffixes: List[str] = (
-            generator_constants.PEOPLE_SUFFIXES + generator_constants.DOCX_ONLY_SUFFIXES
-        ),
+        people_list: Iterable[str]
     ) -> None:
         self.custom_people_plurals = {
             var_name: var_name for var_name in list(people_list)

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -939,6 +939,13 @@ class DAFieldList(DAList):
         """
         people_vars = reserved_person_pluralizers_map.values()
         people = set()
+        if custom_only:
+            suffixes_to_use = set(people_suffixes_map.keys()) - set(["_name"])
+        else:
+            suffixes_to_use = people_suffixes_map.keys()
+        match_pdf_person_suffixes = (
+            r"(.+?)(?:(" + "$)|(".join(suffixes_to_use) + "$))"
+        )
         for field in self:
             # fields are currently tuples for PDF and strings for docx
             file_type = field.source_document_type
@@ -983,9 +990,6 @@ class DAFieldList(DAList):
                 # In this branch and all subbranches strip trailing numbers
                 # regex to check for matching suffixes, and catch things like mailing_address_address
                 # instead of just _address_address, if the longer one matches
-                match_pdf_person_suffixes = (
-                    r"(.+?)(?:(" + "$)|(".join(people_suffixes_map.keys()) + "$))"
-                )
                 matches = re.match(match_pdf_person_suffixes, field_to_check)
                 if matches:
                     if not matches.groups()[0] in undefined_person_prefixes:

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -946,9 +946,7 @@ class DAFieldList(DAList):
             suffixes_to_use = set(people_suffixes_map.keys()) - set(["_name"])
         else:
             suffixes_to_use = people_suffixes_map.keys()
-        match_pdf_person_suffixes = (
-            r"(.+?)(?:(" + "$)|(".join(suffixes_to_use) + "$))"
-        )
+        match_pdf_person_suffixes = r"(.+?)(?:(" + "$)|(".join(suffixes_to_use) + "$))"
         for field in self:
             # fields are currently tuples for PDF and strings for docx
             file_type = field.source_document_type
@@ -1005,10 +1003,7 @@ class DAFieldList(DAList):
         else:
             return people - (set(reserved_pluralizers_map.values()) - set(people_vars))
 
-    def mark_people_as_builtins(
-        self,
-        people_list: Iterable[str]
-    ) -> None:
+    def mark_people_as_builtins(self, people_list: Iterable[str]) -> None:
         self.custom_people_plurals = {
             var_name: var_name for var_name in list(people_list)
         }

--- a/docassemble/ALWeaver/test_pdf_files.py
+++ b/docassemble/ALWeaver/test_pdf_files.py
@@ -56,12 +56,12 @@ class test_pdfs(unittest.TestCase):
         fields = DAFieldList()
         fields.add_fields_from_file(da_pdf)
         fields.gathered = True
-        self.assertIn("decision_maker", fields.get_person_candidates(custom_only=True))
-        fields.mark_people_as_builtins(["decision_maker"])
+        self.assertIn("have_served_other_party", fields.get_person_candidates(custom_only=True))
+        fields.mark_people_as_builtins(["have_served_other_party"])
         fields = DAFieldList()
         fields.add_fields_from_file(da_pdf)
         fields.gathered = True
-        self.assertIn("decision_maker", fields.get_person_candidates(custom_only=True))
+        self.assertIn("have_served_other_party", fields.get_person_candidates(custom_only=True))
 
 
 if __name__ == "__main__":

--- a/docassemble/ALWeaver/test_pdf_files.py
+++ b/docassemble/ALWeaver/test_pdf_files.py
@@ -23,6 +23,7 @@ class MockDAStaticFile(DAStaticFile):
             if kwargs["extension"] == "pdf":
                 kwargs["mimetype"] = "application/pdf"
         super().init(*pargs, **kwargs)
+
     def path(self):
         return self.full_path
 
@@ -55,12 +56,16 @@ class test_pdfs(unittest.TestCase):
         fields = DAFieldList()
         fields.add_fields_from_file(da_pdf)
         fields.gathered = True
-        self.assertIn("have_served_other_party", fields.get_person_candidates(custom_only=True))
+        self.assertIn(
+            "have_served_other_party", fields.get_person_candidates(custom_only=True)
+        )
         fields.mark_people_as_builtins(["have_served_other_party"])
         fields = DAFieldList()
         fields.add_fields_from_file(da_pdf)
         fields.gathered = True
-        self.assertIn("have_served_other_party", fields.get_person_candidates(custom_only=True))
+        self.assertIn(
+            "have_served_other_party", fields.get_person_candidates(custom_only=True)
+        )
 
 
 if __name__ == "__main__":

--- a/docassemble/ALWeaver/test_pdf_files.py
+++ b/docassemble/ALWeaver/test_pdf_files.py
@@ -23,7 +23,6 @@ class MockDAStaticFile(DAStaticFile):
             if kwargs["extension"] == "pdf":
                 kwargs["mimetype"] = "application/pdf"
         super().init(*pargs, **kwargs)
-
     def path(self):
         return self.full_path
 
@@ -45,13 +44,13 @@ class test_pdfs(unittest.TestCase):
         )
 
     def test_person_candidates(self):
-        push_button_pdf = (
+        person_pdf = (
             Path(__file__).parent / "data/sources/test_civil_docketing_statement.pdf"
         )
         docassemble.base.functions.this_thread.current_question = type("", (), {})
         docassemble.base.functions.this_thread.current_question.package = "ALWeaver"
         da_pdf = MockDAStaticFile(
-            full_path=str(push_button_pdf), extension="pdf", mimetype="application/pdf"
+            full_path=str(person_pdf), extension="pdf", mimetype="application/pdf"
         )
         fields = DAFieldList()
         fields.add_fields_from_file(da_pdf)


### PR DESCRIPTION
Was the reason that we turned off custom people for LITCon. Before we turn it
back on, we should stop the cause of false positives.

Decided to hardcode the ending to avoid "_name" in the method for now; I don't
think we need to make it general now, as it's kinda hacky, and still needs a
better long term syntax to handle when people want things to be objects or
people, like #96.

Also did some small cleanups; to avoid looking at those, just look at https://github.com/SuffolkLITLab/docassemble-ALWeaver/commit/2453f40624efa9c35eaa26be63989de23f62636f.