### PR TITLE
More robust round tripping between gui and YAML code

### DIFF
--- a/docassemble/ALWeaver/api_editor.py
+++ b/docassemble/ALWeaver/api_editor.py
@@ -106,6 +106,7 @@ try:
         delete_block_from_yaml,
         delete_saved_file,
         generate_draft_order,
+        insert_block_in_yaml,
         parse_interview_yaml,
         metadata_source_slice,
         parse_order_code,
@@ -4804,7 +4805,14 @@ def editor_api_save_block() -> Response:
         _validate_block_yaml_payload(new_yaml)
 
         current_content = playground_read_yaml(uid, project, filename)
-        updated_content = update_block_in_yaml(current_content, block_id, new_yaml)
+        updated_content = update_block_in_yaml(
+            current_content,
+            block_id,
+            new_yaml,
+            preserve_unchanged_annotations=(
+                str(post_data.get("edit_mode") or "").strip().lower() == "graphical"
+            ),
+        )
         playground_write_yaml(uid, project, filename, updated_content)
 
         model = parse_interview_yaml(updated_content)
@@ -5076,31 +5084,10 @@ def editor_api_insert_block() -> Response:
         _validate_block_yaml_payload(block_yaml)
 
         current_content = playground_read_yaml(uid, project, filename)
-        model = parse_interview_yaml(current_content)
-        blocks = model["blocks"]
-
-        block_text = canonicalize_block_yaml(block_yaml)
-        existing_parts = [
-            b["yaml"].strip()
-            for b in blocks
-            if b.get("yaml", "").strip() and b.get("yaml", "").strip() != "{}"
-        ]
-
-        insert_at: int
-        if not insert_after_id:
-            insert_at = 0
-        else:
-            found_insert_at: Optional[int] = None
-            for idx, block in enumerate(blocks):
-                if block.get("id") == insert_after_id:
-                    found_insert_at = idx + 1
-                    break
-            if found_insert_at is None:
-                raise ValueError(f"Block with id {insert_after_id!r} not found")
-            insert_at = found_insert_at
-
-        existing_parts.insert(insert_at, block_text)
-        updated_content = "\n---\n".join(existing_parts) + "\n"
+        block_text = block_yaml.strip("\r\n")
+        updated_content = insert_block_in_yaml(
+            current_content, block_text, insert_after_id
+        )
         playground_write_yaml(uid, project, filename, updated_content)
 
         updated_model = parse_interview_yaml(updated_content)
@@ -5108,9 +5095,9 @@ def editor_api_insert_block() -> Response:
         id_match = re.search(r"(?m)^id:\s*['\"]?([^'\"\n]+)['\"]?\s*$", block_text)
         if id_match:
             inserted_block_id = id_match.group(1).strip()
-        elif 0 <= insert_at < len(updated_model["blocks"]):
+        elif updated_model["blocks"]:
             inserted_block_id = (
-                str(updated_model["blocks"][insert_at].get("id") or "").strip() or None
+                str(updated_model["blocks"][-1].get("id") or "").strip() or None
             )
 
         return jsonify(
@@ -5252,7 +5239,10 @@ def editor_api_save_order() -> Response:
             block_data["code"] = code_body
             order_yaml = canonical_block_yaml(block_data)
             updated = update_block_in_yaml(
-                current_content, target_block["id"], order_yaml
+                current_content,
+                target_block["id"],
+                order_yaml,
+                preserve_unchanged_annotations=True,
             )
         else:
             # Append a new mandatory code block
@@ -5342,6 +5332,8 @@ def editor_api_ai_generate_screen() -> Response:
             - Choose datatypes from the provided allowed list.
             - Keep labels plain and user-friendly.
             - Keep variable names python-safe snake_case.
+            - When fields is non-empty, continue_button_field must be an empty string.
+            - Use continue_button_field only for a screen with no input fields.
             """).strip()
 
         user_message = (

--- a/docassemble/ALWeaver/data/static/editor.js
+++ b/docassemble/ALWeaver/data/static/editor.js
@@ -5034,6 +5034,10 @@
           if (!res.success || !res.data) return false;
           refreshFromFileResponse(res.data);
           return true;
+        }).catch(function (error) {
+          if (isSupersededRequest(error)) return false;
+          window.alert('Unable to save metadata safely: ' + String((error && error.message) || error || 'Unknown error'));
+          return false;
         });
       }
       return apiPost('/api/file', {
@@ -5043,6 +5047,10 @@
       }).then(function (res) {
         if (!res.success) return false;
         return loadFile().then(function () { return true; });
+      }).catch(function (error) {
+        if (isSupersededRequest(error)) return false;
+        window.alert('Unable to save YAML: ' + String((error && error.message) || error || 'Unknown error'));
+        return false;
       });
     }
     if (state.orderDirty) {
@@ -5059,6 +5067,10 @@
         }
         state.orderDirty = false;
         return loadFile().then(function () { return true; });
+      }).catch(function (error) {
+        if (isSupersededRequest(error)) return false;
+        window.alert('Unable to save interview order: ' + String((error && error.message) || error || 'Unknown error'));
+        return false;
       });
     }
     var editingRawOrder = state.canvasMode === 'full-yaml' && state.fullYamlTab === 'order';
@@ -5075,6 +5087,7 @@
       filename: state.filename,
       block_id: originalBlockId,
       block_yaml: yamlVal,
+      edit_mode: editingRawOrder || state.questionEditMode !== 'preview' ? 'source' : 'graphical',
     }).then(function (res) {
       if (!res.success || !res.data) {
         window.alert((res.error && res.error.message) || 'Unable to save block.');
@@ -5086,6 +5099,10 @@
       renderOutline();
       renderCanvas();
       return !dirtyState.hasDirty(state.filename);
+    }).catch(function (error) {
+      if (isSupersededRequest(error)) return false;
+      window.alert('Unable to save block: ' + String((error && error.message) || error || 'Unknown error'));
+      return false;
     });
   }
 
@@ -5111,6 +5128,10 @@
       var saveSectionBtn = document.getElementById('save-section-file');
       if (saveSectionBtn) saveSectionBtn.disabled = true;
       return true;
+    }).catch(function (error) {
+      if (isSupersededRequest(error)) return false;
+      window.alert('Unable to save file: ' + String((error && error.message) || error || 'Unknown error'));
+      return false;
     });
   }
 
@@ -8202,6 +8223,9 @@
         }
         state.filename = res.data && res.data.filename ? res.data.filename : newInterviewName;
         loadFiles();
+      }).catch(function (error) {
+        if (isSupersededRequest(error)) return;
+        window.alert('Unable to create file: ' + String((error && error.message) || error || 'Unknown error'));
       });
       return;
     }
@@ -8793,6 +8817,7 @@
         filename: state.filename,
         block_id: originalBlockId,
         block_yaml: yamlVal,
+        edit_mode: state.questionEditMode === 'preview' ? 'graphical' : 'source',
       }).then(function (res) {
         if (res.success && res.data) {
           var keepBlockId = res.data.saved_block_id || originalBlockId;
@@ -8859,6 +8884,7 @@
           filename: state.filename,
           block_id: state.activeOrderBlockId,
           block_yaml: yamlContent,
+          edit_mode: 'source',
         }).then(function (res) {
           if (res.success && res.data) {
             refreshFromFileResponse(res.data, { savedBlockId: state.activeOrderBlockId });

--- a/docassemble/ALWeaver/editor_ai_utils.py
+++ b/docassemble/ALWeaver/editor_ai_utils.py
@@ -238,8 +238,12 @@ def normalize_generated_screen(
     subquestion = _safe_prose(raw_screen.get("subquestion"))
 
     continue_button_field = _safe_text(raw_screen.get("continue_button_field"))
-    if not continue_button_field and fields:
-        continue_button_field = _safe_text(fields[0].get("field"))
+    # A Docassemble question is completed either by its input fields or by a
+    # continue button field. Combining both makes the generated screen define
+    # an unrelated completion variable (models commonly return a generic
+    # ``continue`` here) and can create collisions elsewhere in the interview.
+    if fields:
+        continue_button_field = ""
 
     return {
         "question": question,

--- a/docassemble/ALWeaver/editor_utils.py
+++ b/docassemble/ALWeaver/editor_utils.py
@@ -27,6 +27,7 @@ __all__ = [
     "serialize_order_steps",
     "generate_draft_order",
     "canonicalize_block_yaml",
+    "insert_block_in_yaml",
     "update_block_in_yaml",
     "delete_block_from_yaml",
     "comment_out_block_in_yaml",
@@ -465,17 +466,19 @@ def _stable_block_id(index: int, block: Dict[str, Any]) -> str:
 
 def _uncomment_yaml_block(block_yaml: str) -> str:
     uncommented_lines = []
-    for line in block_yaml.rstrip().splitlines():
-        stripped = line.lstrip()
+    for line in block_yaml.splitlines(keepends=True):
+        content = line.rstrip("\r\n")
+        ending = line[len(content) :]
+        stripped = content.lstrip()
         if stripped.startswith("#"):
-            comment_offset = line.index("#")
-            remainder = line[comment_offset + 1 :]
+            comment_offset = content.index("#")
+            remainder = content[comment_offset + 1 :]
             if remainder.startswith(" "):
                 remainder = remainder[1:]
-            uncommented_lines.append(remainder)
+            uncommented_lines.append(remainder + ending)
         else:
             uncommented_lines.append(line)
-    return "\n".join(uncommented_lines)
+    return "".join(uncommented_lines)
 
 
 def _detect_block_type(block: Dict[str, Any]) -> str:
@@ -642,7 +645,6 @@ def parse_interview_yaml(raw_yaml: str) -> Dict[str, Any]:
         order_blocks: indices of mandatory code blocks (interview order)
         raw_yaml: the original YAML text
     """
-    raw_lines = raw_yaml.splitlines()
 
     def _is_comment_only_segment(segment: str) -> bool:
         lines = [line for line in segment.splitlines() if line.strip()]
@@ -651,26 +653,25 @@ def parse_interview_yaml(raw_yaml: str) -> Dict[str, Any]:
         return all(line.lstrip().startswith("#") for line in lines)
 
     segments: List[Dict[str, Any]] = []
-    segment_start_line = 1
-    segment_lines: List[str] = []
-    for line_number, line in enumerate(raw_lines, start=1):
-        if re.match(r"^---\s*$", line):
-            segments.append(
-                {
-                    "start_line": segment_start_line,
-                    "end_line": line_number - 1,
-                    "text": "\n".join(segment_lines),
-                }
-            )
-            segment_lines = []
-            segment_start_line = line_number + 1
-        else:
-            segment_lines.append(line)
+    body_start = 0
+    for separator in _YAML_DOCUMENT_SEPARATOR_RE.finditer(raw_yaml):
+        body = raw_yaml[body_start : separator.start()]
+        start_line = raw_yaml.count("\n", 0, body_start) + 1
+        segments.append(
+            {
+                "start_line": start_line,
+                "end_line": start_line + len(body.splitlines()) - 1,
+                "text": body,
+            }
+        )
+        body_start = separator.end()
+    body = raw_yaml[body_start:]
+    start_line = raw_yaml.count("\n", 0, body_start) + 1
     segments.append(
         {
-            "start_line": segment_start_line,
-            "end_line": len(raw_lines),
-            "text": "\n".join(segment_lines),
+            "start_line": start_line,
+            "end_line": start_line + len(body.splitlines()) - 1,
+            "text": body,
         }
     )
 
@@ -757,11 +758,10 @@ def parse_interview_yaml(raw_yaml: str) -> Dict[str, Any]:
         editor_objects = (
             _build_editor_objects(doc.get("objects")) if "objects" in doc else []
         )
-        block_yaml = (
-            segment_text
-            if block_type == BLOCK_TYPE_OBJECTS
-            else canonical_block_yaml(doc)
-        )
+        # The source shown in a block's YAML tab must be the source the user
+        # wrote.  Canonicalizing it here silently discarded comments, anchors,
+        # quoting and scalar styles before the user had made any edit.
+        block_yaml = segment_text_raw.strip("\r\n")
 
         block_entry: Dict[str, Any] = {
             "id": block_id,
@@ -924,32 +924,197 @@ def serialize_blocks_to_yaml(blocks: Sequence[Dict[str, Any]]) -> str:
     return "\n---\n".join(parts)
 
 
-def update_block_in_yaml(full_yaml: str, block_id: str, new_block_yaml: str) -> str:
+def _unique_block_document(
+    full_yaml: str, block_id: str
+) -> Tuple[Dict[str, Any], int, int, str]:
+    """Return one block and its exact document-body source range."""
+    matches = [
+        block
+        for block in parse_interview_yaml(full_yaml)["blocks"]
+        if block["id"] == block_id
+    ]
+    if not matches:
+        raise ValueError(f"Block with id {block_id!r} not found in interview YAML")
+    if len(matches) != 1:
+        raise ValueError(
+            f"Block id {block_id!r} is duplicated; edit the IDs in source mode first"
+        )
+    block = matches[0]
+    bodies = _source_document_bodies(full_yaml)
+    document_index = int(block["index"])
+    if document_index < 0 or document_index >= len(bodies):
+        raise ValueError(f"Could not map block {block_id!r} safely to source")
+    start, end, body = bodies[document_index]
+    return block, start, end, body
+
+
+def _mapping_value_ranges(yaml_text: str) -> Dict[str, Tuple[int, int]]:
+    """Return exact top-level YAML value ranges, or an empty mapping."""
+    try:
+        node = yaml.compose(yaml_text)
+    except yaml.YAMLError:
+        return {}
+    if not isinstance(node, yaml.MappingNode):
+        return {}
+    ranges: Dict[str, Tuple[int, int]] = {}
+    for key_node, value_node in node.value:
+        if not isinstance(key_node, yaml.ScalarNode):
+            return {}
+        key = str(key_node.value)
+        if key in ranges:
+            return {}
+        ranges[key] = (value_node.start_mark.index, value_node.end_mark.index)
+    return ranges
+
+
+def _merge_changed_mapping_values(
+    original_body: str, edited_body: str
+) -> Optional[str]:
+    """Patch only semantically changed values in a graphical block edit.
+
+    This keeps comments, anchors, quote choices and scalar styles on unchanged
+    properties.  It is deliberately limited to edits with the same top-level
+    keys; structural changes fall back to exact document-body replacement.
+    """
+    try:
+        original = yaml.safe_load(original_body)
+        edited = yaml.safe_load(edited_body)
+    except yaml.YAMLError:
+        return None
+    if not isinstance(original, dict) or not isinstance(edited, dict):
+        return None
+    if list(original.keys()) != list(edited.keys()):
+        return None
+    original_ranges = _mapping_value_ranges(original_body)
+    edited_ranges = _mapping_value_ranges(edited_body)
+    if set(original_ranges) != set(original) or set(edited_ranges) != set(edited):
+        return None
+
+    def normalized_graphical_value(key: str, value: Any) -> Any:
+        """Remove explicit values that are identical to graphical defaults."""
+        if isinstance(value, str):
+            # Textareas do not represent YAML's final line break separately.
+            # Treat it as presentation so touching another control does not
+            # collapse an unchanged literal block scalar to a plain scalar.
+            return value.rstrip("\r\n")
+        if key == "fields" and isinstance(value, list):
+            normalized_fields: List[Any] = []
+            for field in value:
+                if not isinstance(field, dict):
+                    normalized_fields.append(field)
+                    continue
+                normalized_field = dict(field)
+                if str(normalized_field.get("datatype", "")).lower() == "text":
+                    normalized_field.pop("datatype", None)
+                if normalized_field.get("required") is True:
+                    normalized_field.pop("required", None)
+                normalized_fields.append(normalized_field)
+            return normalized_fields
+        return value
+
+    operations: List[Tuple[int, int, str]] = []
+    for key in original:
+        if normalized_graphical_value(
+            str(key), original[key]
+        ) == normalized_graphical_value(str(key), edited[key]):
+            continue
+        start, end = original_ranges[str(key)]
+        edited_start, edited_end = edited_ranges[str(key)]
+        replacement = edited_body[edited_start:edited_end]
+        original_fragment = original_body[start:end]
+        if original_fragment.endswith("\r\n") and not replacement.endswith(
+            ("\r", "\n")
+        ):
+            replacement += "\r\n"
+        elif original_fragment.endswith("\n") and not replacement.endswith(
+            ("\r", "\n")
+        ):
+            replacement += "\n"
+        elif original_fragment.endswith("\r") and not replacement.endswith(
+            ("\r", "\n")
+        ):
+            replacement += "\r"
+        operations.append((start, end, replacement))
+    updated = original_body
+    for start, end, replacement in reversed(operations):
+        updated = updated[:start] + replacement + updated[end:]
+    return updated
+
+
+def _replace_document_body(
+    full_yaml: str, start: int, end: int, replacement: str
+) -> str:
+    return full_yaml[:start] + replacement + full_yaml[end:]
+
+
+def update_block_in_yaml(
+    full_yaml: str,
+    block_id: str,
+    new_block_yaml: str,
+    *,
+    preserve_unchanged_annotations: bool = False,
+) -> str:
     """Replace a single block in a full interview YAML by its id.
 
-    Locates the block matching *block_id* in the parsed output, then
-    rebuilds the YAML with the replacement.
+    Locates the block matching *block_id* and replaces only its exact source
+    range.  Other documents and separators are never serialized again.
     """
-    model = parse_interview_yaml(full_yaml)
-    blocks = model["blocks"]
-    updated: List[str] = []
-    found = False
-    normalized_new_block_yaml = canonicalize_block_yaml(new_block_yaml)
-    for block in blocks:
-        block_text = (
-            normalized_new_block_yaml if block["id"] == block_id else block["yaml"]
-        )
+    _block, start, end, original_body = _unique_block_document(full_yaml, block_id)
+    edited_body = new_block_yaml.strip("\r\n")
+    replacement: Optional[str] = None
+    if preserve_unchanged_annotations:
+        replacement = _merge_changed_mapping_values(original_body, edited_body)
+    if replacement is None:
+        leading_len = len(original_body) - len(original_body.lstrip("\r\n"))
+        trailing_len = len(original_body) - len(original_body.rstrip("\r\n"))
+        leading = original_body[:leading_len]
+        trailing = original_body[-trailing_len:] if trailing_len else ""
+        replacement = leading + edited_body + trailing
+    return _replace_document_body(full_yaml, start, end, replacement)
 
-        if block["id"] == block_id:
-            found = True
 
-        block_text = block_text.strip()
-        if block_text and block_text != "{}":
-            updated.append(block_text)
+def insert_block_in_yaml(
+    full_yaml: str, new_block_yaml: str, insert_after_id: Optional[str] = None
+) -> str:
+    """Insert one new document without serializing any existing document."""
+    edited_body = new_block_yaml.strip("\r\n")
+    if not edited_body:
+        raise ValueError("block_yaml must be a non-empty YAML string")
+    try:
+        inserted_value = yaml.safe_load(edited_body)
+    except yaml.YAMLError as exc:
+        raise ValueError(f"Invalid YAML: {exc}") from exc
+    if not isinstance(inserted_value, dict):
+        raise ValueError("block_yaml must contain exactly one YAML mapping block")
+    inserted_id = str(inserted_value.get("id") or "").strip()
+    if inserted_id:
+        existing_ids = {
+            str(block.get("id") or "").strip()
+            for block in parse_interview_yaml(full_yaml)["blocks"]
+        }
+        if inserted_id in existing_ids:
+            raise ValueError(f"Block id {inserted_id!r} already exists")
 
-    if not found:
-        raise ValueError(f"Block with id {block_id!r} not found in interview YAML")
-    return "\n---\n".join(updated) + "\n"
+    newline = (
+        "\r\n"
+        if "\r\n" in full_yaml and "\n" not in full_yaml.replace("\r\n", "")
+        else "\n"
+    )
+    document = edited_body + newline
+    if not full_yaml:
+        return document
+    separator = "---" + newline
+    if not insert_after_id:
+        if full_yaml.startswith("%"):
+            raise ValueError(
+                "Top insertion is not safe when the YAML stream begins with directives"
+            )
+        return document + separator + full_yaml
+
+    _block, _start, end, _body = _unique_block_document(full_yaml, insert_after_id)
+    prefix = full_yaml[:end]
+    line_break = "" if prefix.endswith(("\n", "\r")) else newline
+    return prefix + line_break + separator + document + full_yaml[end:]
 
 
 def delete_block_from_yaml(full_yaml: str, block_id: str) -> str:
@@ -958,78 +1123,40 @@ def delete_block_from_yaml(full_yaml: str, block_id: str) -> str:
     Locates the block matching *block_id* in the parsed output, then
     rebuilds the YAML without it.
     """
-    model = parse_interview_yaml(full_yaml)
-    blocks = model["blocks"]
-    updated: List[str] = []
-    found = False
-    for block in blocks:
-        if block["id"] == block_id:
-            found = True
-            continue
-
-        block_text = block["yaml"].strip()
-        if block_text and block_text != "{}":
-            updated.append(block_text)
-
-    if not found:
-        raise ValueError(f"Block with id {block_id!r} not found in interview YAML")
-    return "\n---\n".join(updated) + "\n" if updated else ""
+    _block, start, end, _body = _unique_block_document(full_yaml, block_id)
+    bodies = _source_document_bodies(full_yaml)
+    body_index = next(i for i, item in enumerate(bodies) if item[0] == start)
+    if body_index > 0:
+        # Remove the separator immediately before the deleted body too.
+        start = bodies[body_index - 1][1]
+    elif len(bodies) > 1:
+        # The first document has no preceding separator, so consume the next.
+        end = bodies[1][0]
+    return _replace_document_body(full_yaml, start, end, "")
 
 
 def _comment_yaml_block(block_yaml: str) -> str:
     commented_lines = []
-    for line in block_yaml.rstrip().splitlines():
-        commented_lines.append(f"# {line}" if line else "#")
-    return "\n".join(commented_lines)
+    for line in block_yaml.splitlines(keepends=True):
+        content = line.rstrip("\r\n")
+        ending = line[len(content) :]
+        commented_lines.append((f"# {content}" if content else "#") + ending)
+    return "".join(commented_lines)
 
 
 def comment_out_block_in_yaml(full_yaml: str, block_id: str) -> str:
     """Comment out a single block in a full interview YAML by its id."""
-    model = parse_interview_yaml(full_yaml)
-    blocks = model["blocks"]
-    updated: List[str] = []
-    found = False
-    for block in blocks:
-        block_text = (
-            _comment_yaml_block(block["yaml"])
-            if block["id"] == block_id
-            else block["yaml"]
-        )
-        if block["id"] == block_id:
-            found = True
-
-        block_text = block_text.strip()
-        if block_text and block_text != "{}":
-            updated.append(block_text)
-
-    if not found:
-        raise ValueError(f"Block with id {block_id!r} not found in interview YAML")
-    return "\n---\n".join(updated) + "\n" if updated else ""
+    _block, start, end, body = _unique_block_document(full_yaml, block_id)
+    return _replace_document_body(full_yaml, start, end, _comment_yaml_block(body))
 
 
 def enable_commented_block_in_yaml(full_yaml: str, block_id: str) -> str:
     """Restore a previously commented-out block in a full interview YAML."""
-    model = parse_interview_yaml(full_yaml)
-    blocks = model["blocks"]
-    updated: List[str] = []
-    found = False
-    for block in blocks:
-        if block["id"] == block_id:
-            if block.get("type") != BLOCK_TYPE_COMMENTED:
-                raise ValueError(f"Block with id {block_id!r} is not commented out")
-            uncommented = canonicalize_block_yaml(_uncomment_yaml_block(block["yaml"]))
-            block_text = uncommented
-            found = True
-        else:
-            block_text = block["yaml"]
-
-        block_text = block_text.strip()
-        if block_text and block_text != "{}":
-            updated.append(block_text)
-
-    if not found:
-        raise ValueError(f"Block with id {block_id!r} not found in interview YAML")
-    return "\n---\n".join(updated) + "\n" if updated else ""
+    block, start, end, body = _unique_block_document(full_yaml, block_id)
+    if block.get("type") != BLOCK_TYPE_COMMENTED:
+        raise ValueError(f"Block with id {block_id!r} is not commented out")
+    uncommented = _uncomment_yaml_block(body)
+    return _replace_document_body(full_yaml, start, end, uncommented)
 
 
 def reorder_blocks_in_yaml(full_yaml: str, block_ids: List[str]) -> str:
@@ -1038,20 +1165,26 @@ def reorder_blocks_in_yaml(full_yaml: str, block_ids: List[str]) -> str:
     Locates each block matching the ids in *block_ids*, then rebuilds the YAML
     in the specified order.
     """
-    model = parse_interview_yaml(full_yaml)
-    blocks = model["blocks"]
-    block_map = {block["id"]: block for block in blocks}
-    updated: List[str] = []
-
-    for block_id in block_ids:
-        if block_id not in block_map:
-            raise ValueError(f"Block with id {block_id!r} not found in interview YAML")
-        block = block_map[block_id]
-        block_text = block["yaml"].strip()
-        if block_text and block_text != "{}":
-            updated.append(block_text)
-
-    return "\n---\n".join(updated) + "\n" if updated else ""
+    blocks = parse_interview_yaml(full_yaml)["blocks"]
+    existing_ids = [str(block["id"]) for block in blocks]
+    if len(set(existing_ids)) != len(existing_ids):
+        raise ValueError("Cannot reorder while duplicate block IDs exist")
+    if len(set(block_ids)) != len(block_ids):
+        raise ValueError("block_ids must not contain duplicates")
+    if set(block_ids) != set(existing_ids) or len(block_ids) != len(existing_ids):
+        raise ValueError("block_ids must contain every interview block exactly once")
+    bodies = _source_document_bodies(full_yaml)
+    block_map = {str(block["id"]): block for block in blocks}
+    destination_indexes = sorted(int(block["index"]) for block in blocks)
+    replacements = {
+        destination_index: bodies[int(block_map[block_id]["index"])][2]
+        for destination_index, block_id in zip(destination_indexes, block_ids)
+    }
+    updated = full_yaml
+    for destination_index in reversed(destination_indexes):
+        start, end, _body = bodies[destination_index]
+        updated = updated[:start] + replacements[destination_index] + updated[end:]
+    return updated
 
 
 # ---------------------------------------------------------------------------

--- a/docassemble/ALWeaver/test_api_utils.py
+++ b/docassemble/ALWeaver/test_api_utils.py
@@ -1,4 +1,4 @@
-# do not pre load
+# do not pre-load
 
 import unittest
 from pathlib import Path

--- a/docassemble/ALWeaver/test_docassemble_compat.py
+++ b/docassemble/ALWeaver/test_docassemble_compat.py
@@ -1,4 +1,4 @@
-# do not pre load
+# do not pre-load
 
 from contextlib import contextmanager, nullcontext
 import json

--- a/docassemble/ALWeaver/test_editor_agent.py
+++ b/docassemble/ALWeaver/test_editor_agent.py
@@ -1,4 +1,4 @@
-# do not pre load
+# do not pre-load
 
 """Fake-model tests for the bounded agent loop.
 

--- a/docassemble/ALWeaver/test_editor_agent_api.py
+++ b/docassemble/ALWeaver/test_editor_agent_api.py
@@ -1,4 +1,4 @@
-# do not pre load
+# do not pre-load
 
 """HTTP-level guarantees for the editing-assistant endpoints.
 

--- a/docassemble/ALWeaver/test_editor_agent_rename.py
+++ b/docassemble/ALWeaver/test_editor_agent_rename.py
@@ -1,4 +1,4 @@
-# do not pre load
+# do not pre-load
 
 """Variable renaming: what gets rewritten, what gets left, what gets refused.
 

--- a/docassemble/ALWeaver/test_editor_agent_repair.py
+++ b/docassemble/ALWeaver/test_editor_agent_repair.py
@@ -1,4 +1,4 @@
-# do not pre load
+# do not pre-load
 
 """Deterministic repair of mechanical id problems.
 

--- a/docassemble/ALWeaver/test_editor_agent_tools.py
+++ b/docassemble/ALWeaver/test_editor_agent_tools.py
@@ -1,4 +1,4 @@
-# do not pre load
+# do not pre-load
 
 """Deterministic invariants for the agent's editing tools.
 

--- a/docassemble/ALWeaver/test_editor_ai_utils.py
+++ b/docassemble/ALWeaver/test_editor_ai_utils.py
@@ -1,4 +1,4 @@
-# do not pre load
+# do not pre-load
 
 """Normalisation rules shared by the AI screen drafter and the editing agent.
 
@@ -83,6 +83,16 @@ class TestScreenNormalisation(unittest.TestCase):
 
     def test_a_continue_button_field_is_never_invented_from_nothing(self):
         screen = normalize_generated_screen({"question": "Anything?"})
+        self.assertEqual(screen["continue_button_field"], "")
+
+    def test_fields_and_continue_button_field_are_not_combined(self):
+        screen = normalize_generated_screen(
+            {
+                "question": "Contact information",
+                "fields": [{"label": "Email", "field": "email"}],
+                "continue_button_field": "continue",
+            }
+        )
         self.assertEqual(screen["continue_button_field"], "")
 
     def test_field_variables_stay_on_one_line(self):

--- a/docassemble/ALWeaver/test_editor_api.py
+++ b/docassemble/ALWeaver/test_editor_api.py
@@ -1,4 +1,4 @@
-# do not pre load
+# do not pre-load
 
 from io import BytesIO
 from contextlib import nullcontext
@@ -70,6 +70,7 @@ def _load_api_editor_for_tests():
         "delete_block_from_yaml": lambda content, block_id: content,
         "delete_saved_file": lambda *args, **kwargs: None,
         "generate_draft_order": lambda *args, **kwargs: {},
+        "insert_block_in_yaml": lambda content, block_yaml, insert_after_id=None: content,
         "parse_interview_yaml": lambda *args, **kwargs: {
             "blocks": [],
             "metadata_blocks": [],
@@ -88,7 +89,7 @@ def _load_api_editor_for_tests():
         "source_revision": lambda text: "test-revision",
         "enable_commented_block_in_yaml": lambda content, block_id: content,
         "reorder_blocks_in_yaml": lambda content, order: content,
-        "update_block_in_yaml": lambda content, block_id, new_yaml: content,
+        "update_block_in_yaml": lambda content, block_id, new_yaml, **kwargs: content,
         "update_metadata_documents_in_yaml": lambda content, edited: content,
     }.items():
         setattr(editor_utils, name, func)

--- a/docassemble/ALWeaver/test_editor_frontend.py
+++ b/docassemble/ALWeaver/test_editor_frontend.py
@@ -1,4 +1,4 @@
-# do not pre load
+# do not pre-load
 
 from collections import Counter
 from html.parser import HTMLParser
@@ -258,6 +258,13 @@ class TestEditorFrontend(unittest.TestCase):
         self.assertIn("uiAction === 'save-file'", editor)
         self.assertNotIn("target.id === 'btn-save-file'", editor)
         self.assertIn("saveCurrentFile", editor)
+
+    def test_new_file_and_save_failures_are_reported_to_the_user(self):
+        editor = (self.package_dir / "data/static/editor.js").read_text()
+
+        self.assertIn("Unable to create file: ", editor)
+        self.assertIn("Unable to save metadata safely: ", editor)
+        self.assertIn("Unable to save block: ", editor)
 
     def test_navbar_matches_docassemble_and_carries_the_account_menu(self):
         """The editor is a full-page app that sits where a native docassemble

--- a/docassemble/ALWeaver/test_editor_metadata_safety.py
+++ b/docassemble/ALWeaver/test_editor_metadata_safety.py
@@ -1,4 +1,4 @@
-# do not pre load
+# do not pre-load
 
 import unittest
 

--- a/docassemble/ALWeaver/test_editor_object_primitives.py
+++ b/docassemble/ALWeaver/test_editor_object_primitives.py
@@ -1,3 +1,5 @@
+# do not pre-load
+
 import unittest
 
 from .editor_utils import _al_individual_primitive_groups

--- a/docassemble/ALWeaver/test_editor_patch_api.py
+++ b/docassemble/ALWeaver/test_editor_patch_api.py
@@ -1,4 +1,4 @@
-# do not pre load
+# do not pre-load
 
 import unittest
 from unittest.mock import patch

--- a/docassemble/ALWeaver/test_editor_project_search.py
+++ b/docassemble/ALWeaver/test_editor_project_search.py
@@ -1,4 +1,4 @@
-# do not pre load
+# do not pre-load
 
 import unittest
 

--- a/docassemble/ALWeaver/test_editor_runtime_api.py
+++ b/docassemble/ALWeaver/test_editor_runtime_api.py
@@ -1,4 +1,4 @@
-# do not pre load
+# do not pre-load
 
 import json
 import unittest

--- a/docassemble/ALWeaver/test_editor_security.py
+++ b/docassemble/ALWeaver/test_editor_security.py
@@ -1,4 +1,4 @@
-# do not pre load
+# do not pre-load
 
 from pathlib import Path
 import types

--- a/docassemble/ALWeaver/test_editor_source_preservation.py
+++ b/docassemble/ALWeaver/test_editor_source_preservation.py
@@ -1,0 +1,175 @@
+# do not pre-load
+"""Regression tests for lossless graphical-editor block operations."""
+
+import unittest
+
+from .editor_utils import (
+    comment_out_block_in_yaml,
+    delete_block_from_yaml,
+    enable_commented_block_in_yaml,
+    insert_block_in_yaml,
+    parse_interview_yaml,
+    reorder_blocks_in_yaml,
+    update_block_in_yaml,
+)
+
+SOURCE = (
+    "# file header\n"
+    "metadata:\n"
+    "  title: 'Quoted' # metadata comment\n"
+    "--- # separator annotation\n"
+    "# question lead\n"
+    "id: intro\n"
+    "question: 'Original' # question comment\n"
+    "fields:\n"
+    "  - 'Name': user_name # field comment\n"
+    "---\n"
+    "\n"
+    "---\n"
+    "# code lead\n"
+    "id: calculation\n"
+    "code: |\n"
+    "  # Python comment\n"
+    "  answer = 'yes'\n"
+)
+
+
+class TestEditorSourcePreservation(unittest.TestCase):
+    def test_parser_returns_exact_block_yaml(self):
+        question = next(
+            block
+            for block in parse_interview_yaml(SOURCE)["blocks"]
+            if block["id"] == "intro"
+        )
+        self.assertIn("# question lead", question["yaml"])
+        self.assertIn("'Original' # question comment", question["yaml"])
+        self.assertIn("'Name': user_name # field comment", question["yaml"])
+
+    def test_graphical_value_edit_preserves_all_unchanged_annotations(self):
+        graphical_yaml = (
+            "id: intro\n" "question: |\n" "  Edited\n" "fields:\n" "- Name: user_name\n"
+        )
+        updated = update_block_in_yaml(
+            SOURCE,
+            "intro",
+            graphical_yaml,
+            preserve_unchanged_annotations=True,
+        )
+        self.assertEqual(
+            updated,
+            SOURCE.replace("'Original'", "|\n  Edited\n"),
+        )
+
+    def test_graphical_defaults_do_not_erase_explicit_field_annotations(self):
+        source = SOURCE.replace(
+            "  - 'Name': user_name # field comment\n",
+            "  - 'Name': user_name # field comment\n    datatype: text\n",
+        )
+        graphical_yaml = (
+            "id: intro\n" "question: Edited\n" "fields:\n" "- Name: user_name\n"
+        )
+        updated = update_block_in_yaml(
+            source,
+            "intro",
+            graphical_yaml,
+            preserve_unchanged_annotations=True,
+        )
+        self.assertIn("'Name': user_name # field comment", updated)
+        self.assertIn("    datatype: text", updated)
+
+    def test_graphical_edit_preserves_unchanged_literal_scalar_style(self):
+        source = SOURCE.replace(
+            "question: 'Original' # question comment\n",
+            "question: 'Original' # question comment\n"
+            "subquestion: |\n"
+            "  Literal text.\n",
+        )
+        graphical_yaml = (
+            "id: intro\n"
+            "question: Edited\n"
+            "subquestion: Literal text.\n"
+            "fields:\n"
+            "- Name: user_name\n"
+        )
+        updated = update_block_in_yaml(
+            source,
+            "intro",
+            graphical_yaml,
+            preserve_unchanged_annotations=True,
+        )
+        self.assertIn("subquestion: |\n  Literal text.\n", updated)
+
+    def test_source_edit_replaces_only_target_document(self):
+        edited = (
+            "# new question lead\n"
+            "id: intro\n"
+            "question: Edited # new inline comment\n"
+            "fields:\n"
+            "  - Name: user_name\n"
+        )
+        updated = update_block_in_yaml(SOURCE, "intro", edited)
+        before, rest = SOURCE.split("# question lead", 1)
+        _old_question, after = rest.split("---\n\n---", 1)
+        self.assertEqual(updated, before + edited + "---\n\n---" + after)
+
+    def test_disable_then_enable_is_byte_exact(self):
+        disabled = comment_out_block_in_yaml(SOURCE, "intro")
+        self.assertIn("# # question lead", disabled)
+        self.assertEqual(enable_commented_block_in_yaml(disabled, "intro"), SOURCE)
+
+    def test_delete_preserves_every_other_source_byte(self):
+        updated = delete_block_from_yaml(SOURCE, "intro")
+        expected = SOURCE.replace(
+            "--- # separator annotation\n"
+            "# question lead\n"
+            "id: intro\n"
+            "question: 'Original' # question comment\n"
+            "fields:\n"
+            "  - 'Name': user_name # field comment\n",
+            "",
+        )
+        self.assertEqual(updated, expected)
+
+    def test_reorder_preserves_bodies_separators_and_empty_document(self):
+        ids = [block["id"] for block in parse_interview_yaml(SOURCE)["blocks"]]
+        updated = reorder_blocks_in_yaml(SOURCE, list(reversed(ids)))
+        self.assertIn("--- # separator annotation\n", updated)
+        self.assertIn("---\n\n---\n", updated)
+        for annotation in (
+            "# file header",
+            "# metadata comment",
+            "# question lead",
+            "# question comment",
+            "# field comment",
+            "# code lead",
+            "# Python comment",
+        ):
+            self.assertEqual(updated.count(annotation), 1)
+
+    def test_reorder_rejects_an_incomplete_list(self):
+        with self.assertRaisesRegex(ValueError, "every interview block"):
+            reorder_blocks_in_yaml(SOURCE, ["intro"])
+
+    def test_insert_after_block_preserves_every_existing_byte(self):
+        inserted = "id: added\nquestion: Added\n"
+        updated = insert_block_in_yaml(SOURCE, inserted, "intro")
+        insertion_point = SOURCE.index("---\n\n---", SOURCE.index("id: intro"))
+        self.assertEqual(
+            updated,
+            SOURCE[:insertion_point] + "---\n" + inserted + SOURCE[insertion_point:],
+        )
+
+    def test_insert_rejects_a_duplicate_id_without_changing_source(self):
+        with self.assertRaisesRegex(ValueError, "already exists"):
+            insert_block_in_yaml(
+                SOURCE, "id: intro\nquestion: Duplicate\n", "calculation"
+            )
+
+    def test_duplicate_ids_are_refused_instead_of_replacing_two_blocks(self):
+        duplicated = SOURCE + "---\nid: intro\nquestion: Other\n"
+        with self.assertRaisesRegex(ValueError, "duplicated"):
+            update_block_in_yaml(duplicated, "intro", "id: intro\nquestion: Edited\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docassemble/ALWeaver/test_feeling_lucky.py
+++ b/docassemble/ALWeaver/test_feeling_lucky.py
@@ -1,4 +1,4 @@
-# do not pre load
+# do not pre-load
 
 import unittest
 from .interview_generator import DAInterview

--- a/docassemble/ALWeaver/test_generate_from_path.py
+++ b/docassemble/ALWeaver/test_generate_from_path.py
@@ -1,4 +1,4 @@
-# do not pre load
+# do not pre-load
 
 import os
 import re

--- a/docassemble/ALWeaver/test_llm_robustness.py
+++ b/docassemble/ALWeaver/test_llm_robustness.py
@@ -1,3 +1,5 @@
+# do not pre-load
+
 import unittest
 from types import MethodType
 from unittest.mock import patch

--- a/docassemble/ALWeaver/test_playground_publish.py
+++ b/docassemble/ALWeaver/test_playground_publish.py
@@ -1,3 +1,5 @@
+# do not pre-load
+
 import unittest
 import tempfile
 from pathlib import Path

--- a/docassemble/ALWeaver/test_source_document.py
+++ b/docassemble/ALWeaver/test_source_document.py
@@ -1,4 +1,4 @@
-# do not pre load
+# do not pre-load
 
 from pathlib import Path
 import unittest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,100 +66,59 @@ show_error_codes = true
 # per-module options:
 [[tool.mypy.overrides]]
 module = "pikepdf.*"
-ignore_missing_imports=true
+ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "docassemble.base.*"
-ignore_missing_imports=true
-
-[[tool.mypy.overrides]]
-module = "docassemble.webapp.*"
-ignore_missing_imports=true
-disable_error_code=["import-untyped"]
-
-[[tool.mypy.overrides]]
-module = "docassemble.webapp.worker_common"
-ignore_missing_imports=true
-disable_error_code=["import-untyped"]
-
-[[tool.mypy.overrides]]
-module = "docassemble.AssemblyLine"
-ignore_missing_imports=true
-disable_error_code=["import-untyped"]
-
-[[tool.mypy.overrides]]
-module = "docassemble.AssemblyLine.*"
-ignore_missing_imports=true
-disable_error_code=["import-untyped"]
-
-[[tool.mypy.overrides]]
-module = "docassemble.ALWeaver.validate_template_files"
-disable_error_code=["import-untyped"]
+ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "more_itertools"
-ignore_missing_imports=true
-
-[[tool.mypy.overrides]]
-module = "sklearn.*"
-ignore_missing_imports=true
+ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "docxtpl"
-ignore_missing_imports=true
+ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "docx2python"
-ignore_missing_imports=true
+ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "bs4"
-ignore_missing_imports=true
+ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "mako.*"
-ignore_missing_imports=true
+ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "flask_cors"
-ignore_missing_imports=true
-disable_error_code=["import-untyped"]
+ignore_missing_imports = true
+disable_error_code = ["import-untyped"]
 
 [[tool.mypy.overrides]]
 module = "flask_login"
-ignore_missing_imports=true
-disable_error_code=["import-untyped"]
+ignore_missing_imports = true
+disable_error_code = ["import-untyped"]
 
 [[tool.mypy.overrides]]
 module = "flask_wtf.*"
-ignore_missing_imports=true
-disable_error_code=["import-untyped"]
-
-[[tool.mypy.overrides]]
-module = "mypy-pdfminer.*"
-ignore_missing_imports=true
-
-[[tool.mypy.overrides]]
-module = "mypy-ruamel"
-ignore_missing_imports=true
+ignore_missing_imports = true
+disable_error_code = ["import-untyped"]
 
 [[tool.mypy.overrides]]
 module = "formfyxer"
-ignore_missing_imports=true
+ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "docassemble.ALDashboard.interview_linter"
-ignore_missing_imports=true
+ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "docassemble.ALDashboard.review_screen_generator"
-ignore_missing_imports=true
+ignore_missing_imports = true
 
-disable_error_code=["import-untyped"]
-
-[[tool.mypy.overrides]]
-module = "docassemble.ALWeaver.interview_generator"
-disable_error_code=["import-untyped"]
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
* Created a test matrix for several common operations
* Walked through; discovered some round-trip bugs, fixed in this branch

## Executed browser matrix

| Area | Case | Expected invariant | Result |
| --- | --- | --- | --- |
| Boot/auth | Authenticated editor and project discovery | Editor loads with no page error and lists `default` | Pass |
| File lifecycle | Create, rename, and delete YAML file through UI | Each operation updates the file picker and persisted file | Pass |
| Graphical edit | Change only question text | Top Save enables; every unrelated byte and all comments remain | Pass |
| Block YAML | Edit question in its YAML tab | Submitted comments and formatting persist; other documents are exact | Pass |
| Metadata block | Edit metadata block source | Top Save enables; only metadata document body changes | Pass |
| Full YAML | Edit complete source | Save enables and `raw_yaml` equals the submitted buffer byte-for-byte | Pass |
| Metadata source | Edit the scoped Metadata tab | Metadata/include/default-parts update; nonmetadata bytes remain exact | Pass |
| Navigation | Stay with unsaved graphical work | Remains in Interview view and keeps dirty buffer | Pass |
| Navigation | Discard unsaved graphical work | Navigates and restores the saved model without writing | Pass |
| Navigation | Save unsaved work before navigating | Persists the intended edit, then navigates | Pass |
| Disable/enable | Comment out and re-enable a block | Complete disable/enable cycle is byte-exact | Pass |
| Reorder | Move a block to the bottom | Bodies move; comments, separators, empty docs, and counts remain | Pass |
| Insert | Insert a question after an existing question | New document is added without changing any pre-existing byte | Pass |
| Order builder | Open an existing mandatory order block | Existing screen references parse into the builder | Pass |
| Assistant | Open assistant panel | Panel opens without changing interview source | Pass |
| Project search | Preview and apply a selected replacement | Only selected exact span changes | Pass |
| Download | Download current interview | Downloaded bytes equal `raw_yaml` | Pass |
| Concurrency | Save stale metadata after a concurrent full-source write | 409 is explained to the user; newer source is not overwritten | Pass |
| Validation | Validate an unsaved graphical buffer | Drawer identifies unsaved source; saved file remains unchanged | Pass |
| Ambiguity | Edit a file with duplicate block IDs | Request is refused and source remains unchanged | Pass |
| File areas | Visit Templates, Modules, Static, Sources, Interview | All views load without a browser page error | Pass |

Final browser result: **21 passed, 0 failed**. The only console-level failed
resource messages were the intentionally induced 409 stale-revision response
and 400 duplicate-ID response; both were handled and produced no unhandled page
error.

## Bugs reproduced and fixed

1. **Whole-stream source loss on block operations.** Editing one graphical
   question caused all documents to be parsed and dumped again. It erased
   unrelated comments, quote choices, indentation, and literal-scalar styles.
   Delete, disable, enable, reorder, and insert used the same lossy pattern.
   These operations now modify exact document-body ranges. Reorder requires
   every block exactly once, duplicate IDs are rejected, empty documents remain
   in place, and insertion retains every existing byte.

2. **YAML-tab comments disappeared before editing.** Parsed blocks exposed a
   canonical dump as `block.yaml`. The YAML tab now receives the exact document
   source.

3. **Graphical defaults rewrote unchanged annotations.** A graphical question
   save omitted explicit defaults such as `datatype: text` and normalized final
   newlines, which made unchanged fields and literal scalars look modified.
   Graphical saves now patch only semantically changed top-level values and
   treat textarea terminal newlines and explicit graphical defaults as
   equivalent. Inline comments on the changed scalar remain in place.

4. **Save failures could be silent.** Stale metadata and duplicate-ID errors
   rejected the request but raised an unhandled `EditorApiError`, leaving no
   useful UI explanation. Metadata, full-source, block, order, secondary-file,
   and New File failures now show an alert and leave dirty state intact.
