### PR TITLE
Don't try "auto drafting" with an empty PDF or DOCX file

### DIFF
--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -2048,6 +2048,10 @@ code: |
       interview.auto_assign_attributes()
     interview_label_draft = varname(interview.title).lower()
 
+  # Check for an empty file
+  if not len(interview.all_fields):
+    force_ask('empty_pdf')
+
   # TODO: refactor this at some point, this is a shim to create objects block but we
   # shouldn't need it forever.
   # person_candidates = interview.all_fields.get_person_candidates()

--- a/docassemble/ALWeaver/data/questions/template_validation.yml
+++ b/docassemble/ALWeaver/data/questions/template_validation.yml
@@ -230,12 +230,18 @@ code: |
   ]
 ---
 event: empty_pdf
-question: You uploaded an empty PDF
+question: |
+  % if interview.get_file_types() == "pdf":
+  You uploaded a PDF without any fields
+  % elif interview.get_file_types() == "docx":
+  You uploaded a DOCX file without any Jinja2 syntax
+  % endif
 subquestion: |
-  The PDF you uploaded (${ interview.uploaded_templates[0].filename }) does not have any 
+  The document you uploaded (${ interview.uploaded_templates[0].filename }) does not have any 
   fillable fields. To make a new interview with the Weaver, we need to have a 
   document that has fillable fields.
   
+  % if interview.get_file_types() == "pdf":
   If you saved a DOCX file as a PDF, you will need to add fillable fields in a 
   tool like [Adobe Acrobat](https://acrobat.adobe.com). 
   For more info, see the [documentation](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/pdfs).
@@ -244,6 +250,7 @@ subquestion: |
   or XFA form), you may need to flatten it first. You can flatten an XFA form
   using [iText PDF's free 
   tool](https://itextpdf.com/en/demos/flatten-dynamic-xfa-pdf-free-online).
+  % endif
 buttons:
   - Restart: restart
 ---

--- a/docassemble/ALWeaver/data/templates/output.mako
+++ b/docassemble/ALWeaver/data/templates/output.mako
@@ -16,16 +16,16 @@ metadata:
   description: |-
 ${ indent(interview.description, by=4) }
   can_I_use_this_form: |
-% if interview.can_I_use_this_form:
+% if showifdef("interview.can_I_use_this_form"):
 ${ indent(interview.can_I_use_this_form, by=4) }
 % endif
   before_you_start: |
-% if interview.getting_started:
+% if showifdef("interview.getting_started"):
 ${ indent(interview.getting_started, by=4) }
 % endif
   maturity: production
-  estimated_completion_minutes: 60
-  estimated_completion_delta: 30
+  estimated_completion_minutes: ${ showifdef("interview.estimated_completion_minutes",'""')}
+  estimated_completion_delta: ${ showifdef("interview.estimated_completion_delta", '""')}
   % if interview.categories.any_true():
   LIST_topics: 
     % for category in sorted(set(interview.categories.true_values())):
@@ -58,7 +58,11 @@ ${ indent(interview.getting_started, by=4) }
   % else:
   original_form: []
   % endif
+  % if defined("interview.original_form_published_on"):
   original_form_published_on: ${ interview.original_form_published_on.format("yyyy-MM-dd") or '""'}
+  % else:
+  original_form_published_on: ""
+  % endif
   % if interview.help_page_url:
   help_page_url: >-
 ${ indent(interview.help_page_url, by=4) }
@@ -80,17 +84,17 @@ ${ indent(interview.help_page_title, by=4) }
   generated_on: "${ today().format("yyyy-MM-dd") }"
   languages:
     - en
-  jurisdiction: ${ interview.jurisdiction }
+  jurisdiction: ${ showifdef("interview.jurisdiction", '""') }
   review_date: ${ today().format("yyyy-MM-dd")}
   form_titles:
     - ${ interview.title }
-  % if interview.form_number:
+  % if showifdef("interview.form_number"):
   form_numbers:
     - ${ interview.form_number }
   % else:
   form_numbers: []
   % endif
-  % if interview.filing_fee:
+  % if showifdef("interview.filing_fee"):
   fees:
     - Filing fee: ${ currency(interview.filing_fee) }
   % endif
@@ -201,9 +205,13 @@ question: |
 subquestion: |
 ${ indent(interview.getting_started, 2) }
 
+% if defined("interview.can_I_use_this_form"):
 ${ indent(interview.can_I_use_this_form, by=2)}
+% endif
 
+% if defined("interview.estimated_completion_minutes"):
   Most people take about ${ interview.estimated_completion_minutes or "_______________"} minutes to complete this interview.
+% endif
 <%doc>
     Main question loop
 </%doc>\

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -1801,7 +1801,7 @@ class DAInterview(DAObject):
             categories = formfyxer.spot(
                 title + ": " + full_text,
                 token=get_config("assembly line", {}).get(
-                    "tools.suffolklitlab.org api key", None
+                    "spot api key", None
                 ),
             )
             if categories and not "401" in categories:

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -1610,8 +1610,11 @@ class DAInterview(DAObject):
 
         if jurisdiction:
             try:
-                if jurisdiction.upper() in {subdivision.code.split('-')[1] for subdivision in pycountry.subdivisions.get(country_code='US')}:
-                    self.jurisdiction = "NAM-US-US+"+jurisdiction.upper()
+                if jurisdiction.upper() in {
+                    subdivision.code.split("-")[1]
+                    for subdivision in pycountry.subdivisions.get(country_code="US")
+                }:
+                    self.jurisdiction = "NAM-US-US+" + jurisdiction.upper()
                     self.state = jurisdiction.upper()
                 else:
                     self.jurisdiction = jurisdiction
@@ -1800,9 +1803,7 @@ class DAInterview(DAObject):
                     full_text += docx_data.text
             categories = formfyxer.spot(
                 title + ": " + full_text,
-                token=get_config("assembly line", {}).get(
-                    "spot api key", None
-                ),
+                token=get_config("assembly line", {}).get("spot api key", None),
             )
             if categories and not "401" in categories:
                 return categories

--- a/docassemble/ALWeaver/requirements.txt
+++ b/docassemble/ALWeaver/requirements.txt
@@ -1,5 +1,4 @@
-docassemble.base>=1.3
-docassemble.webapp
+docassemble.base
 more_itertools
 pyyaml
 docx2python


### PR DESCRIPTION
Fix #933 

1. Checks the uploaded document for fields before attempting auto drafting mode
2. Skips some metadata that we added in #925 when autodrafting is used (rather than awkwardly prompting the user)
3. Map the jurisdiction code to LMSS jurisdiction code, if the jurisdiction provided looks like the abbreviation for a US state.