### PR TITLE
Wrap download_list_html in <p> so VoiceRSS sees it

### DIFF
--- a/docassemble/ALWeaver/data/templates/output.mako
+++ b/docassemble/ALWeaver/data/templates/output.mako
@@ -292,7 +292,9 @@ subquestion: |
   <%text>${</%text> action_button_html(url_action('review_${ interview.interview_label }'), label='Edit answers', color='info') <%text>}</%text>
   
   <%text>
+  <p>
   ${ al_user_bundle.download_list_html() }
+  </p>
   </%text>
 
   <%text>${</%text> al_user_bundle.send_button_html(show_editable_checkbox=${False if any(map(lambda templ: templ.mimetype == "application/pdf", interview.uploaded_templates)) else True}) <%text>}</%text>


### PR DESCRIPTION
Originally found in https://github.com/mplp/docassemble-mlhframework/issues/62, docassemble only sends parts of the page to Voice RSS to be read. It has a fairly complicated set of rules, including the fact that it skips over `div`s and the contents of any tag that isn't only a string. All that means that the download list buttons and document titles aren't read out.

It's fairly minor, and the voice RSS has a bunch of other issues as well (see https://github.com/mplp/docassemble-mlhframework/issues/62#issuecomment-1874630556), but wrapping the entire `download_list_html` in paragraph tags stops docassemble from skipping over those buttons. It's a bit hacky, but it's not something that's worth fixing upstream, and this is a fairly simple change.