### PR TITLE
Interview template fixes

### DIFF
--- a/docassemble/ALWeaver/data/templates/output.mako
+++ b/docassemble/ALWeaver/data/templates/output.mako
@@ -411,10 +411,10 @@ event: review_${ interview.interview_label }
 question: |
   Review your answers
 review:
-  % for coll in interview.all_fields.find_parent_collections():
+  % for coll in review_collections:
 ${ review_yaml(coll) | trim }\
   % endfor
-% for coll in interview.all_fields.find_parent_collections():
+% for coll in review_collections:
   % if coll.var_type == 'list':
 ---
 id: ${ fix_id("edit " + coll.var_name) }

--- a/docassemble/ALWeaver/data/templates/output.mako
+++ b/docassemble/ALWeaver/data/templates/output.mako
@@ -43,7 +43,56 @@
       else:
           jurisdiction_value = "NAM-US"
   intro_prompt_value = str(getattr(interview, "intro_prompt", "") or "")
-%>
+
+  allowed_courts_value = sorted(
+      set(
+          interview.allowed_courts.true_values()
+          + (
+              interview.allowed_courts_text.split(",")
+              if interview.allowed_courts.get("Other")
+              else []
+          )
+      )
+      - {"Other"}
+  )
+
+  has_addendum = interview.all_fields.has_addendum_fields()
+  aldocument_kwargs = "enabled=True, has_addendum=%s" % has_addendum
+  if has_addendum:
+      aldocument_kwargs += ", default_overflow_message=AL_DEFAULT_OVERFLOW_MESSAGE"
+
+  # The name of the ALDocument variable each uploaded template is attached to.
+  if len(interview.uploaded_templates) == 1:
+      attachment_variable_names = {
+          interview.uploaded_templates[0].filename: f"{ interview.interview_label }_attachment"
+      }
+  else:
+      attachment_variable_names = {
+          document.filename: varname(base_name(document.filename))
+          for document in interview.uploaded_templates
+      }
+
+  # Every signature the finished document needs, whether it belongs to a person
+  # in an ALPeopleList (built-in) or is a standalone signature field. Anything in
+  # this list is gathered by `basic_questions_signature_flow`, so the preview and
+  # signature screens are only worth generating when it is non-empty.
+  signature_field_triggers = list(
+      dict.fromkeys(
+          list(interview.all_fields.built_in_signature_triggers())
+          + [
+              field.trigger_gather(interview.all_fields.custom_people_plurals)
+              for field in interview.all_fields.signatures()
+          ]
+      )
+  )
+
+  # Emitted once, inside the first `attachment` block it describes.
+  attachment_key_comment = (
+      "# Each attachment defines a key in an ALDocument. We use `i` as the placeholder here so the\n"
+      "# same template is used for \"preview\" and \"final\" keys, and logic in the template checks\n"
+      "# the value of `i` to show or hide the user's signature"
+  )
+%>\
 ---
 include:
   - docassemble.AssemblyLine:assembly_line.yml
@@ -58,17 +107,23 @@ metadata:
     ${ interview.short_title }
   description: |-
 ${ indent(interview.description, by=4) }
-  can_I_use_this_form: |
 % if getattr(interview, "can_I_use_this_form", ""):
+  can_I_use_this_form: |
 ${ indent(interview.can_I_use_this_form, by=4) }
+% else:
+  can_I_use_this_form: ""
 % endif
-  before_you_start: |
 % if getattr(interview, "getting_started", ""):
+  before_you_start: |
 ${ indent(interview.getting_started, by=4) }
+% else:
+  before_you_start: ""
 % endif
-  when_you_are_finished: |
 % if getattr(interview, "when_you_are_finished", ""):
+  when_you_are_finished: |
 ${ indent(interview.when_you_are_finished, by=4) }
+% else:
+  when_you_are_finished: ""
 % endif
   efiling_enabled: ${ "True" if getattr(interview, "efiling_enabled", False) else "False" }
   integrated_efiling: ${ "True" if getattr(interview, "integrated_efiling", False) else "False" }
@@ -88,13 +143,13 @@ ${ indent(landing_page_url_value, by=4) }
     % for category in topic_values:
     - "${ escape_double_quoted_yaml(oneline(category)).strip() }"
     % endfor
+  % if interview.categories.any_true() or len(other_categories_selected) > 0:
+  # Keep legacy tags behavior for compatibility with downstream tools.
+  % endif
   tags:
     % for category in topic_values:
     - "${ escape_double_quoted_yaml(oneline(category)).strip() }"
     % endfor
-  % if interview.categories.any_true() or len(other_categories_selected) > 0:
-  # Keep legacy tags behavior for compatibility with downstream tools.
-  % endif
   authors:
     % for author in interview.author.splitlines():
     - ${ author }
@@ -116,11 +171,11 @@ ${ indent(interview.help_page_url, by=4) }
   help_page_title: >-
 ${ indent(interview.help_page_title, by=4) }
   % endif
-  % if len(interview.allowed_courts.true_values()) < 1:
+  % if len(allowed_courts_value) < 1:
   allowed_courts: []
   % else:
-  allowed_courts: 
-    % for court in sorted(set(interview.allowed_courts.true_values() + (interview.allowed_courts_text.split(",") if interview.allowed_courts.get("Other") else [])) - {"Other"}):
+  allowed_courts:
+    % for court in allowed_courts_value:
     - "${ escape_double_quoted_yaml(oneline(court)).strip() }"
     % endfor
   % endif
@@ -145,7 +200,7 @@ ${ indent(interview.help_page_title, by=4) }
   fees:
     - Filing fee: ${ currency(interview.filing_fee) }
   % endif
-  update_notes: |
+  update_notes: ""
 ---
 code: |
   # This controls the default country and list of states in address field questions
@@ -156,7 +211,7 @@ code: |
   AL_DEFAULT_STATE = "${ interview.state }"
 ---
 code: |
-  github_repo_name =  'docassemble-${ interview.package_title }'
+  github_repo_name = 'docassemble-${ interview.package_title }'
 % if intro_prompt_value:
 ---
 template: interview_short_title
@@ -166,7 +221,7 @@ ${ indent(intro_prompt_value, by=2) }
 % if generate_download_screen:
 ---
 code: |
-  al_form_type = "${ interview.form_type }" 
+  al_form_type = "${ interview.form_type }"
 % endif
 % if len(objects) > 0:
 ---
@@ -182,15 +237,18 @@ sections:
   % endfor
   - review_${ interview.interview_label }: Review your answers
 ---
-#################### Interview order #####################
+<%text>#################### Interview order #####################</%text>
 comment: |
   Controls order and branching logic for questions specific to this form
 id: interview_order_${ interview.interview_label }
 code: |
-  % if generate_download_screen:
+  % if generate_download_screen and interview.court_related:
+  % if allowed_courts_value:
   # Set the allowed courts for this interview
-  % if interview.court_related:
-  allowed_courts = ${ repr(sorted(interview.allowed_courts.true_values() + (interview.allowed_courts_text.split(",") if interview.allowed_courts.get("Other") else []))) }
+  allowed_courts = ${ repr(allowed_courts_value) }
+  % else:
+  # Uncomment and list the courts this form can be filed in, for example:
+  # allowed_courts = ["Boston Municipal Court"]
   % endif
   % endif
   % if interview.typical_role == 'unknown':
@@ -209,7 +267,7 @@ code: |
   % endif
   interview_order_${ interview.interview_label } = True
 ---
-###################### Main order ######################
+<%text>###################### Main order ######################</%text>
 comment: |
   This block includes the logic for standalone interviews.
   Delete mandatory: True to include in another interview
@@ -228,12 +286,9 @@ code: |
           "reached_interview_end": True,
       },
   )
-  % if len(interview.all_fields.signatures()) > 0:
+  % if signature_field_triggers:
   ${ interview.interview_label }_preview_question
-  basic_questions_signature_flow    
-  % for signature_field in interview.all_fields.signatures():
-  ${ signature_field.trigger_gather(interview.all_fields.custom_people_plurals) }
-  % endfor
+  basic_questions_signature_flow
   % endif
   ${ interview.interview_label }_download
   % else:
@@ -242,25 +297,20 @@ code: |
 <%doc>
     Question blocks
 </%doc>\
-<%doc>
-    TODO(qs): 
-      - add _intro to question ID (after finished testing equivalence to output_patterns.yml)
-      - just use interview_label instead of varname(interview.title)
-</%doc>\
 ---
-id: ${ varname(interview.title) }
+id: ${ fix_id(interview.title) } intro
 continue button field: ${ interview.interview_label }_intro
 question: |
   ${ interview.title }
 subquestion: |
 ${ indent(interview.getting_started, 2) }
+% if getattr(interview, 'can_I_use_this_form', ''):
 
-% if hasattr(interview, 'can_I_use_this_form'):
 ${ indent(interview.can_I_use_this_form, by=2)}
 % endif
+% if getattr(interview, 'estimated_completion_minutes', ''):
 
-% if hasattr(interview, 'estimated_completion_minutes'):
-  Most people take about ${ interview.estimated_completion_minutes or "_______________"} minutes to complete this interview.
+  Most people take about ${ interview.estimated_completion_minutes } minutes to complete this interview.
 % endif
 <%doc>
     Main question loop
@@ -291,14 +341,14 @@ continue button field: ${ varname(question.question_text) }
 <%doc>
     End question loop
 </%doc>\
-% if generate_download_screen:
+% if generate_download_screen and signature_field_triggers:
 ---
 id: preview ${ interview.interview_label }
 question: |
   Preview your form before you sign it
 subquestion: |
-  Here is a preview of the form you will sign on the next page.   
-  
+  Here is a preview of the form you will sign on the next page.
+
   % if interview.court_related:
   <%text>${</%text> al_court_bundle.as_pdf(key='preview') <%text>}</%text>
   % else:
@@ -309,17 +359,17 @@ subquestion: |
   answers.
 
   <%text>${</%text> action_button_html(url_action('review_${ interview.interview_label }'), label=word('Edit answers'), color='info') <%text>}</%text>
-  
+
   Return to this interview tab to continue and sign your form.
-continue button field: ${ interview.interview_label }_preview_question    
+continue button field: ${ interview.interview_label }_preview_question
 % endif
 <%doc>
     TODO(qs): signature fields shouldn't depend on whether we have a download screen
 </%doc>\
-% if generate_download_screen:
+% if generate_download_screen and signature_field_triggers:
 ---
 code: |
-  signature_fields = ${ str(list(interview.all_fields.built_in_signature_triggers()) + [field.trigger_gather(interview.all_fields.custom_people_plurals) for field in interview.all_fields.signatures()] ) }
+  signature_fields = ${ repr(signature_field_triggers) }
 % endif
 % for custom_signature in interview.all_fields.custom_signatures():
 ---
@@ -345,7 +395,7 @@ code: |
 ---
 code: |
   # This is a placeholder for the addresses that will be searched
-  # for matching address to court. Edit if court venue is based on 
+  # for matching address to court. Edit if court venue is based on
   # a different address than the user's
   [user.address.address for user in users.complete_elements()]
   addresses_to_search = [user.address for user in users.complete_elements()]
@@ -376,7 +426,6 @@ subquestion: |
 
   ${ "${ " + coll.var_name + ".add_action() }" }
 ${ table_page(coll) }
-
   % endif
 % endfor
 <%doc>
@@ -391,15 +440,13 @@ question: |
   All done
 subquestion: |
   Thank you <%text>${users}</%text>. Your form is ready to download and deliver.
-  
+
   Use the options on this page to view, download and send your form. Use the
   "Edit answers" button to fix any mistakes.
 
   <%text>${</%text> action_button_html(url_action('review_${ interview.interview_label }'), label=word('Edit answers'), color='info') <%text>}</%text>
-  
-  <%text>
-  ${ al_user_bundle.download_list_html() }
-  </%text>
+
+  <%text>${ al_user_bundle.download_list_html() }</%text>
 
   <%text>${</%text> al_user_bundle.send_button_html(show_editable_checkbox=${False if any(map(lambda templ: templ.mimetype == "application/pdf", interview.uploaded_templates)) else True}) <%text>}</%text>
 
@@ -415,8 +462,8 @@ event: ${ interview.interview_label }_thank_you
 question: |
   Thank You!
 subquestion: |
-  Thank you for submitting your answers! We appreciate your time. 
-  
+  Thank you for submitting your answers! We appreciate your time.
+
   A copy of your answers was saved in our database.
 
 progress: 100
@@ -451,10 +498,10 @@ objects:
   - ${ interview.interview_label }_Post_interview_instructions: ALDocument.using(filename="${ interview.interview_label }_next_steps.docx", enabled=True, has_addendum=False)
   % endif
   % if len(interview.uploaded_templates) == 1:
-  - ${ interview.interview_label }_attachment: ALDocument.using(filename="${ interview.interview_label }", enabled=True, has_addendum=${ interview.all_fields.has_addendum_fields() }, ${ "default_overflow_message=AL_DEFAULT_OVERFLOW_MESSAGE" if interview.all_fields.has_addendum_fields() else ''})
+  - ${ interview.interview_label }_attachment: ALDocument.using(filename="${ interview.interview_label }", ${ aldocument_kwargs })
   % else:
   % for document in interview.uploaded_templates:
-  - ${ varname(base_name(document.filename)) }: ALDocument.using(filename="${ base_name(document.filename) }", enabled=True, has_addendum=${ interview.all_fields.has_addendum_fields() }, ${ "default_overflow_message=AL_DEFAULT_OVERFLOW_MESSAGE" if interview.all_fields.has_addendum_fields() else ''})
+  - ${ varname(base_name(document.filename)) }: ALDocument.using(filename="${ base_name(document.filename) }", ${ aldocument_kwargs })
   % endfor
   % endif
 ---
@@ -504,11 +551,10 @@ template: al_recipient_bundle.title
 content: |
   All forms to file
 % endif
-# Each attachment defines a key in an ALDocument. We use `i` as the placeholder here so the same template is 
-# used for "preview" and "final" keys, and logic in the template checks the value of 
-# `i` to show or hide the user's signature
 % if interview.include_next_steps:
 ---
+${ attachment_key_comment }
+<% attachment_key_comment = "" %>\
 attachment:
   name: Post-interview-Instructions
   filename: ${ interview.interview_label }_next_steps
@@ -519,22 +565,25 @@ attachment:
 % endif
 % for document in interview.uploaded_templates:
 ---
+% if attachment_key_comment:
+${ attachment_key_comment }
+<% attachment_key_comment = "" %>\
+% endif
 attachment:
 % if len(interview.uploaded_templates) == 1:
   name: ${ interview.interview_label.replace('_',' ') }
   filename: ${ interview.interview_label }
-  variable name: ${ interview.interview_label }_attachment[i]
 % else:
   name: ${ base_name(document.filename).replace('_',' ') }
   filename: ${ base_name(document.filename) }
-  variable name: ${ varname(base_name(document.filename)) }[i]
 % endif
+  variable name: ${ attachment_variable_names[document.filename] }[i]
 % if document.mimetype == "application/pdf":
   skip undefined: True
   pdf template file: ${ document.filename }
   fields:
     % for field in interview.all_fields.matching_pdf_fields_from_file(document):
-${ attachment_yaml(field, attachment_name=f"{ interview.interview_label}_attachment") }\
+${ attachment_yaml(field, attachment_name=attachment_variable_names[document.filename]) }\
     % endfor
 % else:
   skip undefined: True
@@ -542,26 +591,28 @@ ${ attachment_yaml(field, attachment_name=f"{ interview.interview_label}_attachm
   tagged pdf: True
 % endif
 % endfor
-% if interview.all_fields.has_addendum_fields():
+% if has_addendum:
 ---
 code: |
+  % for attachment_variable_name in attachment_variable_names.values():
   % for field in interview.all_fields.addendum_fields():
   ${ attachment_variable_name }.overflow_fields["${ field.variable }"].overflow_trigger = ${ field.maxlength }
   ${ attachment_variable_name }.overflow_fields["${ field.variable }"].label = "${ field.label }"
   % endfor
   ${ attachment_variable_name }.overflow_fields.gathered = True
-  % endif
+  % endfor
 <%doc>
-    End optional addendum code block    
-</%doc>
+    End optional addendum code block
+</%doc>\
+% endif
 % endif
 <%doc>
     End optional blocks related to attachments (if generating a file as output)
-</%doc>
+</%doc>\
 <%doc>
   HACK: add the name change questions directly to the Weaver output for now. See https://github.com/SuffolkLITLab/docassemble-AssemblyLine/pull/668#discussion_r1149774674
   We need a more generalized way to do this in the future but this can get us through LIT Con
-</%doc>
+</%doc>\
 % if showifdef("add_name_change_questions"):
 ---
 id: consent of parent 1

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -113,6 +113,21 @@ _PERSON_DEFAULT_PARAMS: Dict[str, Dict[str, Any]] = {
     "guardians_ad_litem": {"ask_number": True},
 }
 
+# Objects AssemblyLine defines and configures itself. Re-declaring these in the
+# generated interview would clobber that setup -- `courts`, for instance, is an
+# ALCourtLoader-backed list whose gathering drives the court picker, and
+# `plaintiffs`/`defendants` are derived from `users` and `other_parties`.
+_AL_MANAGED_OBJECTS: Set[str] = {
+    "case_numbers",
+    "courts",
+    "defendants",
+    "docket_numbers",
+    "petitioners",
+    "plaintiffs",
+    "respondents",
+    "trial_court",
+}
+
 
 __all__ = [
     "attachment_download_html",
@@ -1801,12 +1816,42 @@ class DAInterview(DAObject):
             self.questions.all_fields_used(all_fields=self.all_fields.custom())
         ) < len(self.all_fields.custom())
 
+    def _referenced_objects(self) -> Tuple[Set[str], Set[str]]:
+        """Names the generated interview actually treats as objects.
+
+        Everything the review screens, tables and interview order block reference
+        comes from :meth:`DAFieldList.find_parent_collections`, so that is the
+        authoritative answer to "what did we turn into an object?".  Returns a
+        ``(lists, singletons)`` pair: names used as ``x.gather()`` / ``x[0].attr``
+        and names used as ``x.attr`` respectively.
+        """
+        lists: Set[str] = set()
+        singletons: Set[str] = set()
+        for collection in self.all_fields.find_parent_collections():
+            var_name = collection.var_name
+            if collection.var_type == "list":
+                if var_name.isidentifier():
+                    lists.add(var_name)
+            elif "." in var_name:
+                root = var_name.split(".", 1)[0]
+                if root.isidentifier() and not keyword.iskeyword(root):
+                    singletons.add(root)
+        return lists, singletons
+
     def _guess_objects_list(self) -> List[_PersonObjectSpec]:
         """Build an objects list for the generated interview using field analysis heuristics.
 
         Mirrors the person candidate consolidation logic in assembly_line.yml and
         adds quantity guessing from field index numbers.  Always includes ``users``.
+
+        Every name the interview gathers as a list gets an entry, so a variable
+        like ``my_user[0].name.last`` can never end up referenced without a
+        matching ``objects`` block.  Conversely, a person the heuristics guessed
+        at but that no field actually uses as a list (a lone ``inspector_name``
+        text field, say) is dropped rather than declared and left unused.
         """
+        referenced_lists, referenced_singletons = self._referenced_objects()
+
         person_candidates: Set[str] = set(self.all_fields.get_person_candidates())
         person_candidates.add("users")
 
@@ -1817,10 +1862,16 @@ class DAInterview(DAObject):
             "respondents" in person_candidates and "petitioners" in person_candidates
         ):
             person_candidates.add("other_parties")
-        person_candidates.discard("petitioners")
-        person_candidates.discard("respondents")
-        person_candidates.discard("plaintiffs")
-        person_candidates.discard("defendants")
+
+        # `users` and `other_parties` back AssemblyLine's own party logic, so they
+        # are declared whether or not a field mentions them directly.
+        person_candidates = (person_candidates & referenced_lists) | (
+            {"users", "other_parties"} & person_candidates
+        )
+        person_candidates |= referenced_lists
+        person_candidates -= _AL_MANAGED_OBJECTS
+
+        singletons = referenced_singletons - _AL_MANAGED_OBJECTS - person_candidates
 
         quantities = self.all_fields._guess_people_quantities()
 
@@ -1834,6 +1885,8 @@ class DAInterview(DAObject):
             else:
                 params = dict(_PERSON_DEFAULT_PARAMS.get(person, {}))
             result.append(_PersonObjectSpec(name=person, params=params))
+        for singleton in sorted(singletons):
+            result.append(_PersonObjectSpec(name=singleton, type="ALIndividual"))
         return result
 
     def draft_screen_order(self, instanceName: str = "screen_order") -> DAList:
@@ -5246,6 +5299,46 @@ def _apply_plain_language_repairs(yaml_text: str, max_rewrites: int = 8) -> str:
     return updated
 
 
+def _tidy_generated_yaml(yaml_text: str) -> str:
+    """Clean up the whitespace Mako leaves behind in a rendered interview.
+
+    Mako emits a newline for every control-flow line that isn't backslash-continued,
+    which leaves a run of blank lines wherever the template opens with a ``<%doc>``
+    or ``<%`` block and again wherever it closes with one.  The result is a file
+    that starts and ends with several blank lines, and that can have large blank
+    runs between blocks.  None of that changes what Docassemble parses, but it
+    makes the generated YAML look unfinished to the person who has to edit it next.
+
+    Applied to the rendered output rather than to ``output.mako`` so that custom
+    output templates from other packages get the same treatment.
+    """
+    lines = yaml_text.replace("\r\n", "\n").split("\n")
+
+    tidied: List[str] = []
+    blank_run = 0
+    for line in lines:
+        if line.strip():
+            blank_run = 0
+            tidied.append(line)
+            continue
+        blank_run += 1
+        # Keep single blank lines (they are meaningful inside Markdown block
+        # scalars) but collapse anything longer.
+        if blank_run < 2 and tidied:
+            tidied.append("")
+
+    while tidied and not tidied[0].strip():
+        tidied.pop(0)
+    while tidied and not tidied[-1].strip():
+        tidied.pop()
+
+    if not tidied:
+        return ""
+    if tidied[0].strip() != "---":
+        tidied.insert(0, "---")
+    return "\n".join(tidied) + "\n"
+
+
 def _repair_generated_yaml_with_lint(
     yaml_text: str, interview: DAInterview, max_passes: int = 3
 ) -> str:
@@ -5406,8 +5499,8 @@ def _render_interview_yaml(
         "remove_multiple_appearance_indicator": remove_multiple_appearance_indicator,
         "get_yml_deps_from_choices": get_yml_deps_from_choices,
     }
-    yaml_text = template.render(**context)
-    return _repair_generated_yaml_with_lint(yaml_text, interview)
+    yaml_text = _tidy_generated_yaml(template.render(**context))
+    return _tidy_generated_yaml(_repair_generated_yaml_with_lint(yaml_text, interview))
 
 
 def _assign_next_steps_template(interview: DAInterview) -> None:

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -961,6 +961,62 @@ class DAField(DAObject):
         return f"{self.variable} ({self.raw_field_names}, {self.final_display_var})"
 
 
+def _with_progress_markers(entries: List[Tuple[str, bool]]) -> List[str]:
+    """Interleave ``set_progress()`` calls through an interview order block.
+
+    The percentage is derived from how far through the screens each marker
+    actually sits, so the bar climbs steadily instead of stalling: the old
+    version added a fixed increment sized for more steps than it ever emitted,
+    which left a twenty-screen interview showing 66% on its last question.
+
+    Progress tops out around 90 because the screens are not the whole interview
+    -- the signature flow and the download screen still follow, and the download
+    screen sets ``progress: 100`` itself.
+    """
+    screen_positions = [
+        index for index, (_, is_screen) in enumerate(entries) if is_screen
+    ]
+    total_screens = len(screen_positions)
+
+    # A progress step every 5 screens, unless the interview is short.
+    screen_divisor = 5 if total_screens > 20 else 3
+    markers: Dict[int, int] = {}
+    if total_screens > screen_divisor:
+        last_value = 0
+        for screens_so_far, entry_index in enumerate(screen_positions):
+            if not screens_so_far or screens_so_far % screen_divisor:
+                continue
+            value = round(screens_so_far / total_screens * 90)
+            if value <= last_value:
+                continue
+            markers[entry_index] = value
+            last_value = value
+
+    lines: List[str] = []
+    for index, (line, _is_screen) in enumerate(entries):
+        if index in markers:
+            lines.append(f"set_progress({markers[index]})")
+        lines.append(line)
+    return lines
+
+
+def _is_signature_only_collection(collection: "ParentCollection") -> bool:
+    """True for review-screen entries that only exist to be signed.
+
+    Signatures and ``signature_date`` are gathered by
+    ``basic_questions_signature_flow`` immediately before the download screen, so
+    an "Edit" link for them on the review screen would either be overwritten
+    moments later or let someone change a date they never picked.
+    """
+    if collection.var_type != "primitive":
+        return False
+    return all(
+        (getattr(field, "group", None) == DAFieldGroup.SIGNATURE)
+        or getattr(field, "final_display_var", "") == "signature_date"
+        for field in collection.fields
+    )
+
+
 class ParentCollection(object):
     """A ParentCollection is "highest" level of data structure containing some DAField.
     For example, the parent collection for `users[0].name.first` is `users`, since that is the list
@@ -1151,6 +1207,47 @@ class DAFieldList(DAList):
             )
             for var_and_type, fields in parent_coll_map.items()
         ]
+
+    def review_collections(
+        self, screen_order: Optional[Sequence[Any]] = None
+    ) -> List[ParentCollection]:
+        """The parent collections a review screen should offer, in asking order.
+
+        ``find_parent_collections`` groups fields by parent but hands them back in
+        whatever order the fields happen to sit in the field list, which is not the
+        order the interview asks for them. Sorting by first appearance in
+        ``screen_order`` means the review screen reads like a recap of what the user
+        just did rather than an arbitrary list.
+        """
+        collections = [
+            collection
+            for collection in self.find_parent_collections()
+            if not _is_signature_only_collection(collection)
+        ]
+        if not screen_order:
+            return collections
+
+        # Number every field in the order it is asked, so collections sort by
+        # their position *within* a screen too, not just by which screen they
+        # landed on.
+        position: Dict[str, int] = {}
+        for screen in screen_order:
+            fields = screen.field_list if hasattr(screen, "field_list") else [screen]
+            for field in fields:
+                variable = getattr(field, "variable", None)
+                if variable and variable not in position:
+                    position[variable] = len(position)
+        unplaced = len(position)
+
+        def sort_key(collection: ParentCollection) -> Tuple[int, str]:
+            positions = [
+                position[field.variable]
+                for field in collection.fields
+                if getattr(field, "variable", None) in position
+            ]
+            return (min(positions) if positions else unplaced, collection.var_name)
+
+        return sorted(collections, key=sort_key)
 
     def add_fields_from_file(self, document: Union[DAFile, DAFileList]) -> None:
         """
@@ -1628,22 +1725,9 @@ class DAQuestionList(DAList):
         if not screens:
             screens = list(self)
 
-        logic_list = []
-
-        total_num_screens = len(screens)
-
-        # We'll have a progress step every 5 screens,
-        # unless it's very short
-        if total_num_screens > 20:
-            screen_divisor = 5
-        else:
-            screen_divisor = 3
-
-        total_steps = (
-            round(total_num_screens / screen_divisor) + 2
-        )  # signature screen adds two steps
-        increment = int(100 / total_steps)
-        progress = 0
+        # Each entry is (line, counts_as_a_screen).  Only the screens count
+        # toward progress; navigation and bookkeeping lines do not.
+        logic_list: List[Tuple[str, bool]] = []
 
         saved_answer_name_flag = False
         current_section: Optional[str] = None
@@ -1651,11 +1735,8 @@ class DAQuestionList(DAList):
             if sections and index < len(sections):
                 section_id = str(sections[index] or "").strip()
                 if section_id and section_id != current_section:
-                    logic_list.append(f'nav.set_section("{section_id}")')
+                    logic_list.append((f'nav.set_section("{section_id}")', False))
                     current_section = section_id
-            if set_progress and index and index % screen_divisor == 0:
-                progress += increment
-                logic_list.append(f"set_progress({int(progress)})")
             if (
                 isinstance(question, DAQuestion)
                 and question.type == "question"
@@ -1669,11 +1750,14 @@ class DAQuestionList(DAList):
                 # Add the first field in every question to our logic tree
                 # This can be customized to control the order of questions later
                 if question.needs_continue_button_field:
-                    logic_list.append(varname(question.question_text))
+                    logic_list.append((varname(question.question_text), True))
                 else:
                     logic_list.append(
-                        question.field_list[0].trigger_gather(
-                            custom_plurals=all_fields.custom_people_plurals.values()
+                        (
+                            question.field_list[0].trigger_gather(
+                                custom_plurals=all_fields.custom_people_plurals.values()
+                            ),
+                            True,
                         )
                     )
             else:
@@ -1685,7 +1769,7 @@ class DAQuestionList(DAList):
                     question in all_fields.builtins()
                     and trigger_gather.endswith(".signature")
                 ):
-                    logic_list.append(trigger_gather)
+                    logic_list.append((trigger_gather, True))
                     # set the saved answer name so it includes the user's name in saved
                     # answer list
                     # NOTE: this is redundant now that we have a custom interview list, but leaving for now
@@ -1693,20 +1777,32 @@ class DAQuestionList(DAList):
                         trigger_gather == "users.gather()"
                         and not saved_answer_name_flag
                     ):
-                        logic_list.append("set_parts(subtitle=str(users))")
+                        logic_list.append(("set_parts(subtitle=str(users))", False))
                         saved_answer_name_flag = True
 
-        unique_lines: List[str] = []
+        unique_entries: List[Tuple[str, bool]] = []
         seen_non_nav: Set[str] = set()
-        for line in logic_list:
+        for line, is_screen in logic_list:
             if line.startswith('nav.set_section("'):
-                unique_lines.append(line)
+                # A section whose screens all deduplicated away leaves its
+                # `nav.set_section` stranded next to the following section's.
+                if unique_entries and unique_entries[-1][0].startswith(
+                    'nav.set_section("'
+                ):
+                    unique_entries[-1] = (line, False)
+                else:
+                    unique_entries.append((line, False))
                 continue
             if line in seen_non_nav:
                 continue
             seen_non_nav.add(line)
-            unique_lines.append(line)
-        return unique_lines
+            unique_entries.append((line, is_screen))
+        while unique_entries and unique_entries[-1][0].startswith('nav.set_section("'):
+            unique_entries.pop()
+
+        if not set_progress:
+            return [line for line, _ in unique_entries]
+        return _with_progress_markers(unique_entries)
 
 
 class DADataType(Enum):
@@ -5477,6 +5573,7 @@ def _render_interview_yaml(
         "objects": objects or [],
         "generate_download_screen": include_download_screen,
         "screen_reordered": screen_reordered,
+        "review_collections": interview.all_fields.review_collections(screen_reordered),
         "navigation_sections": navigation_sections,
         "interview_order_lines": interview_order_lines,
         "package_version_number": __version__,

--- a/docassemble/ALWeaver/test_generate_from_path.py
+++ b/docassemble/ALWeaver/test_generate_from_path.py
@@ -315,6 +315,119 @@ question: |
                 ["generated-next-steps", "uploaded-template"],
             )
 
+    def test_generated_yaml_has_no_leading_or_trailing_blank_lines(self):
+        """Mako's control-flow lines used to leave blank lines wrapping the file."""
+        for source in (
+            "test/test_docx_no_pdf_field_names.docx",
+            "test/test_petition_to_enforce_sanitary_code.pdf",
+        ):
+            with self.subTest(source=source):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    result = generate_interview_from_path(
+                        str(Path(__file__).parent / source),
+                        output_dir=tmpdir,
+                        create_package_zip=False,
+                        include_next_steps=False,
+                    )
+                    yaml_text = Path(result.yaml_path).read_text(encoding="utf-8")
+                self.assertTrue(yaml_text.startswith("---\n"), repr(yaml_text[:40]))
+                self.assertFalse(yaml_text.endswith("\n\n"), repr(yaml_text[-40:]))
+                self.assertTrue(yaml_text.endswith("\n"))
+                # No runs of blank lines anywhere in the file either.
+                self.assertNotIn("\n\n\n", yaml_text)
+
+    def test_attachment_comment_sits_in_the_block_it_describes(self):
+        """The `i` placeholder comment documents the attachment, not the bundle title."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = generate_interview_from_path(
+                str(Path(__file__).parent / "test/test_docx_no_pdf_field_names.docx"),
+                output_dir=tmpdir,
+                create_package_zip=False,
+                include_next_steps=False,
+            )
+            yaml_text = Path(result.yaml_path).read_text(encoding="utf-8")
+
+        marker = "# Each attachment defines a key in an ALDocument."
+        self.assertEqual(yaml_text.count(marker), 1)
+        comment_start = yaml_text.index(marker)
+        # The nearest `---` above the comment must be the one that opens the
+        # attachment block, and nothing but comment lines may sit between them.
+        separator = yaml_text.rindex("\n---\n", 0, comment_start)
+        between = yaml_text[separator + len("\n---\n") : comment_start]
+        self.assertEqual(between.strip(), "")
+        after = yaml_text[comment_start:].split("\n")
+        self.assertEqual(
+            [line for line in after[:5] if not line.startswith("#")][0],
+            "attachment:",
+        )
+
+    def test_every_gathered_object_has_an_objects_block(self):
+        """Anything the interview treats as an object needs a declaration to match."""
+        # AssemblyLine declares and configures these itself; re-declaring them
+        # would clobber its own setup.
+        al_provided = {
+            "users",
+            "other_parties",
+            "children",
+            "courts",
+            "trial_court",
+            "plaintiffs",
+            "defendants",
+            "petitioners",
+            "respondents",
+            "witnesses",
+            "docket_numbers",
+            "case_numbers",
+            "al_user_bundle",
+            "al_court_bundle",
+            "al_recipient_bundle",
+            "nav",
+        }
+        for source in (
+            "test/test_petition_to_enforce_sanitary_code.pdf",
+            "test/test_docx_no_pdf_field_names.docx",
+            "test/unmap_suffixes.docx",
+        ):
+            with self.subTest(source=source):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    result = generate_interview_from_path(
+                        str(Path(__file__).parent / source),
+                        output_dir=tmpdir,
+                        create_package_zip=False,
+                        include_next_steps=False,
+                    )
+                    yaml_text = Path(result.yaml_path).read_text(encoding="utf-8")
+
+                declared = set(re.findall(r"(?m)^  - (\w+):", yaml_text))
+                order_block = yaml_text.split("id: interview_order_", 1)[1].split(
+                    "\n---\n", 1
+                )[0]
+                referenced = set(
+                    re.findall(
+                        r"(?m)^  (\w+)(?:\.gather\(\)|\[\d+\]|\.\w)", order_block
+                    )
+                )
+                undeclared = referenced - declared - al_provided
+                self.assertEqual(undeclared, set(), f"undeclared in {source}")
+
+        # The sanitary-code PDF is the concrete case that used to slip through:
+        # `my_user` and `some_identifier_mail` were gathered but never declared.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = generate_interview_from_path(
+                str(
+                    Path(__file__).parent
+                    / "test/test_petition_to_enforce_sanitary_code.pdf"
+                ),
+                output_dir=tmpdir,
+                create_package_zip=False,
+                include_next_steps=False,
+            )
+            yaml_text = Path(result.yaml_path).read_text(encoding="utf-8")
+        self.assertIn("  - my_user: ALPeopleList", yaml_text)
+        self.assertIn("  - some_identifier_mail: ALPeopleList", yaml_text)
+        # `inspector_name` is a plain text field, so there is no `inspector` list.
+        self.assertNotIn("  - inspector:", yaml_text)
+
     def test_custom_frontend_sections_respected(self):
         docx_path = Path(__file__).parent / "test/test_docx_no_pdf_field_names.docx"
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/docassemble/ALWeaver/test_generate_from_path.py
+++ b/docassemble/ALWeaver/test_generate_from_path.py
@@ -15,6 +15,7 @@ from .interview_generator import (
     generate_interview_from_path,
     generate_interview_artifacts,
     _ensure_unique_question_ids,
+    _with_progress_markers,
 )
 
 
@@ -314,6 +315,56 @@ question: |
                 folders_and_files["templates"],
                 ["generated-next-steps", "uploaded-template"],
             )
+
+    def test_progress_markers_climb_across_the_whole_interview(self):
+        """Progress used to stall around 66% because the step size was too small."""
+        entries = [("screen_%d" % index, True) for index in range(18)]
+        entries.insert(0, ('nav.set_section("people")', False))
+        lines = _with_progress_markers(entries)
+
+        values = [
+            int(line[len("set_progress(") : -1])
+            for line in lines
+            if line.startswith("set_progress(")
+        ]
+        self.assertEqual(values, sorted(set(values)), "must climb, never repeat")
+        self.assertGreaterEqual(values[-1], 70)
+        self.assertLessEqual(values[-1], 90)
+        # A marker always introduces a screen; it never trails the block.
+        self.assertFalse(lines[-1].startswith("set_progress("))
+
+        # Interviews too short to have meaningful steps get no markers at all.
+        self.assertEqual(
+            [line for line in _with_progress_markers([("a", True), ("b", True)])],
+            ["a", "b"],
+        )
+
+    def test_review_screen_follows_the_order_the_questions_are_asked(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = generate_interview_from_path(
+                str(
+                    Path(__file__).parent
+                    / "test/test_petition_to_enforce_sanitary_code.pdf"
+                ),
+                output_dir=tmpdir,
+                create_package_zip=False,
+                include_next_steps=False,
+            )
+            yaml_text = Path(result.yaml_path).read_text(encoding="utf-8")
+
+        asked = re.findall(r'(?m)^  - "[^"]*": (\w+)$', yaml_text)
+        self.assertGreater(len(asked), 5, "expected several question screen fields")
+        reviewed = re.findall(r"(?m)^  - Edit: (\w+)$", yaml_text)
+        # Every reviewed field that is asked on a screen must keep its position.
+        self.assertEqual(
+            [name for name in reviewed if name in asked],
+            [name for name in asked if name in reviewed],
+        )
+
+        # Signatures and the signature date belong to the signature flow, not to
+        # a review screen "Edit" link -- but the date is still gathered.
+        self.assertNotIn("- Edit: signature_date", yaml_text)
+        self.assertIn("\n  signature_date\n", yaml_text)
 
     def test_generated_yaml_has_no_leading_or_trailing_blank_lines(self):
         """Mako's control-flow lines used to leave blank lines wrapping the file."""


### PR DESCRIPTION
Fixes to the underlying/base Weaver mako template and some logic errors that sometimes led to broken interviews (missing object definition, signatures not gathered) or incorrect progress bar movement