### PR TITLE
Ignore bad field names

### DIFF
--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -868,7 +868,11 @@ code: |
   
   bad_fields = get_variable_name_warnings(interview.all_fields)
   if len(bad_fields) > 0:
-    force_ask('non_descriptive_field_name')
+    if non_descriptive_field_name == 'ignore':
+        interview.all_fields.remove_incorrect_names()
+    else:
+        del non_descriptive_field_name
+        non_descriptive_field_name
   validate_field_names = True
 ---
 code: |

--- a/docassemble/ALWeaver/data/questions/template_validation.yml
+++ b/docassemble/ALWeaver/data/questions/template_validation.yml
@@ -242,7 +242,6 @@ subquestion: |
 buttons:
   - Restart: restart
 ---
-event: non_descriptive_field_name
 question: Some of the fields in your template are not descriptive
 subquestion: |
   Some of your field names can't be turned into valid variable names for a Docassemble interview.
@@ -255,9 +254,11 @@ subquestion: |
   % for bad_field in bad_fields:
     * ${ bad_field }
   % endfor
-
 buttons:
   - Restart: restart
+  - I know what I'm doing, ignore these fields and continue:
+      code: |
+        non_descriptive_field_name = 'ignore'
 ---
 event: parsing_exception
 question: ${ parsing_ex.main_issue }

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -1111,6 +1111,18 @@ class DAFieldList(DAList):
             if not hasattr(item, "group") or item.group == DAFieldGroup.CUSTOM
         ]
 
+    def remove_incorrect_names(self) -> None:
+        """
+        If any fields have invalid variable names, remove them from the DAField list.
+        """
+        to_remove = [
+          item
+          for item in self.elements
+          if bad_name_reason(item) is not None
+        ]
+        for val in to_remove:
+          self.remove(val)
+
     def skip_fields(self) -> List[DAField]:
         return [
             item

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -1116,12 +1116,10 @@ class DAFieldList(DAList):
         If any fields have invalid variable names, remove them from the DAField list.
         """
         to_remove = [
-          item
-          for item in self.elements
-          if bad_name_reason(item) is not None
+            item for item in self.elements if bad_name_reason(item) is not None
         ]
         for val in to_remove:
-          self.remove(val)
+            self.remove(val)
 
     def skip_fields(self) -> List[DAField]:
         return [
@@ -2024,14 +2022,22 @@ def bad_name_reason(field: DAField) -> Optional[str]:
             return f"`{ field.variable }` is already used with a [different meaning](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/framework/reserved_keywords) in Python, Docassemble, or the AssemblyLine package"
         if len(field.variable) == 0:
             if len(field.raw_field_names) == 0:
-              start = f"A { field.field_type_guess } field has no name. "
+                start = f"A { field.field_type_guess } field has no name. "
             if len(field.raw_field_names) == 1:
-              start = f"A { field.field_type_guess } field has no name. In the PDF, it is called "
+                start = f"A { field.field_type_guess } field has no name. In the PDF, it is called "
             else:
-              start = f"Some { field.field_type_guess } fields have no name. In the PDF, they are called "
+                start = f"Some { field.field_type_guess } fields have no name. In the PDF, they are called "
             if len(field.raw_field_names) > 0:
-              start += comma_and_list([n.replace('`', '\`') for n in field.raw_field_names]) + ". "
-            return start + "All field names should be in [snake case](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/naming#pdf-variables--snake_case)."
+                start += (
+                    comma_and_list(
+                        [n.replace("`", "\`") for n in field.raw_field_names]
+                    )
+                    + ". "
+                )
+            return (
+                start
+                + "All field names should be in [snake case](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/naming#pdf-variables--snake_case)."
+            )
         # log(field[0], "console")
         python_var = map_raw_to_final_display(
             remove_multiple_appearance_indicator(varname(field.variable)),


### PR DESCRIPTION
Can across some PDFs that had fields had bad Adobe names (like \`25, etc.), but
Gavel wouldn't show those fields, so authors with those PDFs aren't able to
progress.

We have the ability to just not fill in certain fields in the docassemble, and
this patch allows authors to continue with the Weaving process if they don't
care about the shown fields.

Example PDF to test with: 
[test-custom-name.pdf](https://github.com/SuffolkLITLab/docassemble-ALWeaver/files/11236597/test-custom-name.pdf)

Should be able to progress by selecting "I know what I'm doing, ignore these fields and continue", and you can make a full interview without the badly named "`25" field.

Realizing I could make a Kiln test for this. Willing to do that, but it'd take some more time. 