### PR TITLE
Remove references to `tools.suffolklitlab.org`

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,15 +71,10 @@ Nharika Singh
 
 ### Using auto drafting mode
 
-As of June 2023, the Weaver includes auto drafting mode.
+To use auto-drafting mode, you can get an Open AI API Key and set it in
+your docassemble configuration.
 
-To use the automatic field grouping feature of auto drafting mode,
-you need to install either:
-
-1. The `en_core_web_lg` model on your server, or
-2. An API token for tools.suffolklitlab.org.
-
-You can request an API token by emailing massaccess@suffolklitlab.org. If you
-prefer to install your own copy of the `en_core_web_lg` model, you can
-access it the first time you select to use auto drafting mode when logged
-in as an administrator.
+```yaml
+open ai:
+  key: ...
+```

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -521,9 +521,6 @@ code: |
         jur=str(
           get_config("assembly line", {}).get("pdf relabel jurisdiction", "MA")
         ),
-        tools_token=get_config("assembly line", {}).get(
-          "tools.suffolklitlab.org api key"
-        ),
         openai_api=get_config("open ai", {}).get("key"),
       )
       if isinstance(stats, dict) and isinstance(stats.get("fields"), list):

--- a/docassemble/ALWeaver/data/questions/template_validation.yml
+++ b/docassemble/ALWeaver/data/questions/template_validation.yml
@@ -200,9 +200,6 @@ code: |
         jur="MA",
         normalize=1,
         rewrite=1,
-        tools_token=get_config("assembly line", {}).get(
-          "tools.suffolklitlab.org api key"
-        ),
       )
       document.commit()
   process_field_normalization = True
@@ -223,9 +220,6 @@ code: |
         jur="MA",
         normalize=1,
         rewrite=1,
-        tools_token=get_config("assembly line", {}).get(
-          "tools.suffolklitlab.org api key"
-        ),
       )
 
       temp_new_pdf.commit()

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -3206,16 +3206,11 @@ Rules:
         try:
             field_grouping = formfyxer.cluster_screens(
                 [field.variable for field in self.all_fields.custom()],
-                tools_token=get_config("assembly line", {}).get(
-                    "tools.suffolklitlab.org api key", None
-                ),
             )
             if not field_grouping:
                 field_grouping = self._null_group_fields()
-        except:
-            log(
-                f"Auto field grouping failed. Tried using tools.suffolklitlab.org api key {get_config('assembly line',{}).get('tools.suffolklitlab.org api key', None)}"
-            )
+        except Exception as ex:
+            log(f"Auto field grouping failed. {ex}")
             field_grouping = self._null_group_fields()
         self.field_grouping = field_grouping
         self.questions.auto_gather = False


### PR DESCRIPTION
Mostly just confirming to myself that the weaver doesn't do anything with that server (which is being shut down). All of the params it's used with are deprecated no-ops as of FormFyxer 1.0.0 (from October 2025).