### PR TITLE
Fix regressions

### DIFF
--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -35,7 +35,7 @@ code: |
     set_interview_type_vars 
     if have_template_to_load: 
       interview.uploaded_templates
-      if all(not has_fields(f.path()) for f in interview.uploaded_templates if f.filename.lower().endswith(".pdf")):
+      if interview.has_all_unlabeled_pdfs():
         if yes_recognize_form_fields: # ask to add fields
           process_field_recognition
       if im_feeling_lucky:
@@ -263,17 +263,6 @@ fields:
     datatype: files
     accept: |
       "application/pdf, application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-  # - Re-process and auto-identify form fields (PDFs, removes existing fields): yes_recognize_form_fields
-  #   datatype: yesno
-  #   help: |
-  #     Use our experimental code to automatically identify boxes and lines. Form fields
-  #     will be added where we think the form author intended the user to type or write-in
-  #     information. If your document already has fields, you don't need this step.
-  # - Rename fields automatically (PDFs only): yes_normalize_fields
-  #   datatype: yesno
-  #   help: |
-  #     Use our experimental code to automatically apply AssemblyLine naming conventions.
-  #     If you already followed naming conventions, you might want to skip this.
 validation code: |
   # HACK Litcon 2023: remove these confusing checkboxes for now
   yes_normalize_fields = False
@@ -297,10 +286,6 @@ subquestion: |
 fields:
   - Auto identify fields: yes_recognize_form_fields
     datatype: yesnoradio
----
-code: |
-  if any(has_fields(f.path()) for f in interview.uploaded_templates if f.filename.lower().endswith(".pdf")):
-    yes_recognize_form_fields = False
 ---
 code: |
   # HACK temporary LIT Con 2023

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -41,7 +41,7 @@ code: |
       if im_feeling_lucky:
         process_im_feeling_lucky
       else:
-        if all(map(lambda y: True if y.filename.endswith(".pdf") else False, interview.uploaded_templates)):
+        if interview.get_file_types() == "pdf":
           if yes_normalize_fields:
             process_field_normalization
           initial_get_fields
@@ -50,13 +50,13 @@ code: |
             warn_no_recognized_al_labels
           fields_checkup_status
           all_look_good
-        elif all(map(lambda y: True if y.filename.endswith(".docx") else False, interview.uploaded_templates)):
+        elif interview.get_file_types() == "docx":
           initial_get_fields
           validate_field_names
           if no_recognized_docx_fields:
             warn_no_recognized_al_labels
           validate_docx
-        else: # mixed PDF and DOCX templates
+        elif interview.get_file_types() == "mixed":
           initial_get_fields
           validate_mixed_documents
  

--- a/docassemble/ALWeaver/data/questions/review_screen.yml
+++ b/docassemble/ALWeaver/data/questions/review_screen.yml
@@ -143,7 +143,7 @@ review:
       <div class="col mb-4">
         <div class="card h-100 weaver-builtin review-question">
           <div class="card-header">
-            <a href="{ url_action("interview.title") }" class="edit-link">${ interview.title }<i class="fas fa-pencil-alt edit-icon"></i></a>
+            <a href="${ url_action("interview.title") }" class="edit-link">${ interview.title }<i class="fas fa-pencil-alt edit-icon"></i></a>
           </div>
           <div class="card-body">
           % for line in interview.getting_started.split("\n"):

--- a/docassemble/ALWeaver/data/questions/template_validation.yml
+++ b/docassemble/ALWeaver/data/questions/template_validation.yml
@@ -91,7 +91,7 @@ subject: |
 content: |
   % if interview.uploaded_templates[i].mimetype == "application/pdf":
   <iframe src="${ pdf_concatenate(overlay_pdf(interview.uploaded_templates[i].pdf_field_preview, quality_check_overlay.path()), filename="do_not_use.pdf").url_for() }" height="400"></iframe>
-  % if all(map(lambda y: True if y.filename.endswith(".pdf") else False, interview.uploaded_templates)):
+  % if interview.get_file_types() == "pdf":
   ${ action_button_html(url_ask(["display_rename_field_choices", "renamed_fields", {"recompute": ["interview.all_fields", interview.uploaded_templates[i].attr_name("pdf_field_preview")]} ]), label="Rename fields") }
   % endif
   % else:

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -1,6 +1,6 @@
 from .custom_values import get_matching_deps
 from .generator_constants import generator_constants
-from .validate_template_files import matching_reserved_names
+from .validate_template_files import matching_reserved_names, has_fields
 from collections import defaultdict
 from dataclasses import field
 from docassemble.base.util import (
@@ -27,7 +27,7 @@ from itertools import zip_longest, chain
 from pdfminer.pdfparser import PDFSyntaxError
 from pdfminer.psparser import PSEOF
 from pikepdf import Pdf
-from typing import Any, Dict, List, Optional, Set, Tuple, Union, Iterable
+from typing import Any, Dict, List, Optional, Set, Tuple, Union, Iterable, Literal
 from urllib.parse import urlparse
 from zipfile import BadZipFile
 import ast
@@ -1591,7 +1591,41 @@ class DAInterview(DAObject):
         self.all_fields.add_fields_from_file(self.uploaded_templates)
         self.all_fields.gathered = True
 
-
+    def get_file_types(self) -> Literal["pdf","docx","mixed"]:
+        """
+        Return the type of templates this interview assembles
+        """
+        kinds = set()
+        for f in self.uploaded_templates:
+            if f.filename.lower().endswith(".pdf"):
+                if "docx" in kinds:
+                    return "mixed"
+                kinds.add("pdf")
+            elif f.filename.lower().endswith(".docx"):
+                if "pdf" in kinds:
+                    return "mixed"
+                kinds.add("docx")
+        if len(kinds) == 1:
+            if "pdf" in kinds:
+                return "pdf"
+            return "docx"
+        return "mixed"
+    
+    def has_all_unlabeled_pdfs(self) -> bool:
+        """
+        Returns true only if the uploaded templates are:
+         1. all PDFs 
+         2. without form fields.
+        """
+        if self.get_file_types() in ["docx", "mixed"]:
+            return False
+        
+        return not any(
+            has_fields(f.path())
+            for f
+            in self.uploaded_templates
+        )
+                
 def fix_id(string: str) -> str:
     """Returns a valid, readable docassemble YAML block id"""
     if string and isinstance(string, str):


### PR DESCRIPTION
Fix #801 - Broken link on review screen
Fix #836 - Only offer to add fields when all templates are PDFs without fields

Moved the check for uploaded template type to a method along with fixing the logic to make it easier to debug.