### PR TITLE
Set minimum supported versions for docassemble.base and webapp.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ docassemble/assemblylinewizard/docassemble*
 .hypothesis/
 *.egg-info
 .code/
+build
 
 # alkiln testing
 tests/chromedriver

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,9 +130,10 @@ disable_error_code=["import-untyped"]
 
 [dependency-groups]
 dev = [
-    "docassemble.base",
-    "docassemble.webapp",
+    "docassemble.base>=1.8.0",
+    "docassemble.webapp>=1.8.0",
     "more_itertools",
+    "pytest",
     "pyyaml",
     "docx2python",
     "boto3",


### PR DESCRIPTION
TL;DR: uv tries to do the right thing and avoid a conflict between boto3's deps and docassemble's overly strict deps. This prevents that from breaking things.

The docassemble.base and webapp versions are only used for testing, as all other times, we're installing this package on a server that has a fixed docassemble version.

When using `uv` to install all of the group dependencies, it will check all of the dependencies down the tree. With docassemble 1.9.11 (and 1.9.12 too), it directly has a dependency on s3transfer 0.16.0. However, it also has a dependency on boto3 1.42.17, which directly depends on s3transfer 0.17.0 (https://github.com/boto/boto3/blob/df96d6dc6d8faca315b905732bdcb89eeb0a252c/setup.py#L19). uv correctly recognizes this as a conflict, and since we don't have a lower limit on the version of docassemble we work with, it tries a slightly older version of docassemble. In short, for some reeason or another, there are dependency conflicts with all versions of docassemble, going all the way back to v 0.4.47. However, that version uses `six` as a dependency, but doesn't declare it, so the tests error out.

If instead, we give a lower limit of the docassemble version we should work with, uv finds that there's always a dependency error, and just uses the latest version available (1.9.11). Not sure why it doesn't make the error clearer, but idk.

Should fix the job failing in #974.