### PR TITLE
Improvements for working with longer sessions in the Weaver

### DIFF
--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -96,6 +96,9 @@ code: |
   nav.set_section("nav_metadata")
   interview.jurisdiction_choices
   interview.form_type
+  interview.intro_prompt
+  interview.title
+  set_name_of_current_session
   if generate_download_screen:
     interview.intro_prompt #branding screen
     interview.title #intro screen
@@ -134,6 +137,10 @@ code: |
   # Display output download screen
   nav.set_section("nav_package")
   show_interview  
+---
+code: |
+  rename_current_session(interview.title)
+  set_name_of_current_session = True  
 ---
 features:
   question help button: True

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -37,6 +37,7 @@ sections:
 mandatory: True
 id: Interview Order
 code: |
+  multi_user
   nav.hide()
   process_url_args
   # Check to see if we are launched from the form explorer, and

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -37,7 +37,7 @@ sections:
 mandatory: True
 id: Interview Order
 code: |
-  multi_user
+  multi_user = True
   nav.hide()
   process_url_args
   # Check to see if we are launched from the form explorer, and
@@ -54,6 +54,7 @@ code: |
     nav.set_section("nav_upload")
     if have_template_to_load:
       interview.uploaded_templates
+      set_name_of_current_session_from_filename
       if interview.has_all_unlabeled_pdfs():
         if yes_recognize_form_fields: # ask to add fields
           process_field_recognition
@@ -138,6 +139,10 @@ code: |
   # Display output download screen
   nav.set_section("nav_package")
   show_interview  
+---
+code: |
+  rename_current_session(interview.uploaded_templates[0].filename)
+  set_name_of_current_session_from_filename = True
 ---
 code: |
   rename_current_session(interview.title)
@@ -292,7 +297,7 @@ event: browse_weaver_sessions
 question: |
   Existing Weaver sessions
 subquestion: |
-  ${ session_list_html(filename=user_info().filename, exclude_current_filename=False) }
+  ${ session_list_html(filename=user_info().filename, exclude_current_filename=False, exclude_newly_started_sessions=True) }
 ---
 id: file upload screen
 question: |


### PR DESCRIPTION
1. Fix #896  - set `multi_user = True` so the "share" link does what it says it will do
2. Fix #691 - Add the filename, and then the title, of the interview in progress to the session list so it is simpler to locate the interview you were in the middle of working on.
3. Filter the list of sessions in the "Load a previous project" list so it only shows interviews past page 1.