### PR TITLE
Clear "undefined names" in Playground

### DIFF
--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -129,10 +129,11 @@ code: |
   menu_items = [ action_menu_item('Configure Weaver', 'configure_weaver') ]
 ---
 objects:
-  - install_step1_status: DAEmpty
+  - install_step1_status: DAEmpty # This and below are to avoid playground error highlighting
   - task_complete: DAEmpty
   - task_status: DAEmpty
   - task_succeeded: DAEmpty
+  - question: DAEmpty
   - weaverdata: DAStore.using(base="docassemble.ALWeaver")
   - upload_template_image: DAStaticFile.using(filename="undraw_upload_re_pasx.svg")
   - start_from_scratch_image: DAStaticFile.using(filename="undraw_start_building_re_xani.svg")
@@ -954,7 +955,14 @@ content: |
 comment: |
   Get the list of fields, and check for any possible labeling errors
   right away
-only sets: initial_get_fields
+only sets: 
+  - initial_get_fields
+  - pdf_variable_name_in_docx_matches
+  - reserved_names_in_docx
+  - keywords_in_docx
+  - mako_matches
+  - jinja_errors
+  - parsing_ex
 code: |
   for document in interview.uploaded_templates:
     if document.mimetype == "application/pdf":

--- a/docassemble/ALWeaver/data/questions/review_screen.yml
+++ b/docassemble/ALWeaver/data/questions/review_screen.yml
@@ -1,4 +1,8 @@
 def: preview_questions
+sets:
+  - preview_question_screen
+  - preview_field
+  - preview_dafield_screen
 mako: |
   <%def name="preview_field(field)">\
           <div class="row">
@@ -443,33 +447,6 @@ subquestion: |-
   ${ weaverdata.table }
 ---
 event: |-
-  jurisdiction_choices.revisit
-id: |-
-  revisit jurisdiction_choices
-question: |-
-  Edit your answers about Jurisdiction Choices
-subquestion: |-
-  ${ jurisdiction_choices.table }
----
-event: |-
-  generic_report.revisit
-id: |-
-  revisit generic_report
-question: |-
-  Edit your answers about Generic Report
-subquestion: |-
-  ${ generic_report.table }
----
-event: |-
-  placeholder_signature.revisit
-id: |-
-  revisit placeholder_signature
-question: |-
-  Edit your answers about Placeholder Signature
-subquestion: |-
-  ${ placeholder_signature.table }
----
-event: |-
   quality_check_overlay.revisit
 id: |-
   revisit quality_check_overlay
@@ -509,17 +486,3 @@ rows: |-
   interview
 table: |-
   interview.table
----
-columns:
-  - 'Descriptive name': |-
-      row_item.description if hasattr(row_item, 'description') else ''
-  - 'Dependency to add to setup.py': |-
-      row_item.dependency_name if hasattr(row_item, 'dependency_name') else ''
-  - 'YAML file name to add to `include` statement (optional)': |-
-      row_item.include_name if hasattr(row_item, 'include_name') else ''
-  - 'Enable by default': |-
-      row_item.default if hasattr(row_item, 'default') else ''
-rows: |-
-  jurisdiction_choices
-table: |-
-  jurisdiction_choices.table


### PR DESCRIPTION
Closes #842

It turns out these were mostly caused by an `only sets` modifier. I assume that was added to resolve an issue with Docassemble's variable scanning function sometimes triggering the block at the wrong time. I added each of the undefined variables mentioned in the relevant block to the `only sets` which should be safe as they each are only mentioned in that block and the specific error screen triggered only from that block.

Some other undefined variables were caused by issues with how variable scanning works in the `review` page and by unnecessary and unused `revisit` blocks created by the review screen generator.

#847 fixed the one true error reference in #842 