### PR TITLE
Continue work on courtformsonline.org prep, next steps enhancements

### DIFF
--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -334,6 +334,20 @@ fields:
     required: False
     validate: |
       lambda y: (not y or is_url(y)) or validation_error("Write a valid URL, like: https://masslegalhelp.org/my_form")
+  - Web page with related resources (optional): interview.help_page_url
+    help: |
+      Include a link to a resource that explains the topic of this form. For example,
+      a page on a legal-aid or official court site. By default this will be shown to
+      the end user on the "about" page and in the next steps instructions.
+    required: False
+    validate: |
+      lambda y: (not y or is_url(y)) or validation_error("Write a valid URL, like: https://masslegalhelp.org/eviction")
+  - Name of web page with more information: interview.help_page_title
+    help: |
+      For example, "MassLegalHelp page about evictions"
+    js show if: |
+      val("interview.help_page_url").length > 0
+    maxlength: 40
   - Is the form court-related?: interview.court_related
     datatype: yesnoradio
     help: |

--- a/docassemble/ALWeaver/data/templates/output.mako
+++ b/docassemble/ALWeaver/data/templates/output.mako
@@ -9,50 +9,14 @@ include:
   % endfor
 ---
 metadata:
-  title: |
-    ${ interview.title }
-  short title: |
-    ${ interview.short_title }
-  % if interview.categories.any_true():
-  tags:
-    % for category in interview.categories.true_values():
-    - ${ category }
-    % endfor
-  % endif
-  authors:
-    % for author in interview.author.splitlines():
-    - ${ author }
-    % endfor
----
-mandatory: True
-comment: |
-  Global interview metadata
-variable name: interview_metadata["${ interview.interview_label }"]
-data:
-  al_weaver_version: "${ package_version_number }"
-  generated on: "${ today().format("yyyy-MM-dd") }"
   title: >-
-    ${ oneline(interview.title) }
+    ${ interview.title }
   short title: >-
-    ${ oneline(interview.short_title) }
+    ${ interview.short_title }
   description: |-
 ${ indent(interview.description, by=4) }
-  % if interview.original_form:
-  original_form: >-
-${ indent(interview.original_form, by=4) }
-  % endif
-  % if len(interview.allowed_courts.true_values()) < 1:
-  allowed courts: []
-  % else:
-  allowed courts: 
-    % for court in interview.allowed_courts.true_values():
-    - "${ escape_double_quoted_yaml(oneline(court)) }"
-    % endfor
-  % endif
-  % if len(interview.categories.true_values()) < 1:
-  categories: []
-  % else:
-  categories:
+  % if interview.categories.any_true():
+  tags:
     % for category in set(interview.categories.true_values()) - {'Other'}:
     - "${ escape_double_quoted_yaml(oneline(category)) }"
     % endfor
@@ -61,14 +25,36 @@ ${ indent(interview.original_form, by=4) }
     - "${ escape_double_quoted_yaml(oneline(category.strip())) }"
     % endfor
     % endif
+  % else:
+  tags: []
+  % endif
+  authors:
+    % for author in interview.author.splitlines():
+    - ${ author }
+    % endfor
+  % if interview.original_form:
+  original_form:
+    - ${ interview.original_form }
+  % endif
+  % if interview.help_page_url:
+  help_page_url: >-
+${ indent(interview.help_page_url, by=4) }
+  help_page_title: >-
+${ indent(interview.help_page_title, by=4) }
+  % endif
+  % if len(interview.allowed_courts.true_values()) < 1:
+  allowed_courts: []
+  % else:
+  allowed_courts: 
+    % for court in sorted(interview.allowed_courts.true_values() + (interview.allowed_courts_text.split(",") if interview.allowed_courts.get("Other") else [])):
+    - "${ escape_double_quoted_yaml(oneline(court)) }"
+    % endfor
   % endif
   % if interview.typical_role:
-  typical role: "${ escape_double_quoted_yaml(oneline(interview.typical_role)) }"
+  typical_role: "${ escape_double_quoted_yaml(oneline(interview.typical_role)) }"
   % endif
-  generate download screen: ${ generate_download_screen }
----
-code: |
-  interview_metadata['main_interview_key'] =  '${ interview.interview_label }'
+  al_weaver_version: "${ package_version_number }"
+  generated_on: "${ today().format("yyyy-MM-dd") }"
 ---
 code: |
   # This controls the default country and list of states in address field questions
@@ -108,7 +94,9 @@ id: interview_order_${ interview.interview_label }
 code: |
   % if generate_download_screen:
   # Set the allowed courts for this interview
-  allowed_courts = interview_metadata["${ interview.interview_label }"]["allowed courts"]
+  % if interview.court_related:
+  allowed_courts = ${ repr(sorted(interview.allowed_courts.true_values() + (interview.allowed_courts_text.split(",") if interview.allowed_courts.get("Other") else []))) }
+  % endif
   % endif
   nav.set_section("review_${ interview.interview_label }")
   % if interview.typical_role == 'unknown':
@@ -376,6 +364,7 @@ attachment:
   docx template file: ${ interview.interview_label }_next_steps.docx
   variable name: ${ interview.interview_label }_Post_interview_instructions[i]
   skip undefined: True
+  tagged pdf: True
 % for document in interview.uploaded_templates:
 ---
 attachment:

--- a/docassemble/ALWeaver/data/templates/output.mako
+++ b/docassemble/ALWeaver/data/templates/output.mako
@@ -398,6 +398,7 @@ ${ attachment_yaml(field, attachment_name=f"{ interview.interview_label}_attachm
 % else:
   skip undefined: True
   docx template file: ${ document.filename }
+  tagged pdf: True
 % endif
 % endfor
 % if interview.all_fields.has_addendum_fields():


### PR DESCRIPTION
Going to merge after tests pass.

Fix #830 - just add the `tagged pdf: True` modifier to attachments, including next_steps
Fix #397 add in a field with more information about the topic in the PDF
Fix #832 - use the metadata dictionary, don't rely on the interview_metadata dictionary for anything anymore

These are preparation for adding a new page to let someone customize the next steps document