### PR TITLE
Allow customization of interview_label

### DIFF
--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -445,9 +445,6 @@ script: |
       });
   </script>
 ---
-code: |
-  interview_label_draft = interview.title
----
 event: update_state_list
 code: |
   if action_argument('interview.default_country_code') and action_argument('interview.default_country_code') != interview.default_country_code:          
@@ -591,7 +588,7 @@ fields:
       file that are shown only internally.
   - Custom filename: interview_label_draft
     show if: interview.customize_file_name
-    default: ${ varname(interview.short_filename_with_spaces) }
+    default: ${ varname(interview.short_filename_with_spaces[:35]) }
   - Description of the form for metadata: interview.description
     default: |
       This interview helps someone in ${ state_name(interview.state, country_code=interview.default_country_code) } ${ interview.intro_prompt[0:1].lower() }${ interview.intro_prompt[1:] }.
@@ -626,6 +623,9 @@ fields:
       prevents frustration later in your interview, especially for longer
       forms. You can use Markdown lists (1. ) and bullets (*) at the beginning
       of a line to add formatting.
+---
+code: |
+  interview_label_draft = interview.title[:35]
 ---
 code: |
   interview.short_title = interview.title

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -446,7 +446,7 @@ script: |
   </script>
 ---
 code: |
-  interview_label_draft = interview.short_filename[:35]
+  interview_label_draft = interview.title
 ---
 event: update_state_list
 code: |
@@ -569,7 +569,7 @@ subquestion: |
   You can change these later in the Playground.
 fields:
   - Title in navigation bar: interview.title
-    default: ${ interview.short_filename_with_spaces }
+    default: ${ interview.short_filename_with_spaces }    
   - note: |
       **Your title is a little long.** Write an alternate version that
       will be used on mobile screens.
@@ -582,6 +582,16 @@ fields:
       val("interview.title").length > 25
     help: |
       This title will appear in the navigation bar on small screens.
+  - Use a different name for the output file (defaults to title): interview.customize_file_name
+    datatype: yesno
+    help: |
+      The filename is used to name the file when the user downloads it.
+
+      This will also be used to name some other variables in your YAML
+      file that are shown only internally.
+  - Custom filename: interview_label_draft
+    show if: interview.customize_file_name
+    default: ${ varname(interview.short_filename_with_spaces) }
   - Description of the form for metadata: interview.description
     default: |
       This interview helps someone in ${ state_name(interview.state, country_code=interview.default_country_code) } ${ interview.intro_prompt[0:1].lower() }${ interview.intro_prompt[1:] }.


### PR DESCRIPTION
Fix #875

1. Defaults to the interview title instead of the original filename, as someone is more likely to cleanup the title.
3. Provides an option to customize the interview label