### PR TITLE
Work on forms without AcroForm

### DIFF
--- a/docassemble/ALWeaver/data/questions/template_validation.yml
+++ b/docassemble/ALWeaver/data/questions/template_validation.yml
@@ -228,8 +228,8 @@ event: empty_pdf
 question: You uploaded an empty PDF
 subquestion: |
   The PDF you uploaded (${ interview.uploaded_templates[0].filename }) does not have any 
-  fillable interview.all_fields. To make a new interview with the Weaver, we need to have a 
-  document that has fillable interview.all_fields.
+  fillable fields. To make a new interview with the Weaver, we need to have a 
+  document that has fillable fields.
   
   If you saved a DOCX file as a PDF, you will need to add fillable fields in a 
   tool like [Adobe Acrobat](https://acrobat.adobe.com). 

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -835,8 +835,10 @@ class DAFieldList(DAList):
             # Use pikepdf to get more info about each field
             pike_fields: Dict = {}
             pike_obj = Pdf.open(document.path())
-            if pike_obj.Root.AcroForm.Fields and isinstance(
-                pike_obj.Root.AcroForm.Fields, Iterable
+            if (
+                hasattr(pike_obj.Root, "AcroForm")
+                and pike_obj.Root.AcroForm.Fields
+                and isinstance(pike_obj.Root.AcroForm.Fields, Iterable)
             ):
                 for pike_info in pike_obj.Root.AcroForm.Fields:
                     pike_fields[str(pike_info.T)] = pike_info


### PR DESCRIPTION
We used to warn folks when they didn't have any fields, but an older change (https://github.com/SuffolkLITLab/docassemble-ALWeaver/commit/c51b30646d3bc80d4b8b1c84b85778e5db58011e) broke that functionality by assuming that all PDF objects had an AcroForm attribute. This patch does not assume that, and can correctly show the user the better error screen.

Tested with PDF:  [AL.PDF.pdf](https://github.com/SuffolkLITLab/docassemble-ALWeaver/files/11236728/AL.PDF.pdf)

Fixes #802.
