### PR TITLE
Don't add next steps documents to the YAML or package if the author requests not to add them

### DIFF
--- a/docassemble/ALWeaver/data/questions/review_screen.yml
+++ b/docassemble/ALWeaver/data/questions/review_screen.yml
@@ -255,10 +255,16 @@ review:
       % endfor
   - note: |
       <h2 class="h3 mt-4">Next steps instructions</h2>
-  - edit:
-      - interview.include_next_steps
+    show if: |
+      interview_type != "survey_with_template"
+  - edit: interview.include_next_steps
     button: |
-      % if interview.include_next_steps:
+      Include next steps: ${ word(yesno(interview.include_next_steps)) }
+  - edit:
+      - interview.customize_next_steps
+    show if: |
+      interview.include_next_steps
+    button: |
       % if interview.customize_next_steps:
       You are customizing the following values of the next steps document:
 
@@ -274,9 +280,6 @@ review:
       * What happens if my request is granted?: ${ interview.custom_next_steps_instructions["what_happens_if_i_win"] }
       % else:
       You selected not to customize the next steps document.
-      % endif
-      % else:
-      **You are not adding a next steps instructions document.**
       % endif
   - note: |
       <h2 class="h3 mt-4">Style and metadata</h2>

--- a/docassemble/ALWeaver/data/templates/output.mako
+++ b/docassemble/ALWeaver/data/templates/output.mako
@@ -364,6 +364,7 @@ objects:
 # Each attachment defines a key in an ALDocument. We use `i` as the placeholder here so the same template is 
 # used for "preview" and "final" keys, and logic in the template checks the value of 
 # `i` to show or hide the user's signature
+% if interview.include_next_steps:
 attachment:
   name: Post-interview-Instructions
   filename: ${ interview.interview_label }_next_steps
@@ -371,6 +372,7 @@ attachment:
   variable name: ${ interview.interview_label }_Post_interview_instructions[i]
   skip undefined: True
   tagged pdf: True
+% endif
 % for document in interview.uploaded_templates:
 ---
 attachment:

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -1399,9 +1399,12 @@ class DAInterview(DAObject):
         }
 
         if generate_download_screen:
-            folders_and_files["templates"] = [
-                self.instructions
-            ] + self.uploaded_templates
+            if self.include_next_steps:
+                folders_and_files["templates"] = [
+                    self.instructions
+                ] + self.uploaded_templates
+            else:
+                folders_and_files["templates"] = self.uploaded_templates
         else:
             folders_and_files["templates"] = []
 


### PR DESCRIPTION
Fix #872

For what it's worth: the test failure appears to be a red herring. I ran all of the (unchanged) test PDFs through the Weaver without any issue. And the mypy test failure is due to a disk space issue on the runner.

Error screen from Kiln (which looks like a false positive):
![error_on-file-upload-screen-I weave the civil docketing statement-1697557530564](https://github.com/SuffolkLITLab/docassemble-ALWeaver/assets/7645641/7eafb4fe-2885-4d3d-8192-8fca4bf82f28)

