### PR TITLE
Show more info about bad names

### DIFF
--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -6,6 +6,7 @@ from dataclasses import field
 from docassemble.base.util import (
     bold,
     comma_list,
+    comma_and_list,
     DADict,
     DAEmpty,
     DAFile,
@@ -2010,7 +2011,15 @@ def bad_name_reason(field: DAField) -> Optional[str]:
         if matching_reserved_names({field.variable}):
             return f"`{ field.variable }` is already used with a [different meaning](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/framework/reserved_keywords) in Python, Docassemble, or the AssemblyLine package"
         if len(field.variable) == 0:
-            return f"A { field.field_type_guess } field has no name. All field names should be in [snake case](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/naming#pdf-variables--snake_case)."
+            if len(field.raw_field_names) == 0:
+              start = f"A { field.field_type_guess } field has no name. "
+            if len(field.raw_field_names) == 1:
+              start = f"A { field.field_type_guess } field has no name. In the PDF, it is called "
+            else:
+              start = f"Some { field.field_type_guess } fields have no name. In the PDF, they are called "
+            if len(field.raw_field_names) > 0:
+              start += comma_and_list([n.replace('`', '\`') for n in field.raw_field_names]) + ". "
+            return start + "All field names should be in [snake case](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/naming#pdf-variables--snake_case)."
         # log(field[0], "console")
         python_var = map_raw_to_final_display(
             remove_multiple_appearance_indicator(varname(field.variable)),


### PR DESCRIPTION
Should show the original PDF field name, not our transformed version if and when possible.

First in a series of small changes here, more to come.

With this PR, information shown on the bad names screen:

```
The fields that have issues are:

    Some text fields have no name. In the PDF, they are called `25, `26, `27, `28, `29, `30, 
    `31, `32, `33, `34, `35, `36, `37, `38, `39, `40, `41, and `42. All field names should be in snake case.
```

Information shown on main:

```
The fields that have issues are:

    A text field has no name. All field names should be in snake case.
```


Test PDF: [Coding Form.pdf](https://github.com/SuffolkLITLab/docassemble-ALWeaver/files/11234312/Coding.Form.pdf)