### PR TITLE
Field recognition bugs

### DIFF
--- a/docassemble/ALWeaver/data/questions/template_validation.yml
+++ b/docassemble/ALWeaver/data/questions/template_validation.yml
@@ -195,7 +195,7 @@ buttons:
 code: |
   for document in interview.uploaded_templates:
     if document.filename.endswith("pdf"):
-      formfyxer.parse_form(document.path(), title=os.path.basename(document.path()), jur="MA", normalize=1,rewrite=1)
+      formfyxer.parse_form(document.path(), title=os.path.basename(document.path()), jur="MA", normalize=1,rewrite=1, tools_token=get_config("assembly line", {}).get("tools.suffolklitlab.org api key"))
       document.commit()
   process_field_normalization = True
 ---
@@ -207,7 +207,7 @@ code: |
       formfyxer.auto_add_fields(document.path(), temp_new_pdf.path())
   
       # also normalize field names after newly recognizing them
-      formfyxer.parse_form(temp_new_pdf.path(), title=document.filename, jur="MA", normalize=1, rewrite=1)
+      formfyxer.parse_form(temp_new_pdf.path(), title=document.filename, jur="MA", normalize=1, rewrite=1, tools_token=get_config("assembly line", {}).get("tools.suffolklitlab.org api key"))
   
       temp_new_pdf.commit()
       document.copy_into(temp_new_pdf)

--- a/docassemble/ALWeaver/validate_template_files.py
+++ b/docassemble/ALWeaver/validate_template_files.py
@@ -197,12 +197,5 @@ def has_fields(pdf_file: str) -> bool:
         bool: True if the PDF has at least one form field, False otherwise.
     """
     with pikepdf.open(pdf_file) as pdf:
-        for page in pdf.pages:
-            if "/Annots" in page:
-                for annot in page.Annots:  # type: ignore
-                    try:
-                        if annot.Type == "/Annot" and annot.Subtype == "/Widget":
-                            return True
-                    except:
-                        continue
+        return hasattr(pdf.Root, "AcroForm") and hasattr(pdf.Root.AcroForm, "Fields")
     return False


### PR DESCRIPTION
Fix #878: use the API key when it's in the config
Fix #877: use a more reliable method to detect whether a PDF has any form fields (e.g., directly check the Acroform rather than looking for annotations)