### PR TITLE
Fix behavior change in more_itertools

### DIFF
--- a/docassemble/ALWeaver/custom_values.py
+++ b/docassemble/ALWeaver/custom_values.py
@@ -148,7 +148,7 @@ def get_possible_deps_as_choices(dep_category=None):
                 ]
             )
 
-    return list(unique_everseen(dep_choices))
+    return list(unique_everseen(dep_choices, key=lambda x: frozenset(x.items())))
 
 
 def get_pypi_deps_from_choices(choices: Union[List[str], DADict]):
@@ -201,7 +201,7 @@ def get_full_dep_details(dep_category: Optional[str] = None) -> List:
         elif dep_category == "jurisdiction":
             dep_choices.extend(capabilities[capability].get("jurisdiction_choices", []))
 
-    return list(unique_everseen(dep_choices))
+    return list(unique_everseen(dep_choices, key=lambda x: frozenset(x.items())))
 
 
 def get_matching_deps(
@@ -234,7 +234,12 @@ def get_matching_deps(
 
     if len(dep_choices) > 0 or str(state).lower() == "any":
         return DADict(
-            elements={item: True for item in unique_everseen(dep_choices)},
+            elements={
+                item: True
+                for item in unique_everseen(
+                    dep_choices, key=lambda x: frozenset(x.items())
+                )
+            },
             auto_gather=False,
             gathered=True,
         )


### PR DESCRIPTION
In more_itertools 11.0.0, they changed the behavior of `unique_everseen` to throw a type error on unhashable types. We can't switch to `unique` because we don't want to change the sorting of the elements.

https://github.com/more-itertools/more-itertools/issues/898

Addresses the current failing Kiln tests (which are the only bits testing `get_possible_deps_as_choices`.