### PR TITLE
More complete weaver replacement

### DIFF
--- a/docassemble/ALWeaver/api_editor.py
+++ b/docassemble/ALWeaver/api_editor.py
@@ -3646,8 +3646,10 @@ def editor_api_reset_next_steps_template() -> Response:
             source,
         )
         if not template_match:
-            raise ValueError("This interview does not reference a next-steps DOCX shell")
-        template_filename = os.path.basename(template_match.group(1).strip('"\''))
+            raise ValueError(
+                "This interview does not reference a next-steps DOCX shell"
+            )
+        template_filename = os.path.basename(template_match.group(1).strip("\"'"))
         area, directory = _editor_storage_directory(
             uid, project, SECTION_TO_STORAGE["templates"]
         )
@@ -6348,7 +6350,9 @@ def _complete_new_project_upload_job(
                 continue
             generated_name = os.path.basename(str(generated_file.get("filename") or ""))
             generated_bytes = generated_file.get("content_bytes")
-            if not generated_name or not isinstance(generated_bytes, (bytes, bytearray)):
+            if not generated_name or not isinstance(
+                generated_bytes, (bytes, bytearray)
+            ):
                 continue
             generated_path = os.path.join(temp_dir, generated_name)
             with open(generated_path, "wb") as generated_handle:
@@ -6997,9 +7001,7 @@ def _new_project_from_uploads(
     include_next_steps = parse_bool(
         request.form.get("include_next_steps"), default=True
     )
-    enable_navigation = parse_bool(
-        request.form.get("enable_navigation"), default=True
-    )
+    enable_navigation = parse_bool(request.form.get("enable_navigation"), default=True)
 
     base_name = normalize_project_name(raw_name)
     existing = get_list_of_projects(uid)

--- a/docassemble/ALWeaver/api_editor.py
+++ b/docassemble/ALWeaver/api_editor.py
@@ -102,6 +102,7 @@ from .api_utils import (
     parse_bool,
     validate_upload_metadata,
 )
+from .assemblyline_settings import read_settings, update_settings
 
 try:
     from .editor_utils import (
@@ -3489,6 +3490,215 @@ def editor_api_save_metadata() -> Response:
         )
 
 
+@app.route(f"{EDITOR_BASE_PATH}/api/assemblyline-settings", methods=["GET"])
+def editor_api_get_assemblyline_settings() -> Response:
+    """Return structured metadata and exact-name AssemblyLine variables."""
+    request_id = str(uuid.uuid4())
+    if not _editor_auth_check():
+        return _auth_fail(request_id)
+    try:
+        uid = _current_user_id()
+        project = _normalize_project(request.args.get("project"))
+        filename = _normalize_filename(request.args.get("filename"))
+        content = playground_read_yaml(uid, project, filename)
+        data = read_settings(content)
+        data.update(
+            {
+                "project": project,
+                "filename": filename,
+                "revision": source_revision(content),
+            }
+        )
+        return jsonify({"success": True, "request_id": request_id, "data": data})
+    except (ValueError, FileNotFoundError) as exc:
+        status = 404 if isinstance(exc, FileNotFoundError) else 400
+        return jsonify_with_status(
+            {
+                "success": False,
+                "request_id": request_id,
+                "error": {"type": "validation_error", "message": str(exc)},
+            },
+            status,
+        )
+    except Exception as exc:
+        log(f"ALWeaver editor: AssemblyLine settings read error: {exc!r}", "error")
+        return jsonify_with_status(
+            {
+                "success": False,
+                "request_id": request_id,
+                "error": {"type": "server_error", "message": str(exc)},
+            },
+            500,
+        )
+
+
+@app.route(f"{EDITOR_BASE_PATH}/api/assemblyline-settings", methods=["POST"])
+def editor_api_save_assemblyline_settings() -> Response:
+    """Atomically update the editor-owned AssemblyLine settings block."""
+    request_id = str(uuid.uuid4())
+    if not _editor_auth_check():
+        return _auth_fail(request_id)
+    try:
+        uid = _current_user_id()
+        post_data = request.get_json(silent=True) or {}
+        project = _normalize_project(post_data.get("project"))
+        filename = _normalize_filename(post_data.get("filename"))
+        expected_revision = post_data.get("expected_revision")
+        submitted = post_data.get("settings")
+        if not isinstance(expected_revision, str) or not expected_revision:
+            raise ValueError("expected_revision is required")
+        if not isinstance(submitted, dict):
+            raise ValueError("settings must be an object")
+
+        current = playground_read_yaml(uid, project, filename)
+        current_revision = source_revision(current)
+        if current_revision != expected_revision:
+            return jsonify_with_status(
+                {
+                    "success": False,
+                    "request_id": request_id,
+                    "error": {
+                        "type": "revision_conflict",
+                        "code": "revision_conflict",
+                        "message": "The file changed since settings were loaded.",
+                        "expected_revision": expected_revision,
+                        "current_revision": current_revision,
+                    },
+                },
+                409,
+            )
+
+        updated = update_settings(current, submitted)
+        validation = validate_candidate_source(filename=filename, raw_yaml=updated)
+        if validation.blocking:
+            return jsonify_with_status(
+                {
+                    "success": False,
+                    "request_id": request_id,
+                    "error": {
+                        "type": "invalid_settings_source",
+                        "message": "The settings would produce an invalid interview.",
+                        "details": {"diagnostics": validation.diagnostics},
+                    },
+                },
+                422,
+            )
+        playground_write_yaml(uid, project, filename, updated)
+        model = validation.model or parse_interview_yaml(updated)
+        data = read_settings(updated)
+        data.update(
+            {
+                "project": project,
+                "filename": filename,
+                "revision": source_revision(updated),
+                "raw_yaml": updated,
+                "blocks": model["blocks"],
+                "metadata_blocks": model["metadata_blocks"],
+                "include_blocks": model["include_blocks"],
+                "default_screen_parts_blocks": model["default_screen_parts_blocks"],
+                "order_blocks": model["order_blocks"],
+                "metadata_raw_yaml": metadata_source_slice(updated),
+            }
+        )
+        return jsonify({"success": True, "request_id": request_id, "data": data})
+    except (ValueError, FileNotFoundError) as exc:
+        status = 404 if isinstance(exc, FileNotFoundError) else 400
+        return jsonify_with_status(
+            {
+                "success": False,
+                "request_id": request_id,
+                "error": {"type": "validation_error", "message": str(exc)},
+            },
+            status,
+        )
+    except Exception as exc:
+        log(f"ALWeaver editor: AssemblyLine settings save error: {exc!r}", "error")
+        return jsonify_with_status(
+            {
+                "success": False,
+                "request_id": request_id,
+                "error": {"type": "server_error", "message": str(exc)},
+            },
+            500,
+        )
+
+
+@app.route(f"{EDITOR_BASE_PATH}/api/next-steps-template/reset", methods=["POST"])
+def editor_api_reset_next_steps_template() -> Response:
+    """Replace a next-steps DOCX shell after making a recoverable backup."""
+    request_id = str(uuid.uuid4())
+    if not _editor_auth_check():
+        return _auth_fail(request_id)
+    try:
+        from .interview_generator import runtime_next_steps_template_for_form_type
+
+        uid = _current_user_id()
+        post_data = request.get_json(silent=True) or {}
+        project = _normalize_project(post_data.get("project"))
+        filename = _normalize_filename(post_data.get("filename"))
+        if post_data.get("confirm_replace") is not True:
+            raise ValueError("confirm_replace must be true")
+        source = playground_read_yaml(uid, project, filename)
+        settings = read_settings(source)["values"]
+        form_type = str(settings.get("al_form_type") or "other")
+        template_match = re.search(
+            r"(?m)^\s*docx template file:\s*([^\s#]+_next_steps\.docx)\s*$",
+            source,
+        )
+        if not template_match:
+            raise ValueError("This interview does not reference a next-steps DOCX shell")
+        template_filename = os.path.basename(template_match.group(1).strip('"\''))
+        area, directory = _editor_storage_directory(
+            uid, project, SECTION_TO_STORAGE["templates"]
+        )
+        destination = os.path.join(directory, template_filename)
+        backup_filename: Optional[str] = None
+        if os.path.isfile(destination):
+            stem, extension = os.path.splitext(template_filename)
+            candidate = f"{stem}.pre-weaver-reset{extension}"
+            counter = 2
+            while os.path.exists(os.path.join(directory, candidate)):
+                candidate = f"{stem}.pre-weaver-reset-{counter}{extension}"
+                counter += 1
+            shutil.copyfile(destination, os.path.join(directory, candidate))
+            backup_filename = candidate
+
+        replacement = runtime_next_steps_template_for_form_type(form_type)
+        shutil.copyfile(replacement, destination)
+        area.finalize()
+        return jsonify(
+            {
+                "success": True,
+                "request_id": request_id,
+                "data": {
+                    "filename": template_filename,
+                    "backup_filename": backup_filename,
+                    "form_type": form_type,
+                },
+            }
+        )
+    except (ValueError, FileNotFoundError) as exc:
+        status = 404 if isinstance(exc, FileNotFoundError) else 400
+        return jsonify_with_status(
+            {
+                "success": False,
+                "request_id": request_id,
+                "error": {"type": "validation_error", "message": str(exc)},
+            },
+            status,
+        )
+    except Exception as exc:
+        log(f"ALWeaver editor: next-steps template reset error: {exc!r}", "error")
+        return jsonify_with_status(
+            {
+                "success": False,
+                "request_id": request_id,
+                "error": {"type": "server_error", "message": str(exc)},
+            },
+            500,
+        )
+
+
 RUNTIME_INSPECTION_ACTIONS = {
     "al_weaver.inspect_object",
     "al_weaver.inspect_variable",
@@ -6130,12 +6340,33 @@ def _complete_new_project_upload_job(
             storage_section=SECTION_TO_STORAGE["templates"],
             files=temp_paths,
         )
+        generated_template_files = first_result.get("generated_template_files", [])
+        generated_paths: List[str] = []
+        for generated_file in generated_template_files:
+            if not isinstance(generated_file, dict):
+                continue
+            generated_name = os.path.basename(str(generated_file.get("filename") or ""))
+            generated_bytes = generated_file.get("content_bytes")
+            if not generated_name or not isinstance(generated_bytes, (bytes, bytearray)):
+                continue
+            generated_path = os.path.join(temp_dir, generated_name)
+            with open(generated_path, "wb") as generated_handle:
+                generated_handle.write(bytes(generated_bytes))
+            generated_paths.append(generated_path)
+        if generated_paths:
+            _copy_files_to_section(
+                user_id=uid,
+                project_name=project_name,
+                storage_section=SECTION_TO_STORAGE["templates"],
+                files=generated_paths,
+            )
 
         result = {
             "project": project_name,
             "filename": "interview.yml",
             "generated_from": first_result.get("input_filename"),
             "uploaded_count": len(temp_paths),
+            "generated_template_count": len(generated_paths),
         }
         _update_new_project_job_state(
             job_id,
@@ -6743,6 +6974,31 @@ def _new_project_from_uploads(
     if not help_source_text:
         help_source_text = generation_notes
     use_llm_assist = parse_bool(request.form.get("use_llm_assist"), default=False)
+    output_type = request.form.get("output_type", "form").strip().lower()
+    if output_type not in {"form", "survey"}:
+        raise ValueError("output_type must be form or survey")
+    form_type = request.form.get("form_type", "auto").strip()
+    valid_form_types = {
+        "auto",
+        "starts_case",
+        "existing_case",
+        "appeal",
+        "other_form",
+        "letter",
+        "other",
+    }
+    if form_type not in valid_form_types:
+        raise ValueError("Unsupported AssemblyLine form type")
+    typical_role = request.form.get("typical_role", "auto").strip()
+    if typical_role not in {"auto", "plaintiff", "defendant", "unknown"}:
+        raise ValueError("Unsupported typical user role")
+    default_state = request.form.get("default_state", "").strip().upper()
+    include_next_steps = parse_bool(
+        request.form.get("include_next_steps"), default=True
+    )
+    enable_navigation = parse_bool(
+        request.form.get("enable_navigation"), default=True
+    )
 
     base_name = normalize_project_name(raw_name)
     existing = get_list_of_projects(uid)
@@ -6788,11 +7044,28 @@ def _new_project_from_uploads(
         if not uploaded_payloads:
             raise ValueError("No valid files were uploaded.")
 
+        interview_overrides: Dict[str, Any] = {
+            "enable_navigation": enable_navigation,
+            "next_steps_enabled": include_next_steps,
+        }
+        if form_type != "auto":
+            interview_overrides["form_type"] = form_type
+            interview_overrides["court_related"] = form_type != "letter"
+        if typical_role != "auto":
+            interview_overrides["typical_role"] = typical_role
+        if default_state:
+            interview_overrides["state"] = default_state
+            interview_overrides["jurisdiction"] = f"NAM-US-US+{default_state}"
+
         generation_options: Dict[str, Any] = {
             "create_package_zip": False,
-            "include_next_steps": False,
+            # Keep a durable disabled shell in form projects so the setting can
+            # be turned on later without reconstructing bundle/attachment YAML.
+            "include_next_steps": output_type == "form",
+            "include_download_screen": output_type == "form",
             "exact_name": uploaded_payloads[0]["filename"],
             "use_llm_assist": use_llm_assist,
+            "interview_overrides": interview_overrides,
         }
         if help_page_url:
             generation_options["help_page_url"] = help_page_url

--- a/docassemble/ALWeaver/api_editor.py
+++ b/docassemble/ALWeaver/api_editor.py
@@ -6305,6 +6305,7 @@ def _complete_new_project_upload_job(
                     mimetype=str(mimetype) if mimetype else None,
                     generation_options=generation_options,
                     include_yaml_text=True,
+                    include_generated_template_bytes=True,
                 )
 
         if first_result is None:

--- a/docassemble/ALWeaver/api_utils.py
+++ b/docassemble/ALWeaver/api_utils.py
@@ -242,6 +242,16 @@ def generate_interview_from_bytes(
             payload["yaml_text"] = result.yaml_text
         if result.yaml_path:
             payload["yaml_filename"] = os.path.basename(result.yaml_path)
+        payload["generated_template_files"] = []
+        for template_path in result.template_paths:
+            if os.path.isfile(template_path):
+                with open(template_path, "rb") as template_handle:
+                    payload["generated_template_files"].append(
+                        {
+                            "filename": os.path.basename(template_path),
+                            "content_bytes": template_handle.read(),
+                        }
+                    )
 
         if result.package_zip_path and os.path.exists(result.package_zip_path):
             payload["package_zip_filename"] = os.path.basename(result.package_zip_path)

--- a/docassemble/ALWeaver/api_utils.py
+++ b/docassemble/ALWeaver/api_utils.py
@@ -213,6 +213,7 @@ def generate_interview_from_bytes(
     generation_options: Mapping[str, Any],
     include_package_zip_base64: bool = False,
     include_yaml_text: bool = True,
+    include_generated_template_bytes: bool = False,
 ) -> Dict[str, Any]:
     safe_filename, extension = validate_upload_metadata(
         filename=filename, content_bytes=content_bytes, mimetype=mimetype
@@ -242,16 +243,17 @@ def generate_interview_from_bytes(
             payload["yaml_text"] = result.yaml_text
         if result.yaml_path:
             payload["yaml_filename"] = os.path.basename(result.yaml_path)
-        payload["generated_template_files"] = []
-        for template_path in result.template_paths:
-            if os.path.isfile(template_path):
-                with open(template_path, "rb") as template_handle:
-                    payload["generated_template_files"].append(
-                        {
-                            "filename": os.path.basename(template_path),
-                            "content_bytes": template_handle.read(),
-                        }
-                    )
+        if include_generated_template_bytes:
+            payload["generated_template_files"] = []
+            for template_path in result.template_paths:
+                if os.path.isfile(template_path):
+                    with open(template_path, "rb") as template_handle:
+                        payload["generated_template_files"].append(
+                            {
+                                "filename": os.path.basename(template_path),
+                                "content_bytes": template_handle.read(),
+                            }
+                        )
 
         if result.package_zip_path and os.path.exists(result.package_zip_path):
             payload["package_zip_filename"] = os.path.basename(result.package_zip_path)

--- a/docassemble/ALWeaver/assemblyline_settings.py
+++ b/docassemble/ALWeaver/assemblyline_settings.py
@@ -350,7 +350,7 @@ def update_settings(source: str, submitted: Mapping[str, Any]) -> str:
     for key, raw_value in submitted.items():
         field = METADATA_FIELDS.get(key) or CODE_FIELDS[key]
         value = _coerce_value(field, raw_value)
-        if key in METADATA_FIELDS:
+        if key in METADATA_FIELDS and value != current.get(key):
             metadata_updates[key] = value
         if key in CODE_FIELDS:
             code_values[key] = value

--- a/docassemble/ALWeaver/assemblyline_settings.py
+++ b/docassemble/ALWeaver/assemblyline_settings.py
@@ -239,6 +239,8 @@ def _coerce_value(field: Mapping[str, Any], value: Any) -> Any:
         if not isinstance(value, bool):
             raise ValueError(f"{field['label']} must be true or false")
     elif kind == "integer":
+        if value is None or (isinstance(value, str) and not value.strip()):
+            return ""
         if isinstance(value, bool):
             raise ValueError(f"{field['label']} must be an integer")
         try:

--- a/docassemble/ALWeaver/assemblyline_settings.py
+++ b/docassemble/ALWeaver/assemblyline_settings.py
@@ -319,21 +319,194 @@ def _replace_or_insert_managed(source: str, block: str) -> str:
     return source[:insertion] + document + source[insertion:]
 
 
+def _yaml_scalar(value: Any) -> str:
+    """Serialize one scalar without PyYAML's document-end marker."""
+    rendered = yaml.safe_dump(
+        value,
+        allow_unicode=True,
+        default_flow_style=True,
+        width=10_000,
+    ).strip()
+    if rendered.endswith("\n..."):
+        rendered = rendered[:-4]
+    elif rendered == "...":
+        rendered = "''"
+    return rendered
+
+
+def _literal_block_value(
+    value: str,
+    *,
+    content_indent: int,
+    newline: str,
+    original_fragment: str = "",
+) -> str:
+    """Render text as a literal block, retaining an existing chomping marker."""
+    header_match = re.match(r"^([|>][1-9]?[+-]?)", original_fragment)
+    if header_match:
+        header = header_match.group(1).replace(">", "|", 1)
+    else:
+        header = "|" if value.endswith(("\n", "\r")) else "|-"
+    normalized = value.replace("\r\n", "\n").replace("\r", "\n").rstrip("\n")
+    if not normalized:
+        return header
+    indentation = " " * content_indent
+    return header + newline + newline.join(
+        indentation + line if line else "" for line in normalized.split("\n")
+    )
+
+
+def _metadata_value_fragment(
+    value: Any,
+    *,
+    value_node: Optional[yaml.Node],
+    original_fragment: str,
+    key_indent: int,
+    newline: str,
+) -> str:
+    """Serialize one changed value while favoring readable literal text."""
+    existing_block = isinstance(value_node, yaml.ScalarNode) and value_node.style in {
+        "|",
+        ">",
+    }
+    if isinstance(value, str) and (
+        existing_block or "\n" in value or "\r" in value
+    ):
+        return _literal_block_value(
+            value,
+            content_indent=key_indent + 2,
+            newline=newline,
+            original_fragment=original_fragment,
+        )
+    if isinstance(value, list):
+        if not value:
+            return "[]"
+        indentation = " " * (key_indent + 2)
+        items: List[str] = []
+        for item in value:
+            if isinstance(item, str) and ("\n" in item or "\r" in item):
+                literal = _literal_block_value(
+                    item,
+                    content_indent=key_indent + 4,
+                    newline=newline,
+                )
+                items.append("- " + literal)
+            else:
+                items.append("- " + _yaml_scalar(item))
+        if isinstance(value_node, yaml.SequenceNode) and not value_node.flow_style:
+            return items[0] + "".join(
+                newline + indentation + item for item in items[1:]
+            )
+        return newline + newline.join(indentation + item for item in items)
+    return _yaml_scalar(value)
+
+
+def _metadata_mapping_node(body: str) -> Optional[yaml.MappingNode]:
+    try:
+        root = yaml.compose(body)
+    except yaml.YAMLError:
+        return None
+    if not isinstance(root, yaml.MappingNode):
+        return None
+    for key_node, value_node in root.value:
+        if (
+            isinstance(key_node, yaml.ScalarNode)
+            and key_node.value == "metadata"
+            and isinstance(value_node, yaml.MappingNode)
+        ):
+            return value_node
+    return None
+
+
 def _update_metadata(source: str, updates: Mapping[str, Any]) -> str:
-    metadata, location = _metadata(source)
+    """Patch changed metadata values without re-serializing the document."""
+    _metadata_values, location = _metadata(source)
     if location is None:
         raise ValueError("No metadata document was found")
-    for key, value in updates.items():
-        metadata[key] = value
     start, end, body = location
-    parsed = yaml.safe_load(body)
-    parsed["metadata"] = metadata
-    rendered = yaml.safe_dump(parsed, sort_keys=False, allow_unicode=True).rstrip("\n")
-    leading = body[: len(body) - len(body.lstrip("\r\n"))]
-    trailing = body[len(body.rstrip("\r\n")) :]
-    newline = "\r\n" if "\r\n" in source else "\n"
-    rendered = rendered.replace("\n", newline)
-    return source[:start] + leading + rendered + trailing + source[end:]
+    metadata_node = _metadata_mapping_node(body)
+    if metadata_node is None:
+        raise ValueError("The metadata mapping could not be edited safely")
+    newline = "\r\n" if "\r\n" in body else "\n"
+    existing: Dict[str, Tuple[yaml.Node, yaml.Node]] = {}
+    for key_node, value_node in metadata_node.value:
+        if not isinstance(key_node, yaml.ScalarNode) or key_node.value in existing:
+            raise ValueError("The metadata mapping contains unsupported duplicate keys")
+        existing[str(key_node.value)] = (key_node, value_node)
+
+    operations: List[Tuple[int, int, str]] = []
+    missing: List[Tuple[str, Any]] = []
+    for key, value in updates.items():
+        if key not in existing:
+            missing.append((key, value))
+            continue
+        key_node, value_node = existing[key]
+        value_start = value_node.start_mark.index
+        value_end = value_node.end_mark.index
+        fragment = body[value_start:value_end]
+        replacement = _metadata_value_fragment(
+            value,
+            value_node=value_node,
+            original_fragment=fragment,
+            key_indent=key_node.start_mark.column,
+            newline=newline,
+        )
+        if fragment.endswith("\r\n") and not replacement.endswith(("\r", "\n")):
+            replacement += "\r\n"
+        elif fragment.endswith("\n") and not replacement.endswith(("\r", "\n")):
+            replacement += "\n"
+        elif fragment.endswith("\r") and not replacement.endswith(("\r", "\n")):
+            replacement += "\r"
+        operations.append((value_start, value_end, replacement))
+
+    if missing:
+        key_indent = (
+            metadata_node.value[0][0].start_mark.column
+            if metadata_node.value
+            else metadata_node.start_mark.column
+        )
+        insertion_at = len(body.rstrip("\r\n"))
+        addition_lines: List[str] = []
+        for key, value in missing:
+            fragment = _metadata_value_fragment(
+                value,
+                value_node=None,
+                original_fragment="",
+                key_indent=key_indent,
+                newline=newline,
+            )
+            separator = "" if fragment.startswith(newline) else " "
+            addition_lines.append(
+                " " * key_indent + key + ":" + separator + fragment
+            )
+        prefix = "" if insertion_at == 0 or body[:insertion_at].endswith(("\n", "\r")) else newline
+        operations.append(
+            (insertion_at, insertion_at, prefix + newline.join(addition_lines))
+        )
+
+    updated_body = body
+    for operation_start, operation_end, replacement in sorted(
+        operations, key=lambda item: item[0], reverse=True
+    ):
+        updated_body = (
+            updated_body[:operation_start]
+            + replacement
+            + updated_body[operation_end:]
+        )
+
+    # Refuse a patch that does not round-trip to the submitted values.
+    parsed = yaml.safe_load(updated_body)
+    parsed_metadata = parsed.get("metadata") if isinstance(parsed, dict) else None
+    if not isinstance(parsed_metadata, dict):
+        raise ValueError("The metadata mapping could not be edited safely")
+    for key, value in updates.items():
+        parsed_value = parsed_metadata.get(key)
+        if isinstance(value, str) and isinstance(parsed_value, str):
+            if parsed_value.rstrip("\r\n") != value.rstrip("\r\n"):
+                raise ValueError(f"Metadata value {key!r} did not round-trip safely")
+        elif parsed_value != value:
+            raise ValueError(f"Metadata value {key!r} did not round-trip safely")
+    return source[:start] + updated_body + source[end:]
 
 
 def update_settings(source: str, submitted: Mapping[str, Any]) -> str:

--- a/docassemble/ALWeaver/assemblyline_settings.py
+++ b/docassemble/ALWeaver/assemblyline_settings.py
@@ -41,8 +41,8 @@ SETTINGS_SCHEMA: List[Dict[str, Any]] = [
         "id": "identity",
         "label": "Form identity and publishing",
         "fields": [
-            _field("title", "Title", scope="metadata"),
-            _field("short title", "Short title", scope="metadata"),
+            _field("title", "Title", scope="metadata", pair="title"),
+            _field("short title", "Short title", scope="metadata", pair="title"),
             _field("description", "Description", "area", scope="metadata"),
             _field("can_I_use_this_form", "Who can use this form?", "area", scope="metadata"),
             _field("before_you_start", "Before you start", "area", scope="metadata"),
@@ -59,8 +59,8 @@ SETTINGS_SCHEMA: List[Dict[str, Any]] = [
             _field("integrated_email_filing", "Integrated email filing", "boolean", False, scope="metadata"),
             _field("requires_notarization", "Requires notarization", "boolean", False, scope="metadata"),
             _field("unlisted", "Keep interview unlisted", "boolean", False, scope="metadata"),
-            _field("estimated_completion_minutes", "Estimated completion minutes", "integer", 10, scope="metadata"),
-            _field("estimated_completion_delta", "Estimate plus or minus", "integer", 5, scope="metadata"),
+            _field("estimated_completion_minutes", "Estimated completion minutes", "integer", 10, scope="metadata", pair="timing"),
+            _field("estimated_completion_delta", "Estimate plus or minus", "integer", 5, scope="metadata", pair="timing"),
         ],
     },
     {
@@ -69,8 +69,8 @@ SETTINGS_SCHEMA: List[Dict[str, Any]] = [
         "fields": [
             _field("AL_ORGANIZATION_TITLE", "Organization title"),
             _field("AL_ORGANIZATION_HOMEPAGE", "Organization homepage", "url"),
-            _field("AL_DEFAULT_COUNTRY", "Default country", default="US"),
-            _field("AL_DEFAULT_STATE", "Default state or province"),
+            _field("AL_DEFAULT_COUNTRY", "Default country", default="US", pair="locale"),
+            _field("AL_DEFAULT_STATE", "Default state or province", pair="locale"),
             _field("AL_DEFAULT_LANGUAGE", "Default document language", default="en"),
             _field("AL_DEFAULT_OVERFLOW_MESSAGE", "PDF overflow message", default="..."),
         ],
@@ -101,8 +101,8 @@ SETTINGS_SCHEMA: List[Dict[str, Any]] = [
         "id": "repository",
         "label": "Repository and feedback",
         "fields": [
-            _field("github_repo_name", "GitHub repository name"),
-            _field("github_user", "GitHub owner"),
+            _field("github_repo_name", "GitHub repository name", pair="github"),
+            _field("github_user", "GitHub owner", pair="github"),
         ],
     },
     {
@@ -110,10 +110,10 @@ SETTINGS_SCHEMA: List[Dict[str, Any]] = [
         "label": "Next steps document",
         "fields": [
             _field("al_next_steps_enabled", "Include next steps", "boolean", True),
-            _field("al_next_steps_document_title", "Document name", default="form"),
-            _field("al_next_steps_document_purpose", "Request name", default="request"),
-            _field("al_next_steps_help_organization", "Help organization"),
-            _field("al_next_steps_help_url", "Help URL", "url"),
+            _field("al_next_steps_document_title", "Document name", default="form", pair="document_names"),
+            _field("al_next_steps_document_purpose", "Request name", default="request", pair="document_names"),
+            _field("al_next_steps_help_organization", "Help organization", pair="help"),
+            _field("al_next_steps_help_url", "Help URL", "url", pair="help"),
             _field("al_next_steps_generate_qr_code", "Add a QR code", "boolean", False),
             _field("al_next_steps_what_happens_next", "What happens next", "area"),
             _field("al_next_steps_what_can_decision_maker_do", "What the decision maker can do", "area"),

--- a/docassemble/ALWeaver/assemblyline_settings.py
+++ b/docassemble/ALWeaver/assemblyline_settings.py
@@ -16,7 +16,6 @@ from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 import yaml
 
-
 MANAGED_BLOCK_ID = "alweaver assemblyline settings"
 DOCS_URL = (
     "https://assemblyline.suffolklitlab.org/docs/components/AssemblyLine/"
@@ -44,23 +43,86 @@ SETTINGS_SCHEMA: List[Dict[str, Any]] = [
             _field("title", "Title", scope="metadata", pair="title"),
             _field("short title", "Short title", scope="metadata", pair="title"),
             _field("description", "Description", "area", scope="metadata"),
-            _field("can_I_use_this_form", "Who can use this form?", "area", scope="metadata"),
+            _field(
+                "can_I_use_this_form",
+                "Who can use this form?",
+                "area",
+                scope="metadata",
+            ),
             _field("before_you_start", "Before you start", "area", scope="metadata"),
-            _field("when_you_are_finished", "When you are finished", "area", scope="metadata"),
-            _field("landing_page_url", "Public landing page URL", "url", scope="metadata"),
+            _field(
+                "when_you_are_finished",
+                "When you are finished",
+                "area",
+                scope="metadata",
+            ),
+            _field(
+                "landing_page_url", "Public landing page URL", "url", scope="metadata"
+            ),
             _field("authors", "Authors", "list", [], scope="metadata"),
             _field("LIST_topics", "LIST topics", "list", [], scope="metadata"),
             _field("original_form", "Original form URLs", "list", [], scope="metadata"),
             _field("jurisdiction", "Jurisdiction code", scope="metadata"),
             _field("allowed_courts", "Allowed courts", "list", [], scope="both"),
-            _field("typical_role", "Typical user role", "choice", "unknown", scope="metadata", choices=["plaintiff", "defendant", "unknown", "na"]),
-            _field("efiling_enabled", "E-filing enabled", "boolean", False, scope="metadata"),
-            _field("integrated_efiling", "Integrated e-filing", "boolean", False, scope="metadata"),
-            _field("integrated_email_filing", "Integrated email filing", "boolean", False, scope="metadata"),
-            _field("requires_notarization", "Requires notarization", "boolean", False, scope="metadata"),
-            _field("unlisted", "Keep interview unlisted", "boolean", False, scope="metadata"),
-            _field("estimated_completion_minutes", "Estimated completion minutes", "integer", 10, scope="metadata", pair="timing"),
-            _field("estimated_completion_delta", "Estimate plus or minus", "integer", 5, scope="metadata", pair="timing"),
+            _field(
+                "typical_role",
+                "Typical user role",
+                "choice",
+                "unknown",
+                scope="metadata",
+                choices=["plaintiff", "defendant", "unknown", "na"],
+            ),
+            _field(
+                "efiling_enabled",
+                "E-filing enabled",
+                "boolean",
+                False,
+                scope="metadata",
+            ),
+            _field(
+                "integrated_efiling",
+                "Integrated e-filing",
+                "boolean",
+                False,
+                scope="metadata",
+            ),
+            _field(
+                "integrated_email_filing",
+                "Integrated email filing",
+                "boolean",
+                False,
+                scope="metadata",
+            ),
+            _field(
+                "requires_notarization",
+                "Requires notarization",
+                "boolean",
+                False,
+                scope="metadata",
+            ),
+            _field(
+                "unlisted",
+                "Keep interview unlisted",
+                "boolean",
+                False,
+                scope="metadata",
+            ),
+            _field(
+                "estimated_completion_minutes",
+                "Estimated completion minutes",
+                "integer",
+                10,
+                scope="metadata",
+                pair="timing",
+            ),
+            _field(
+                "estimated_completion_delta",
+                "Estimate plus or minus",
+                "integer",
+                5,
+                scope="metadata",
+                pair="timing",
+            ),
         ],
     },
     {
@@ -69,21 +131,57 @@ SETTINGS_SCHEMA: List[Dict[str, Any]] = [
         "fields": [
             _field("AL_ORGANIZATION_TITLE", "Organization title"),
             _field("AL_ORGANIZATION_HOMEPAGE", "Organization homepage", "url"),
-            _field("AL_DEFAULT_COUNTRY", "Default country", default="US", pair="locale"),
+            _field(
+                "AL_DEFAULT_COUNTRY", "Default country", default="US", pair="locale"
+            ),
             _field("AL_DEFAULT_STATE", "Default state or province", pair="locale"),
             _field("AL_DEFAULT_LANGUAGE", "Default document language", default="en"),
-            _field("AL_DEFAULT_OVERFLOW_MESSAGE", "PDF overflow message", default="..."),
+            _field(
+                "AL_DEFAULT_OVERFLOW_MESSAGE", "PDF overflow message", default="..."
+            ),
         ],
     },
     {
         "id": "interview",
         "label": "Interview behavior",
         "fields": [
-            _field("al_form_type", "Form type", "choice", "other", choices=["starts_case", "existing_case", "appeal", "other_form", "letter", "other"]),
-            _field("user_ask_role", "User role", "choice", "unknown", choices=["plaintiff", "defendant", "unknown"]),
-            _field("al_person_answering", "Person answering", "choice", "user", choices=["user", "attorney", "advocate", "other"]),
-            _field("al_form_requires_digital_signature", "Require a digital signature", "boolean", False),
-            _field("al_typed_signature_prefix", "Typed-signature prefix", default="/s/"),
+            _field(
+                "al_form_type",
+                "Form type",
+                "choice",
+                "other",
+                choices=[
+                    "starts_case",
+                    "existing_case",
+                    "appeal",
+                    "other_form",
+                    "letter",
+                    "other",
+                ],
+            ),
+            _field(
+                "user_ask_role",
+                "User role",
+                "choice",
+                "unknown",
+                choices=["plaintiff", "defendant", "unknown"],
+            ),
+            _field(
+                "al_person_answering",
+                "Person answering",
+                "choice",
+                "user",
+                choices=["user", "attorney", "advocate", "other"],
+            ),
+            _field(
+                "al_form_requires_digital_signature",
+                "Require a digital signature",
+                "boolean",
+                False,
+            ),
+            _field(
+                "al_typed_signature_prefix", "Typed-signature prefix", default="/s/"
+            ),
             _field("al_typed_signature_font", "Typed-signature font"),
             _field("speak_text", "Enable read-aloud control", "boolean", True),
         ],
@@ -92,7 +190,12 @@ SETTINGS_SCHEMA: List[Dict[str, Any]] = [
         "id": "language",
         "label": "Languages",
         "fields": [
-            _field("enable_al_language", "Enable AssemblyLine language switching", "boolean", True),
+            _field(
+                "enable_al_language",
+                "Enable AssemblyLine language switching",
+                "boolean",
+                True,
+            ),
             _field("al_user_default_language", "Default user language", default="en"),
             _field("al_interview_languages", "Supported languages", "list", ["en"]),
         ],
@@ -110,14 +213,32 @@ SETTINGS_SCHEMA: List[Dict[str, Any]] = [
         "label": "Next steps document",
         "fields": [
             _field("al_next_steps_enabled", "Include next steps", "boolean", True),
-            _field("al_next_steps_document_title", "Document name", default="form", pair="document_names"),
-            _field("al_next_steps_document_purpose", "Request name", default="request", pair="document_names"),
+            _field(
+                "al_next_steps_document_title",
+                "Document name",
+                default="form",
+                pair="document_names",
+            ),
+            _field(
+                "al_next_steps_document_purpose",
+                "Request name",
+                default="request",
+                pair="document_names",
+            ),
             _field("al_next_steps_help_organization", "Help organization", pair="help"),
             _field("al_next_steps_help_url", "Help URL", "url", pair="help"),
             _field("al_next_steps_generate_qr_code", "Add a QR code", "boolean", False),
             _field("al_next_steps_what_happens_next", "What happens next", "area"),
-            _field("al_next_steps_what_can_decision_maker_do", "What the decision maker can do", "area"),
-            _field("al_next_steps_what_happens_if_i_win", "What happens if the request is granted", "area"),
+            _field(
+                "al_next_steps_what_can_decision_maker_do",
+                "What the decision maker can do",
+                "area",
+            ),
+            _field(
+                "al_next_steps_what_happens_if_i_win",
+                "What happens if the request is granted",
+                "area",
+            ),
         ],
     },
     {
@@ -277,7 +398,9 @@ def _managed_block(values: Mapping[str, Any]) -> str:
             try:
                 ast.parse(rendered, mode="eval")
             except SyntaxError as exc:
-                raise ValueError(f"{CODE_FIELDS[key]['label']} is not valid Python") from exc
+                raise ValueError(
+                    f"{CODE_FIELDS[key]['label']} is not valid Python"
+                ) from exc
         else:
             rendered = repr(value)
         lines.append(f"  {key} = {rendered}")
@@ -295,7 +418,13 @@ def _replace_or_insert_managed(source: str, block: str) -> str:
         if isinstance(parsed, dict) and parsed.get("id") == MANAGED_BLOCK_ID:
             leading = body[: len(body) - len(body.lstrip("\r\n"))]
             trailing = body[len(body.rstrip("\r\n")) :]
-            return source[:start] + leading + block.rstrip("\r\n") + trailing + source[end:]
+            return (
+                source[:start]
+                + leading
+                + block.rstrip("\r\n")
+                + trailing
+                + source[end:]
+            )
 
     # Put initial settings before the first mandatory block. Existing document
     # bytes are otherwise untouched.
@@ -351,8 +480,12 @@ def _literal_block_value(
     if not normalized:
         return header
     indentation = " " * content_indent
-    return header + newline + newline.join(
-        indentation + line if line else "" for line in normalized.split("\n")
+    return (
+        header
+        + newline
+        + newline.join(
+            indentation + line if line else "" for line in normalized.split("\n")
+        )
     )
 
 
@@ -369,9 +502,7 @@ def _metadata_value_fragment(
         "|",
         ">",
     }
-    if isinstance(value, str) and (
-        existing_block or "\n" in value or "\r" in value
-    ):
+    if isinstance(value, str) and (existing_block or "\n" in value or "\r" in value):
         return _literal_block_value(
             value,
             content_indent=key_indent + 2,
@@ -476,10 +607,12 @@ def _update_metadata(source: str, updates: Mapping[str, Any]) -> str:
                 newline=newline,
             )
             separator = "" if fragment.startswith(newline) else " "
-            addition_lines.append(
-                " " * key_indent + key + ":" + separator + fragment
-            )
-        prefix = "" if insertion_at == 0 or body[:insertion_at].endswith(("\n", "\r")) else newline
+            addition_lines.append(" " * key_indent + key + ":" + separator + fragment)
+        prefix = (
+            ""
+            if insertion_at == 0 or body[:insertion_at].endswith(("\n", "\r"))
+            else newline
+        )
         operations.append(
             (insertion_at, insertion_at, prefix + newline.join(addition_lines))
         )
@@ -489,9 +622,7 @@ def _update_metadata(source: str, updates: Mapping[str, Any]) -> str:
         operations, key=lambda item: item[0], reverse=True
     ):
         updated_body = (
-            updated_body[:operation_start]
-            + replacement
-            + updated_body[operation_end:]
+            updated_body[:operation_start] + replacement + updated_body[operation_end:]
         )
 
     # Refuse a patch that does not round-trip to the submitted values.

--- a/docassemble/ALWeaver/assemblyline_settings.py
+++ b/docassemble/ALWeaver/assemblyline_settings.py
@@ -1,0 +1,357 @@
+"""Round-trip helpers for graphical AssemblyLine interview settings.
+
+AssemblyLine has two distinct setting families: publishing metadata stored in a
+``metadata`` document, and exact-name Python variables normally defined in
+``code`` blocks.  This module keeps that distinction explicit and writes the
+latter to one Weaver-owned block so the graphical editor never has to guess
+which arbitrary author code it is allowed to replace.
+"""
+
+from __future__ import annotations
+
+import ast
+import copy
+import re
+from typing import Any, Dict, List, Mapping, Optional, Tuple
+
+import yaml
+
+
+MANAGED_BLOCK_ID = "alweaver assemblyline settings"
+DOCS_URL = (
+    "https://assemblyline.suffolklitlab.org/docs/components/AssemblyLine/"
+    "magic_variables/"
+)
+
+
+def _field(
+    key: str,
+    label: str,
+    kind: str = "text",
+    default: Any = "",
+    **kwargs: Any,
+) -> Dict[str, Any]:
+    result = {"key": key, "label": label, "kind": kind, "default": default}
+    result.update(kwargs)
+    return result
+
+
+SETTINGS_SCHEMA: List[Dict[str, Any]] = [
+    {
+        "id": "identity",
+        "label": "Form identity and publishing",
+        "fields": [
+            _field("title", "Title", scope="metadata"),
+            _field("short title", "Short title", scope="metadata"),
+            _field("description", "Description", "area", scope="metadata"),
+            _field("can_I_use_this_form", "Who can use this form?", "area", scope="metadata"),
+            _field("before_you_start", "Before you start", "area", scope="metadata"),
+            _field("when_you_are_finished", "When you are finished", "area", scope="metadata"),
+            _field("landing_page_url", "Public landing page URL", "url", scope="metadata"),
+            _field("authors", "Authors", "list", [], scope="metadata"),
+            _field("LIST_topics", "LIST topics", "list", [], scope="metadata"),
+            _field("original_form", "Original form URLs", "list", [], scope="metadata"),
+            _field("jurisdiction", "Jurisdiction code", scope="metadata"),
+            _field("allowed_courts", "Allowed courts", "list", [], scope="both"),
+            _field("typical_role", "Typical user role", "choice", "unknown", scope="metadata", choices=["plaintiff", "defendant", "unknown", "na"]),
+            _field("efiling_enabled", "E-filing enabled", "boolean", False, scope="metadata"),
+            _field("integrated_efiling", "Integrated e-filing", "boolean", False, scope="metadata"),
+            _field("integrated_email_filing", "Integrated email filing", "boolean", False, scope="metadata"),
+            _field("requires_notarization", "Requires notarization", "boolean", False, scope="metadata"),
+            _field("unlisted", "Keep interview unlisted", "boolean", False, scope="metadata"),
+            _field("estimated_completion_minutes", "Estimated completion minutes", "integer", 10, scope="metadata"),
+            _field("estimated_completion_delta", "Estimate plus or minus", "integer", 5, scope="metadata"),
+        ],
+    },
+    {
+        "id": "organization",
+        "label": "Organization and locale",
+        "fields": [
+            _field("AL_ORGANIZATION_TITLE", "Organization title"),
+            _field("AL_ORGANIZATION_HOMEPAGE", "Organization homepage", "url"),
+            _field("AL_DEFAULT_COUNTRY", "Default country", default="US"),
+            _field("AL_DEFAULT_STATE", "Default state or province"),
+            _field("AL_DEFAULT_LANGUAGE", "Default document language", default="en"),
+            _field("AL_DEFAULT_OVERFLOW_MESSAGE", "PDF overflow message", default="..."),
+        ],
+    },
+    {
+        "id": "interview",
+        "label": "Interview behavior",
+        "fields": [
+            _field("al_form_type", "Form type", "choice", "other", choices=["starts_case", "existing_case", "appeal", "other_form", "letter", "other"]),
+            _field("user_ask_role", "User role", "choice", "unknown", choices=["plaintiff", "defendant", "unknown"]),
+            _field("al_person_answering", "Person answering", "choice", "user", choices=["user", "attorney", "advocate", "other"]),
+            _field("al_form_requires_digital_signature", "Require a digital signature", "boolean", False),
+            _field("al_typed_signature_prefix", "Typed-signature prefix", default="/s/"),
+            _field("al_typed_signature_font", "Typed-signature font"),
+            _field("speak_text", "Enable read-aloud control", "boolean", True),
+        ],
+    },
+    {
+        "id": "language",
+        "label": "Languages",
+        "fields": [
+            _field("enable_al_language", "Enable AssemblyLine language switching", "boolean", True),
+            _field("al_user_default_language", "Default user language", default="en"),
+            _field("al_interview_languages", "Supported languages", "list", ["en"]),
+        ],
+    },
+    {
+        "id": "repository",
+        "label": "Repository and feedback",
+        "fields": [
+            _field("github_repo_name", "GitHub repository name"),
+            _field("github_user", "GitHub owner"),
+        ],
+    },
+    {
+        "id": "next_steps",
+        "label": "Next steps document",
+        "fields": [
+            _field("al_next_steps_enabled", "Include next steps", "boolean", True),
+            _field("al_next_steps_document_title", "Document name", default="form"),
+            _field("al_next_steps_document_purpose", "Request name", default="request"),
+            _field("al_next_steps_help_organization", "Help organization"),
+            _field("al_next_steps_help_url", "Help URL", "url"),
+            _field("al_next_steps_generate_qr_code", "Add a QR code", "boolean", False),
+            _field("al_next_steps_what_happens_next", "What happens next", "area"),
+            _field("al_next_steps_what_can_decision_maker_do", "What the decision maker can do", "area"),
+            _field("al_next_steps_what_happens_if_i_win", "What happens if the request is granted", "area"),
+        ],
+    },
+    {
+        "id": "advanced",
+        "label": "Advanced and derived variables",
+        "readonly": True,
+        "notes": [
+            "al_logo is an object backed by a file; edit it in Objects and Static files.",
+            "addresses_to_search is executable court-routing logic; edit its code block directly.",
+            "al_intro_screen is an interview-order event, not metadata.",
+            "al_user_bundle, al_court_bundle, signature_fields, and trial_court are runtime structure.",
+            "user_role and user_started_case are derived from al_form_type and user_ask_role.",
+            "users and other_parties are AssemblyLine objects and should be edited in the object/screen tools.",
+            "al_menu_items_custom_items may contain dynamic code; edit its data block directly.",
+            "Server-wide AssemblyLine configuration is intentionally not editable here.",
+        ],
+        "fields": [],
+    },
+]
+
+
+CODE_FIELDS = {
+    field["key"]: field
+    for section in SETTINGS_SCHEMA
+    for field in section.get("fields", [])
+    if field.get("scope") in {None, "both"}
+}
+METADATA_FIELDS = {
+    field["key"]: field
+    for section in SETTINGS_SCHEMA
+    for field in section.get("fields", [])
+    if field.get("scope") in {"metadata", "both"}
+}
+
+
+_SEPARATOR_RE = re.compile(r"(?m)^---[ \t]*(?:\r?\n|$)")
+
+
+def _documents(source: str) -> List[Tuple[int, int, str]]:
+    result: List[Tuple[int, int, str]] = []
+    start = 0
+    for match in _SEPARATOR_RE.finditer(source):
+        result.append((start, match.start(), source[start : match.start()]))
+        start = match.end()
+    result.append((start, len(source), source[start:]))
+    return result
+
+
+def _literal_assignments(code: str) -> Dict[str, Any]:
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return {}
+    result: Dict[str, Any] = {}
+    for node in tree.body:
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        value_node = node.value
+        if value_node is None:
+            continue
+        try:
+            value = ast.literal_eval(value_node)
+        except (ValueError, TypeError):
+            value = ast.get_source_segment(code, value_node) or ""
+        for target in targets:
+            if isinstance(target, ast.Name) and target.id in CODE_FIELDS:
+                result[target.id] = value
+    return result
+
+
+def _metadata(source: str) -> Tuple[Dict[str, Any], Optional[Tuple[int, int, str]]]:
+    for start, end, body in _documents(source):
+        try:
+            parsed = yaml.safe_load(body)
+        except yaml.YAMLError:
+            continue
+        if isinstance(parsed, dict) and isinstance(parsed.get("metadata"), dict):
+            return dict(parsed["metadata"]), (start, end, body)
+    return {}, None
+
+
+def read_settings(source: str) -> Dict[str, Any]:
+    """Read metadata and supported literal assignments from an interview."""
+    values: Dict[str, Any] = {
+        key: copy.deepcopy(field.get("default"))
+        for key, field in {**METADATA_FIELDS, **CODE_FIELDS}.items()
+    }
+    metadata, _location = _metadata(source)
+    for key in METADATA_FIELDS:
+        if key in metadata:
+            values[key] = metadata[key]
+
+    sources: Dict[str, str] = {}
+    for _start, _end, body in _documents(source):
+        try:
+            parsed = yaml.safe_load(body)
+        except yaml.YAMLError:
+            continue
+        if not isinstance(parsed, dict) or not isinstance(parsed.get("code"), str):
+            continue
+        assignments = _literal_assignments(parsed["code"])
+        block_id = str(parsed.get("id") or "code block")
+        for key, value in assignments.items():
+            values[key] = value
+            sources[key] = block_id
+
+    return {
+        "schema": copy.deepcopy(SETTINGS_SCHEMA),
+        "values": values,
+        "sources": sources,
+        "docs_url": DOCS_URL,
+    }
+
+
+def _coerce_value(field: Mapping[str, Any], value: Any) -> Any:
+    kind = field.get("kind")
+    if kind == "boolean":
+        if not isinstance(value, bool):
+            raise ValueError(f"{field['label']} must be true or false")
+    elif kind == "integer":
+        if isinstance(value, bool):
+            raise ValueError(f"{field['label']} must be an integer")
+        try:
+            value = int(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"{field['label']} must be an integer") from exc
+    elif kind == "list":
+        if isinstance(value, str):
+            value = [line.strip() for line in value.splitlines() if line.strip()]
+        if not isinstance(value, list):
+            raise ValueError(f"{field['label']} must be a list")
+    elif kind == "choice":
+        value = str(value or "")
+        if value not in field.get("choices", []):
+            raise ValueError(f"{field['label']} has an unsupported value")
+    else:
+        value = str(value or "")
+    return value
+
+
+def _managed_block(values: Mapping[str, Any]) -> str:
+    lines = [
+        f"id: {MANAGED_BLOCK_ID}",
+        "initial: True",
+        "code: |",
+        "  # Managed by the graphical AssemblyLine settings editor.",
+    ]
+    for key in CODE_FIELDS:
+        if key not in values:
+            continue
+        value = values[key]
+        if CODE_FIELDS[key].get("kind") == "python":
+            rendered = str(value or "None")
+            try:
+                ast.parse(rendered, mode="eval")
+            except SyntaxError as exc:
+                raise ValueError(f"{CODE_FIELDS[key]['label']} is not valid Python") from exc
+        else:
+            rendered = repr(value)
+        lines.append(f"  {key} = {rendered}")
+    return "\n".join(lines) + "\n"
+
+
+def _replace_or_insert_managed(source: str, block: str) -> str:
+    newline = "\r\n" if "\r\n" in source else "\n"
+    block = block.replace("\n", newline)
+    for start, end, body in _documents(source):
+        try:
+            parsed = yaml.safe_load(body)
+        except yaml.YAMLError:
+            continue
+        if isinstance(parsed, dict) and parsed.get("id") == MANAGED_BLOCK_ID:
+            leading = body[: len(body) - len(body.lstrip("\r\n"))]
+            trailing = body[len(body.rstrip("\r\n")) :]
+            return source[:start] + leading + block.rstrip("\r\n") + trailing + source[end:]
+
+    # Put initial settings before the first mandatory block. Existing document
+    # bytes are otherwise untouched.
+    insertion = None
+    for start, _end, body in _documents(source):
+        try:
+            parsed = yaml.safe_load(body)
+        except yaml.YAMLError:
+            continue
+        if isinstance(parsed, dict) and parsed.get("mandatory") is True:
+            insertion = start
+            break
+    document = block.rstrip("\r\n") + newline + "---" + newline
+    if insertion is None:
+        prefix = source
+        if prefix and not prefix.endswith(("\n", "\r")):
+            prefix += newline
+        if prefix:
+            prefix += "---" + newline
+        return prefix + block
+    return source[:insertion] + document + source[insertion:]
+
+
+def _update_metadata(source: str, updates: Mapping[str, Any]) -> str:
+    metadata, location = _metadata(source)
+    if location is None:
+        raise ValueError("No metadata document was found")
+    for key, value in updates.items():
+        metadata[key] = value
+    start, end, body = location
+    parsed = yaml.safe_load(body)
+    parsed["metadata"] = metadata
+    rendered = yaml.safe_dump(parsed, sort_keys=False, allow_unicode=True).rstrip("\n")
+    leading = body[: len(body) - len(body.lstrip("\r\n"))]
+    trailing = body[len(body.rstrip("\r\n")) :]
+    newline = "\r\n" if "\r\n" in source else "\n"
+    rendered = rendered.replace("\n", newline)
+    return source[:start] + leading + rendered + trailing + source[end:]
+
+
+def update_settings(source: str, submitted: Mapping[str, Any]) -> str:
+    """Update supported settings, preserving every unrelated YAML document."""
+    if not isinstance(submitted, Mapping):
+        raise ValueError("settings must be an object")
+    unknown = set(submitted) - set(METADATA_FIELDS) - set(CODE_FIELDS)
+    if unknown:
+        raise ValueError("Unsupported settings: " + ", ".join(sorted(unknown)))
+
+    current = read_settings(source)["values"]
+    metadata_updates: Dict[str, Any] = {}
+    code_values = {key: current[key] for key in CODE_FIELDS}
+    for key, raw_value in submitted.items():
+        field = METADATA_FIELDS.get(key) or CODE_FIELDS[key]
+        value = _coerce_value(field, raw_value)
+        if key in METADATA_FIELDS:
+            metadata_updates[key] = value
+        if key in CODE_FIELDS:
+            code_values[key] = value
+
+    updated = _update_metadata(source, metadata_updates) if metadata_updates else source
+    return _replace_or_insert_managed(updated, _managed_block(code_values))

--- a/docassemble/ALWeaver/data/static/editor.js
+++ b/docassemble/ALWeaver/data/static/editor.js
@@ -88,6 +88,7 @@
     validationBaseRevisionMatches: null,
     assemblyLineSettings: null,
     assemblyLineSettingsDirty: false,
+    assemblyLineSettingsFilter: '',
   };
 
   var RECENT_PROJECTS_STORAGE_KEY = 'alweaver_recent_projects';
@@ -5726,19 +5727,39 @@
     var key = esc(field.key);
     var kind = field.kind || 'text';
     var common = ' data-al-setting="' + key + '" id="al-setting-' + key.replace(/[^a-zA-Z0-9_-]/g, '-') + '"';
+    var variableHint = '<div class="form-text editor-al-setting-key"><code>' + key + '</code></div>';
     if (kind === 'boolean') {
-      return '<div class="form-check form-switch"><input class="form-check-input" type="checkbox"' + common + (value ? ' checked' : '') + '><label class="form-check-label" for="al-setting-' + key.replace(/[^a-zA-Z0-9_-]/g, '-') + '">' + esc(field.label) + '</label></div>';
+      return '<div class="form-check form-switch"><input class="form-check-input" type="checkbox"' + common + (value ? ' checked' : '') + '><label class="form-check-label" for="al-setting-' + key.replace(/[^a-zA-Z0-9_-]/g, '-') + '">' + esc(field.label) + '</label>' + variableHint + '</div>';
     }
     if (kind === 'choice') {
       var select = '<label class="editor-tiny" for="al-setting-' + key + '">' + esc(field.label) + '</label><select class="form-select form-select-sm mt-1"' + common + '>';
       (field.choices || []).forEach(function (choice) { select += '<option value="' + esc(choice) + '"' + (String(value) === String(choice) ? ' selected' : '') + '>' + esc(String(choice).replace(/_/g, ' ')) + '</option>'; });
-      return select + '</select>';
+      return select + '</select>' + variableHint;
     }
     var rendered = kind === 'list' ? (Array.isArray(value) ? value.join('\n') : '') : String(value === null || value === undefined ? '' : value);
     if (kind === 'area' || kind === 'list' || kind === 'python') {
-      return '<label class="editor-tiny" for="al-setting-' + key + '">' + esc(field.label) + '</label><textarea class="form-control form-control-sm mt-1' + (kind === 'python' ? ' font-monospace' : '') + '" rows="' + (kind === 'area' ? '4' : '3') + '"' + common + '>' + esc(rendered) + '</textarea>' + (kind === 'list' ? '<div class="form-text">One value per line.</div>' : '');
+      return '<label class="editor-tiny" for="al-setting-' + key + '">' + esc(field.label) + '</label><textarea class="form-control form-control-sm mt-1' + (kind === 'python' ? ' font-monospace' : '') + '" rows="' + (kind === 'area' ? '4' : '3') + '"' + common + '>' + esc(rendered) + '</textarea>' + variableHint + (kind === 'list' ? '<div class="form-text">One value per line.</div>' : '');
     }
-    return '<label class="editor-tiny" for="al-setting-' + key + '">' + esc(field.label) + '</label><input class="form-control form-control-sm mt-1" type="' + (kind === 'integer' ? 'number' : (kind === 'url' ? 'url' : 'text')) + '"' + common + ' value="' + esc(rendered) + '">';
+    return '<label class="editor-tiny" for="al-setting-' + key + '">' + esc(field.label) + '</label><input class="form-control form-control-sm mt-1" type="' + (kind === 'integer' ? 'number' : (kind === 'url' ? 'url' : 'text')) + '"' + common + ' value="' + esc(rendered) + '">' + variableHint;
+  }
+
+  function applyAssemblyLineSettingsFilter() {
+    var query = String(state.assemblyLineSettingsFilter || '').trim().toLowerCase();
+    var visibleSections = 0;
+    document.querySelectorAll('[data-al-settings-section]').forEach(function (section) {
+      var sectionMatch = !query || String(section.getAttribute('data-search') || '').indexOf(query) !== -1;
+      var visibleItems = 0;
+      section.querySelectorAll('[data-al-settings-item]').forEach(function (item) {
+        var visible = sectionMatch || String(item.getAttribute('data-search') || '').indexOf(query) !== -1;
+        item.classList.toggle('d-none', !visible);
+        if (visible) visibleItems += 1;
+      });
+      var visible = sectionMatch || visibleItems > 0;
+      section.classList.toggle('d-none', !visible);
+      if (visible) visibleSections += 1;
+    });
+    var empty = document.getElementById('assemblyline-settings-filter-empty');
+    if (empty) empty.classList.toggle('d-none', visibleSections > 0);
   }
 
   function renderAssemblyLineSettings() {
@@ -5750,16 +5771,19 @@
     var html = '<div class="editor-new-project-shell"><div class="editor-card"><div class="editor-card-body d-flex justify-content-between align-items-start gap-3 flex-wrap">';
     html += '<div><h2 style="font-weight:700;font-size:18px;margin:0 0 6px">AssemblyLine settings</h2><p class="text-muted small mb-0">Edit publishing metadata and predefined AssemblyLine variables without finding their YAML or code blocks.</p></div>';
     html += '<div class="d-flex gap-2"><button class="btn btn-sm btn-outline-secondary" id="close-assemblyline-settings">Back</button><button class="btn btn-sm btn-primary" id="save-assemblyline-settings"' + (state.assemblyLineSettingsDirty ? '' : ' disabled') + '>Save settings</button></div></div></div>';
+    html += '<div class="editor-card"><div class="editor-card-body"><label class="editor-tiny" for="assemblyline-settings-filter">Filter settings</label><div class="input-group input-group-sm mt-1"><span class="input-group-text"><i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i></span><input class="form-control" id="assemblyline-settings-filter" type="search" value="' + esc(state.assemblyLineSettingsFilter) + '" placeholder="Search by label or magic variable name" autocomplete="off"></div></div></div>';
     (data.schema || []).forEach(function (section) {
-      html += '<div class="editor-card"><div class="editor-card-header">' + esc(section.label) + '</div><div class="editor-card-body">';
+      var sectionSearch = [section.id, section.label].concat(section.notes || []).join(' ').toLowerCase();
+      html += '<div class="editor-card" data-al-settings-section data-search="' + esc(sectionSearch) + '"><div class="editor-card-header">' + esc(section.label) + '</div><div class="editor-card-body">';
       if (section.readonly) {
-        html += '<p class="small text-muted">These values are structural, derived, dynamic, or server-wide and are not rewritten as metadata.</p><ul class="small mb-0">';
+        html += '<div data-al-settings-item data-search="' + esc(sectionSearch) + '"><p class="small text-muted">These values are structural, derived, dynamic, or server-wide and are not rewritten as metadata.</p><ul class="small mb-0">';
         (section.notes || []).forEach(function (note) { html += '<li class="mb-1">' + esc(note) + '</li>'; });
-        html += '</ul>';
+        html += '</ul></div>';
       } else {
         html += '<div class="row g-3">';
         (section.fields || []).forEach(function (field) {
-          html += '<div class="' + ((field.kind === 'area' || field.kind === 'list' || field.kind === 'python') ? 'col-12' : 'col-md-6') + '">' + _settingsInput(field, data.values[field.key]) + '</div>';
+          var fieldSearch = [field.key, field.label, section.id, section.label].join(' ').toLowerCase();
+          html += '<div class="' + (field.pair ? 'col-12 col-md-6' : 'col-12') + '" data-al-settings-item data-search="' + esc(fieldSearch) + '">' + _settingsInput(field, data.values[field.key]) + '</div>';
         });
         html += '</div>';
         if (section.id === 'next_steps') {
@@ -5768,8 +5792,10 @@
       }
       html += '</div></div>';
     });
+    html += '<div class="alert alert-light border d-none" id="assemblyline-settings-filter-empty">No settings match that filter.</div>';
     html += '<p class="small text-muted">See the <a href="' + esc(data.docs_url) + '" target="_blank" rel="noopener">AssemblyLine special-variable documentation</a>.</p></div>';
     canvasContent.innerHTML = html;
+    applyAssemblyLineSettingsFilter();
   }
 
   function collectAssemblyLineSettings() {
@@ -9638,6 +9664,11 @@
   // Track dirty state from inline inputs
   document.addEventListener('input', function (e) {
     var target = e.target;
+    if (target.id === 'assemblyline-settings-filter') {
+      state.assemblyLineSettingsFilter = target.value || '';
+      applyAssemblyLineSettingsFilter();
+      return;
+    }
     if (target.matches('[data-al-setting]')) {
       state.assemblyLineSettingsDirty = true;
       var settingsSave = document.getElementById('save-assemblyline-settings');

--- a/docassemble/ALWeaver/data/static/editor.js
+++ b/docassemble/ALWeaver/data/static/editor.js
@@ -7580,6 +7580,7 @@
     html += '<div class="editor-dropzone-icon">&#128196;</div>';
     html += '<div style="font-weight:600">Drag &amp; drop PDF or DOCX files here</div>';
     html += '<div class="text-muted small mt-1">or click to browse</div>';
+    html += '<div class="text-warning-emphasis small mt-2">If you add more than one file, Weaver automates the first file and keeps the others in Templates for you to connect later.</div>';
     html += '<input type="file" id="upload-file-input" multiple accept=".pdf,.docx,application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document" style="display:none">';
     html += '</div>';
     html += '<div id="upload-file-list" class="mt-2"></div>';

--- a/docassemble/ALWeaver/data/static/editor.js
+++ b/docassemble/ALWeaver/data/static/editor.js
@@ -86,6 +86,8 @@
     validationMode: 'validation',
     validationSourceScope: 'saved_source',
     validationBaseRevisionMatches: null,
+    assemblyLineSettings: null,
+    assemblyLineSettingsDirty: false,
   };
 
   var RECENT_PROJECTS_STORAGE_KEY = 'alweaver_recent_projects';
@@ -179,7 +181,7 @@
     var buttons = document.querySelectorAll('.js-save-file-btn');
     if (!buttons.length) return;
     dirtyState.activate(state.filename, state.selectedBlockId);
-    var isDirty = dirtyState.hasDirty(state.filename) || state.sectionDirty;
+    var isDirty = dirtyState.hasDirty(state.filename) || state.sectionDirty || state.assemblyLineSettingsDirty;
     buttons.forEach(function (btn) {
       btn.disabled = !isDirty;
       var badge = btn.querySelector('.js-save-badge');
@@ -192,6 +194,8 @@
   function saveCurrentFile() {
     if (!isInterviewView()) {
       saveCurrentSectionFileIfDirty();
+    } else if (state.canvasMode === 'assemblyline-settings') {
+      saveAssemblyLineSettings();
     } else if (state.filename) {
       saveCurrentBlockIfDirty();
     }
@@ -231,7 +235,7 @@
   }
 
   function hasUnsavedChanges() {
-    return dirtyState.hasDirty(state.filename) || state.sectionDirty;
+    return dirtyState.hasDirty(state.filename) || state.sectionDirty || state.assemblyLineSettingsDirty;
   }
 
   function sectionSnapshotKey() {
@@ -246,6 +250,12 @@
     var editor = _sourceEditors['section-file-source-editor'];
     if (editor) editor.setValue(savedContent);
     state.sectionDirty = false;
+    updateTopbarSaveState();
+    return true;
+  }
+
+  function discardAssemblyLineSettingsChanges() {
+    state.assemblyLineSettingsDirty = false;
     updateTopbarSaveState();
     return true;
   }
@@ -5366,7 +5376,8 @@
           if (choice === 'discard') {
             var interviewDiscarded = !dirtyState.hasDirty(state.filename) || discardInterviewChanges();
             var sectionDiscarded = discardSectionChanges();
-            if (interviewDiscarded && sectionDiscarded) {
+            var settingsDiscarded = discardAssemblyLineSettingsChanges();
+            if (interviewDiscarded && sectionDiscarded && settingsDiscarded) {
               finish(true);
             } else if (errorBox) {
               errorBox.textContent = 'The last saved version could not be restored. Your changes were kept.';
@@ -5379,6 +5390,7 @@
           saveCurrentSectionFileIfDirty()
             .then(function (sectionSaved) {
               if (!sectionSaved) return false;
+              if (state.assemblyLineSettingsDirty) return saveAssemblyLineSettings();
               return saveCurrentBlockIfDirty();
             })
             .then(function (saved) {
@@ -5690,6 +5702,114 @@
     body.innerHTML = html;
   }
 
+  function loadAssemblyLineSettings() {
+    if (!state.project || !state.filename) return Promise.resolve(false);
+    state.assemblyLineSettings = null;
+    state.assemblyLineSettingsDirty = false;
+    renderAssemblyLineSettings();
+    return apiGet('/api/assemblyline-settings?project=' + encodeURIComponent(state.project) + '&filename=' + encodeURIComponent(state.filename))
+      .then(function (res) {
+        if (!res.success || !res.data) throw new Error((res.error && res.error.message) || 'Unable to load settings.');
+        state.assemblyLineSettings = res.data;
+        state.revision = res.data.revision || state.revision;
+        renderAssemblyLineSettings();
+        updateTopbarSaveState();
+        return true;
+      })
+      .catch(function (error) {
+        canvasContent.innerHTML = '<div class="alert alert-danger">' + esc(error.message || 'Unable to load AssemblyLine settings.') + '</div>';
+        return false;
+      });
+  }
+
+  function _settingsInput(field, value) {
+    var key = esc(field.key);
+    var kind = field.kind || 'text';
+    var common = ' data-al-setting="' + key + '" id="al-setting-' + key.replace(/[^a-zA-Z0-9_-]/g, '-') + '"';
+    if (kind === 'boolean') {
+      return '<div class="form-check form-switch"><input class="form-check-input" type="checkbox"' + common + (value ? ' checked' : '') + '><label class="form-check-label" for="al-setting-' + key.replace(/[^a-zA-Z0-9_-]/g, '-') + '">' + esc(field.label) + '</label></div>';
+    }
+    if (kind === 'choice') {
+      var select = '<label class="editor-tiny" for="al-setting-' + key + '">' + esc(field.label) + '</label><select class="form-select form-select-sm mt-1"' + common + '>';
+      (field.choices || []).forEach(function (choice) { select += '<option value="' + esc(choice) + '"' + (String(value) === String(choice) ? ' selected' : '') + '>' + esc(String(choice).replace(/_/g, ' ')) + '</option>'; });
+      return select + '</select>';
+    }
+    var rendered = kind === 'list' ? (Array.isArray(value) ? value.join('\n') : '') : String(value === null || value === undefined ? '' : value);
+    if (kind === 'area' || kind === 'list' || kind === 'python') {
+      return '<label class="editor-tiny" for="al-setting-' + key + '">' + esc(field.label) + '</label><textarea class="form-control form-control-sm mt-1' + (kind === 'python' ? ' font-monospace' : '') + '" rows="' + (kind === 'area' ? '4' : '3') + '"' + common + '>' + esc(rendered) + '</textarea>' + (kind === 'list' ? '<div class="form-text">One value per line.</div>' : '');
+    }
+    return '<label class="editor-tiny" for="al-setting-' + key + '">' + esc(field.label) + '</label><input class="form-control form-control-sm mt-1" type="' + (kind === 'integer' ? 'number' : (kind === 'url' ? 'url' : 'text')) + '"' + common + ' value="' + esc(rendered) + '">';
+  }
+
+  function renderAssemblyLineSettings() {
+    if (!state.assemblyLineSettings) {
+      canvasContent.innerHTML = '<div class="text-center py-5"><div class="spinner-border" role="status"></div><p class="text-muted mt-3">Loading AssemblyLine settings…</p></div>';
+      return;
+    }
+    var data = state.assemblyLineSettings;
+    var html = '<div class="editor-new-project-shell"><div class="editor-card"><div class="editor-card-body d-flex justify-content-between align-items-start gap-3 flex-wrap">';
+    html += '<div><h2 style="font-weight:700;font-size:18px;margin:0 0 6px">AssemblyLine settings</h2><p class="text-muted small mb-0">Edit publishing metadata and predefined AssemblyLine variables without finding their YAML or code blocks.</p></div>';
+    html += '<div class="d-flex gap-2"><button class="btn btn-sm btn-outline-secondary" id="close-assemblyline-settings">Back</button><button class="btn btn-sm btn-primary" id="save-assemblyline-settings"' + (state.assemblyLineSettingsDirty ? '' : ' disabled') + '>Save settings</button></div></div></div>';
+    (data.schema || []).forEach(function (section) {
+      html += '<div class="editor-card"><div class="editor-card-header">' + esc(section.label) + '</div><div class="editor-card-body">';
+      if (section.readonly) {
+        html += '<p class="small text-muted">These values are structural, derived, dynamic, or server-wide and are not rewritten as metadata.</p><ul class="small mb-0">';
+        (section.notes || []).forEach(function (note) { html += '<li class="mb-1">' + esc(note) + '</li>'; });
+        html += '</ul>';
+      } else {
+        html += '<div class="row g-3">';
+        (section.fields || []).forEach(function (field) {
+          html += '<div class="' + ((field.kind === 'area' || field.kind === 'list' || field.kind === 'python') ? 'col-12' : 'col-md-6') + '">' + _settingsInput(field, data.values[field.key]) + '</div>';
+        });
+        html += '</div>';
+        if (section.id === 'next_steps') {
+          html += '<div class="alert alert-warning small mt-3 mb-0"><strong>Word document safety:</strong> changing these values updates YAML only and does not overwrite the DOCX shell. If you changed the form type and want the matching standard shell, use the explicit replacement below; Weaver first saves a backup.<div class="mt-2"><button type="button" class="btn btn-sm btn-outline-danger" id="reset-next-steps-template">Back up and replace with standard shell</button></div></div>';
+        }
+      }
+      html += '</div></div>';
+    });
+    html += '<p class="small text-muted">See the <a href="' + esc(data.docs_url) + '" target="_blank" rel="noopener">AssemblyLine special-variable documentation</a>.</p></div>';
+    canvasContent.innerHTML = html;
+  }
+
+  function collectAssemblyLineSettings() {
+    var values = {};
+    document.querySelectorAll('[data-al-setting]').forEach(function (input) {
+      var key = input.getAttribute('data-al-setting');
+      var field = null;
+      (state.assemblyLineSettings.schema || []).some(function (section) { return (section.fields || []).some(function (candidate) { if (candidate.key === key) { field = candidate; return true; } return false; }); });
+      if (!field) return;
+      if (field.kind === 'boolean') values[key] = input.checked;
+      else if (field.kind === 'integer') values[key] = input.value === '' ? 0 : Number(input.value);
+      else if (field.kind === 'list') values[key] = input.value.split(/\r?\n/).map(function (line) { return line.trim(); }).filter(Boolean);
+      else values[key] = input.value;
+    });
+    return values;
+  }
+
+  function saveAssemblyLineSettings() {
+    if (!state.assemblyLineSettings || !state.assemblyLineSettingsDirty) return Promise.resolve(true);
+    return apiPost('/api/assemblyline-settings', {
+      project: state.project,
+      filename: state.filename,
+      expected_revision: state.assemblyLineSettings.revision || state.revision,
+      settings: collectAssemblyLineSettings(),
+    }).then(function (res) {
+      if (!res.success || !res.data) throw new Error((res.error && res.error.message) || 'Unable to save settings.');
+      state.assemblyLineSettings = res.data;
+      state.assemblyLineSettingsDirty = false;
+      refreshFromFileResponse(res.data);
+      state.canvasMode = 'assemblyline-settings';
+      renderAssemblyLineSettings();
+      updateTopbarSaveState();
+      _showSuccessBanner('AssemblyLine settings saved.');
+      return true;
+    }).catch(function (error) {
+      if (!isSupersededRequest(error)) window.alert(error.message || 'Unable to save AssemblyLine settings.');
+      return false;
+    });
+  }
+
   function renderCanvas() {
     disposeSourceEditors();
     updateLeftRailMode();
@@ -5707,6 +5827,8 @@
       renderProjectSelector();
     } else if (state.canvasMode === 'new-project') {
       renderNewProject();
+    } else if (state.canvasMode === 'assemblyline-settings') {
+      renderAssemblyLineSettings();
     } else if (state.canvasMode === 'full-yaml') {
       renderFullYaml();
     } else if (state.canvasMode === 'order-builder') {
@@ -7472,6 +7594,12 @@
     html += '<label class="form-check-label editor-tiny" for="new-project-use-llm-assist">Use AI assistance for drafting</label>';
     html += '<div class="text-muted small mt-1">If enabled, Weaver will use your context and reference page to refine labels and screen grouping.</div>';
     html += '</div>';
+    html += '<div class="row g-3"><div class="col-md-6"><label class="editor-tiny" for="new-project-output-type">Output</label><select class="form-select form-select-sm mt-1" id="new-project-output-type"><option value="form">Assemble downloadable forms</option><option value="survey">Save answers only</option></select></div>';
+    html += '<div class="col-md-6"><label class="editor-tiny" for="new-project-form-type">AssemblyLine form type</label><select class="form-select form-select-sm mt-1" id="new-project-form-type"><option value="auto">Let Weaver decide</option><option value="starts_case">Starts a case</option><option value="existing_case">Existing case</option><option value="appeal">Appeal</option><option value="other_form">Other form</option><option value="letter">Letter</option><option value="other">Other</option></select></div></div>';
+    html += '<div class="row g-3"><div class="col-md-6"><label class="editor-tiny" for="new-project-default-state">Default state/province (optional)</label><input class="form-control form-control-sm mt-1" id="new-project-default-state" placeholder="MA"></div>';
+    html += '<div class="col-md-6"><label class="editor-tiny" for="new-project-user-role">Typical user role</label><select class="form-select form-select-sm mt-1" id="new-project-user-role"><option value="auto">Let Weaver decide</option><option value="plaintiff">Starts the case/request</option><option value="defendant">Responds to it</option><option value="unknown">Ask the user</option></select></div></div>';
+    html += '<div class="form-check form-switch m-0"><input class="form-check-input" type="checkbox" id="new-project-include-next-steps" checked><label class="form-check-label editor-tiny" for="new-project-include-next-steps">Include a next steps document</label><div class="text-muted small mt-1">The generated DOCX is a reusable shell. Later settings changes do not overwrite custom Word edits.</div></div>';
+    html += '<div class="form-check form-switch m-0"><input class="form-check-input" type="checkbox" id="new-project-enable-navigation" checked><label class="form-check-label editor-tiny" for="new-project-enable-navigation">Enable left navigation</label></div>';
     html += '<div><label class="editor-tiny" for="new-project-help-page-url">Reference page URL (optional)</label>';
     html += '<input class="form-control form-control-sm mt-1" id="new-project-help-page-url" type="url" placeholder="https://example.com/help"></div>';
     html += '<div><label class="editor-tiny" for="new-project-help-page-title">Reference page title (optional)</label>';
@@ -8630,6 +8758,50 @@
       toggleFullYaml();
       return;
     }
+    if (uiAction === 'open-assemblyline-settings') {
+      if (!state.project || !state.filename) return;
+      function openAssemblyLineSettings() {
+        stashCurrentEditorState();
+        state.canvasMode = 'assemblyline-settings';
+        state.currentView = 'interview';
+        renderCanvas();
+        loadAssemblyLineSettings();
+      }
+      if (deferNavigationForUnsavedChanges('open AssemblyLine settings', openAssemblyLineSettings)) return;
+      openAssemblyLineSettings();
+      return;
+    }
+    if (target.id === 'close-assemblyline-settings') {
+      function closeAssemblyLineSettings() {
+        state.assemblyLineSettingsDirty = false;
+        state.canvasMode = 'question';
+        renderCanvas();
+      }
+      if (deferNavigationForUnsavedChanges('close AssemblyLine settings', closeAssemblyLineSettings)) return;
+      closeAssemblyLineSettings();
+      return;
+    }
+    if (target.id === 'save-assemblyline-settings') {
+      saveAssemblyLineSettings();
+      return;
+    }
+    if (target.id === 'reset-next-steps-template') {
+      if (!window.confirm('Replace the current next steps DOCX with the standard shell for the selected form type? Weaver will keep a backup in Templates.')) return;
+      var proceedWithReset = function () {
+        apiPost('/api/next-steps-template/reset', {
+          project: state.project,
+          filename: state.filename,
+          confirm_replace: true,
+        }).then(function (res) {
+          if (!res.success) throw new Error((res.error && res.error.message) || 'Unable to replace the template.');
+          var backup = res.data && res.data.backup_filename ? ' Backup: ' + res.data.backup_filename + '.' : '';
+          _showSuccessBanner('Next steps shell replaced.' + backup);
+        }).catch(function (error) { window.alert(error.message || 'Unable to replace the next steps template.'); });
+      };
+      if (state.assemblyLineSettingsDirty) saveAssemblyLineSettings().then(function (saved) { if (saved) proceedWithReset(); });
+      else proceedWithReset();
+      return;
+    }
     if (uiAction === 'open-runtime-inspector') {
       if (!state.project || !state.filename) return;
       function openRuntimeInspector() {
@@ -9338,12 +9510,24 @@
       var helpPageUrlInput = document.getElementById('new-project-help-page-url');
       var helpPageTitleInput = document.getElementById('new-project-help-page-title');
       var useLlmAssistInput = document.getElementById('new-project-use-llm-assist');
+      var outputTypeInput = document.getElementById('new-project-output-type');
+      var formTypeInput = document.getElementById('new-project-form-type');
+      var defaultStateInput = document.getElementById('new-project-default-state');
+      var userRoleInput = document.getElementById('new-project-user-role');
+      var includeNextStepsInput = document.getElementById('new-project-include-next-steps');
+      var enableNavigationInput = document.getElementById('new-project-enable-navigation');
       var githubUrlInput = document.getElementById('new-project-github-url');
       var projectName = nameInput ? nameInput.value : 'NewProject';
       var notes = notesInput ? notesInput.value : '';
       var helpPageUrl = helpPageUrlInput ? helpPageUrlInput.value : '';
       var helpPageTitle = helpPageTitleInput ? helpPageTitleInput.value : '';
       var useLlmAssist = useLlmAssistInput ? useLlmAssistInput.checked : false;
+      var outputType = outputTypeInput ? outputTypeInput.value : 'form';
+      var formType = formTypeInput ? formTypeInput.value : 'auto';
+      var defaultState = defaultStateInput ? defaultStateInput.value.trim() : '';
+      var userRole = userRoleInput ? userRoleInput.value : 'auto';
+      var includeNextSteps = includeNextStepsInput ? includeNextStepsInput.checked : true;
+      var enableNavigation = enableNavigationInput ? enableNavigationInput.checked : true;
       var githubUrl = githubUrlInput ? githubUrlInput.value.trim() : '';
       if (githubUrl && _uploadedFiles.length > 0) {
         window.alert('Choose either a GitHub repository or uploaded documents, not both.');
@@ -9359,6 +9543,12 @@
         formData.append('help_page_url', helpPageUrl);
         formData.append('help_page_title', helpPageTitle);
         formData.append('use_llm_assist', useLlmAssist ? 'true' : 'false');
+        formData.append('output_type', outputType);
+        formData.append('form_type', formType);
+        formData.append('default_state', defaultState);
+        formData.append('typical_role', userRole);
+        formData.append('include_next_steps', includeNextSteps ? 'true' : 'false');
+        formData.append('enable_navigation', enableNavigation ? 'true' : 'false');
         _uploadedFiles.forEach(function (f) { formData.append('files', f, f.name); });
         apiUploadDetailed('/api/new-project', formData)
           .then(function (response) {
@@ -9447,6 +9637,13 @@
   // Track dirty state from inline inputs
   document.addEventListener('input', function (e) {
     var target = e.target;
+    if (target.matches('[data-al-setting]')) {
+      state.assemblyLineSettingsDirty = true;
+      var settingsSave = document.getElementById('save-assemblyline-settings');
+      if (settingsSave) settingsSave.disabled = false;
+      updateTopbarSaveState();
+      return;
+    }
     if (target.id === 'symbol-insert-search') {
       refreshSymbolInsertModalList(target.value || '');
       return;
@@ -9487,6 +9684,13 @@
 
   document.addEventListener('change', function (e) {
     var target = e.target;
+    if (target.matches('[data-al-setting]')) {
+      state.assemblyLineSettingsDirty = true;
+      var settingsSave = document.getElementById('save-assemblyline-settings');
+      if (settingsSave) settingsSave.disabled = false;
+      updateTopbarSaveState();
+      return;
+    }
     if (target.matches('.editor-field-required-switch') || target.id === 'adv-mandatory-switch' || target.id === 'review-skip-undefined') {
       markInterviewDirty();
       return;

--- a/docassemble/ALWeaver/data/static/editor.js
+++ b/docassemble/ALWeaver/data/static/editor.js
@@ -5806,7 +5806,7 @@
       (state.assemblyLineSettings.schema || []).some(function (section) { return (section.fields || []).some(function (candidate) { if (candidate.key === key) { field = candidate; return true; } return false; }); });
       if (!field) return;
       if (field.kind === 'boolean') values[key] = input.checked;
-      else if (field.kind === 'integer') values[key] = input.value === '' ? 0 : Number(input.value);
+      else if (field.kind === 'integer') values[key] = input.value === '' ? '' : Number(input.value);
       else if (field.kind === 'list') values[key] = input.value.split(/\r?\n/).map(function (line) { return line.trim(); }).filter(Boolean);
       else values[key] = input.value;
     });

--- a/docassemble/ALWeaver/data/templates/editor.html
+++ b/docassemble/ALWeaver/data/templates/editor.html
@@ -40,6 +40,7 @@
             <button type="button" class="btn btn-sm btn-outline-light dropdown-toggle" id="topbar-more-menu" data-bs-toggle="dropdown" data-bs-display="static" aria-expanded="false" aria-label="More editor tools">More</button>
             <ul class="dropdown-menu dropdown-menu-end" data-bs-theme="light" aria-labelledby="topbar-more-menu">
               <li><button type="button" class="dropdown-item" data-action="open-full-yaml"><i class="fa-solid fa-code fa-fw me-2" aria-hidden="true"></i>YAML source</button></li>
+              <li><button type="button" class="dropdown-item" data-action="open-assemblyline-settings"><i class="fa-solid fa-sliders fa-fw me-2" aria-hidden="true"></i>AssemblyLine settings</button></li>
               <li><button type="button" class="dropdown-item" data-action="open-standard-playground"><i class="fa-solid fa-flask fa-fw me-2" aria-hidden="true"></i>Open in Playground</button></li>
               <li><button type="button" class="dropdown-item" data-action="open-github-publish"><i class="fa-brands fa-github fa-fw me-2" aria-hidden="true"></i>Commit to GitHub</button></li>
               <li class="d-none" id="github-pull-menu-item"><button type="button" class="dropdown-item" data-action="pull-github"><i class="fa-solid fa-code-pull-request fa-fw me-2" aria-hidden="true"></i>Pull changes from GitHub</button></li>

--- a/docassemble/ALWeaver/data/templates/output.mako
+++ b/docassemble/ALWeaver/data/templates/output.mako
@@ -223,6 +223,25 @@ ${ indent(intro_prompt_value, by=2) }
 code: |
   al_form_type = "${ interview.form_type }"
 % endif
+% if generate_download_screen and interview.include_next_steps:
+---
+id: alweaver assemblyline settings
+initial: True
+code: |
+  # These exact-name variables drive the reusable next-steps DOCX shell and
+  # are editable in Weaver's AssemblyLine settings panel.
+  al_next_steps_enabled = ${ repr(bool(getattr(interview, "next_steps_enabled", True))) }
+  al_next_steps_intro_prompt = ${ repr(str(getattr(interview, "intro_prompt", "") or "")) }
+  al_next_steps_title = ${ repr(str(getattr(interview, "title", "") or "")) }
+  al_next_steps_document_title = ${ repr(str(getattr(interview, "next_steps_document_title", "form") or "form")) }
+  al_next_steps_document_purpose = ${ repr(str(getattr(interview, "next_steps_document_concept", "request") or "request")) }
+  al_next_steps_help_organization = ${ repr(str(getattr(interview, "next_steps_help_organization", "") or "")) }
+  al_next_steps_help_url = ${ repr(str(getattr(interview, "next_steps_help_url", getattr(interview, "help_page_url", "")) or "")) }
+  al_next_steps_generate_qr_code = ${ repr(bool(getattr(interview, "generate_next_steps_qr_code", False))) }
+  al_next_steps_what_happens_next = ${ repr(str(getattr(interview, "custom_next_steps_instructions", {}).get("what_happens_next", "") or "")) }
+  al_next_steps_what_can_decision_maker_do = ${ repr(str(getattr(interview, "custom_next_steps_instructions", {}).get("what_can_decision_maker_do", "") or "")) }
+  al_next_steps_what_happens_if_i_win = ${ repr(str(getattr(interview, "custom_next_steps_instructions", {}).get("what_happens_if_i_win", "") or "")) }
+% endif
 % if len(objects) > 0:
 ---
 objects:
@@ -495,7 +514,7 @@ code: |
 # ALDocument objects specify the metadata for each template
 objects:
   % if interview.include_next_steps:
-  - ${ interview.interview_label }_Post_interview_instructions: ALDocument.using(filename="${ interview.interview_label }_next_steps.docx", enabled=True, has_addendum=False)
+  - ${ interview.interview_label }_Post_interview_instructions: ALDocument.using(filename="${ interview.interview_label }_next_steps.docx", enabled=al_next_steps_enabled, has_addendum=False)
   % endif
   % if len(interview.uploaded_templates) == 1:
   - ${ interview.interview_label }_attachment: ALDocument.using(filename="${ interview.interview_label }", ${ aldocument_kwargs })

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -57,6 +57,7 @@ import docassemble.base.pdftk
 import formfyxer
 import importlib
 import json
+import html
 import keyword
 import mako.runtime
 import mako.template
@@ -5633,27 +5634,81 @@ def _runtime_next_steps_template(source_path: str) -> str:
         for info in source_zip.infolist():
             content = source_zip.read(info.filename)
             if info.filename.endswith(".xml"):
-                text = content.decode("utf-8")
-                for old, new in _NEXT_STEPS_RUNTIME_REPLACEMENTS.items():
-                    text = text.replace(old, new)
-                text = text.replace(
-                    "[ Your local legal aid]",
-                    '{{ al_next_steps_help_organization or "Your local legal aid" }}',
+                content = _rewrite_next_steps_xml(content.decode("utf-8")).encode(
+                    "utf-8"
                 )
-                # The old shells accidentally gated the granted-result section
-                # on a different answer. The runtime variables make the intended
-                # condition unambiguous.
-                mistaken_condition = "if al_next_steps_what_can_decision_maker_do %}"
-                condition_at = text.rfind(mistaken_condition)
-                if condition_at >= 0:
-                    text = (
-                        text[:condition_at]
-                        + "if al_next_steps_what_happens_if_i_win %}"
-                        + text[condition_at + len(mistaken_condition) :]
-                    )
-                content = text.encode("utf-8")
             target_zip.writestr(info, content)
     return handle.name
+
+
+_WORD_PARAGRAPH_RE = re.compile(r"<w:p(?:\s[^>]*)?>.*?</w:p>", re.DOTALL)
+_WORD_TEXT_RE = re.compile(r"(<w:t(?:\s[^>]*)?>)(.*?)(</w:t>)", re.DOTALL)
+
+
+def _rewrite_next_steps_xml(xml_text: str) -> str:
+    """Replace template expressions even when Word splits them across runs."""
+    paragraphs = list(_WORD_PARAGRAPH_RE.finditer(xml_text))
+    logical_values: List[str] = []
+    for paragraph in paragraphs:
+        logical_values.append(
+            "".join(
+                html.unescape(match.group(2))
+                for match in _WORD_TEXT_RE.finditer(paragraph.group(0))
+            )
+        )
+
+    transformed: List[str] = []
+    for logical in logical_values:
+        updated = logical
+        for old, new in _NEXT_STEPS_RUNTIME_REPLACEMENTS.items():
+            updated = updated.replace(old, new)
+        updated = updated.replace(
+            "[ Your local legal aid]",
+            '{{ al_next_steps_help_organization or "Your local legal aid" }}',
+        )
+        transformed.append(updated)
+
+    mistaken_condition = "if al_next_steps_what_can_decision_maker_do %}"
+    condition_indices = [
+        index
+        for index, logical in enumerate(transformed)
+        if mistaken_condition in logical
+    ]
+    if condition_indices:
+        index = condition_indices[-1]
+        transformed[index] = transformed[index].replace(
+            mistaken_condition,
+            "if al_next_steps_what_happens_if_i_win %}",
+        )
+
+    pieces: List[str] = []
+    cursor = 0
+    for paragraph, original, updated in zip(paragraphs, logical_values, transformed):
+        pieces.append(xml_text[cursor : paragraph.start()])
+        paragraph_xml = paragraph.group(0)
+        if updated == original:
+            pieces.append(paragraph_xml)
+        else:
+            text_nodes = list(_WORD_TEXT_RE.finditer(paragraph_xml))
+            node_pieces: List[str] = []
+            node_cursor = 0
+            remaining = updated
+            for node_index, node in enumerate(text_nodes):
+                node_pieces.append(paragraph_xml[node_cursor : node.start()])
+                if node_index == len(text_nodes) - 1:
+                    replacement = remaining
+                else:
+                    original_length = len(html.unescape(node.group(2)))
+                    replacement = remaining[:original_length]
+                    remaining = remaining[original_length:]
+                escaped = html.escape(replacement, quote=False)
+                node_pieces.append(node.group(1) + escaped + node.group(3))
+                node_cursor = node.end()
+            node_pieces.append(paragraph_xml[node_cursor:])
+            pieces.append("".join(node_pieces))
+        cursor = paragraph.end()
+    pieces.append(xml_text[cursor:])
+    return "".join(pieces)
 
 
 def runtime_next_steps_template_for_form_type(form_type: str) -> str:

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -63,6 +63,7 @@ import mako.template
 import more_itertools
 import os
 import re
+import shutil
 import tempfile
 import uuid
 import zipfile
@@ -85,6 +86,7 @@ class WeaverGenerationResult:
     yaml_text: str
     yaml_path: Optional[str] = None
     package_zip_path: Optional[str] = None
+    template_paths: List[str] = field(default_factory=list)
 
 
 @dataclass
@@ -5600,7 +5602,62 @@ def _render_interview_yaml(
     return _tidy_generated_yaml(_repair_generated_yaml_with_lint(yaml_text, interview))
 
 
-def _assign_next_steps_template(interview: DAInterview) -> None:
+_NEXT_STEPS_RUNTIME_REPLACEMENTS = {
+    "interview.intro_prompt": "al_next_steps_intro_prompt",
+    "interview.title": "al_next_steps_title",
+    "interview.next_steps_document_title": "al_next_steps_document_title",
+    "interview.next_steps_document_purpose": "al_next_steps_document_purpose",
+    "interview.next_steps_document_concept": "al_next_steps_document_purpose",
+    "interview.customize_next_steps": "al_next_steps_enabled",
+    'interview.custom_next_steps_instructions["what_happens_next"]': "al_next_steps_what_happens_next",
+    'interview.custom_next_steps_instructions["what_can_decision_maker_do"]': "al_next_steps_what_can_decision_maker_do",
+    'interview.custom_next_steps_instructions["what_happens_if_i_win"]': "al_next_steps_what_happens_if_i_win",
+    "interview.next_steps_help_url": "al_next_steps_help_url",
+    "interview.generate_next_steps_qr_code": "al_next_steps_generate_qr_code",
+}
+
+
+def _runtime_next_steps_template(source_path: str) -> str:
+    """Return a DOCX shell that reads stable runtime settings variables.
+
+    The historical templates refer to the Weaver author's temporary
+    ``interview`` object. That object does not exist in a generated package.
+    Rewrite XML expressions in a temporary copy while leaving the bundled
+    source template (used by the question-driven Weaver) untouched.
+    """
+    handle = tempfile.NamedTemporaryFile(suffix=".docx", delete=False)
+    handle.close()
+    with zipfile.ZipFile(source_path, "r") as source_zip, zipfile.ZipFile(
+        handle.name, "w"
+    ) as target_zip:
+        for info in source_zip.infolist():
+            content = source_zip.read(info.filename)
+            if info.filename.endswith(".xml"):
+                text = content.decode("utf-8")
+                for old, new in _NEXT_STEPS_RUNTIME_REPLACEMENTS.items():
+                    text = text.replace(old, new)
+                text = text.replace(
+                    "[ Your local legal aid]",
+                    '{{ al_next_steps_help_organization or "Your local legal aid" }}',
+                )
+                # The old shells accidentally gated the granted-result section
+                # on a different answer. The runtime variables make the intended
+                # condition unambiguous.
+                mistaken_condition = "if al_next_steps_what_can_decision_maker_do %}"
+                condition_at = text.rfind(mistaken_condition)
+                if condition_at >= 0:
+                    text = (
+                        text[:condition_at]
+                        + "if al_next_steps_what_happens_if_i_win %}"
+                        + text[condition_at + len(mistaken_condition) :]
+                    )
+                content = text.encode("utf-8")
+            target_zip.writestr(info, content)
+    return handle.name
+
+
+def runtime_next_steps_template_for_form_type(form_type: str) -> str:
+    """Build a temporary reusable next-steps shell for an AssemblyLine form type."""
     template_map = {
         "starts_case": "next_steps_starts_case.docx",
         "existing_case": "next_steps_existing_case.docx",
@@ -5609,11 +5666,15 @@ def _assign_next_steps_template(interview: DAInterview) -> None:
         "other_form": "next_steps_other_form.docx",
         "other": "next_steps_other.docx",
     }
-    template_name = template_map.get(interview.form_type, "next_steps_other.docx")
-    template_path = _resolve_template_path(template_name)
+    template_name = template_map.get(form_type, "next_steps_other.docx")
+    return _runtime_next_steps_template(_resolve_template_path(template_name))
+
+
+def _assign_next_steps_template(interview: DAInterview) -> None:
     instructions_filename = f"{interview.interview_label}_next_steps.docx"
     interview.instructions = _LocalFile(
-        path=template_path, filename=instructions_filename
+        path=runtime_next_steps_template_for_form_type(interview.form_type),
+        filename=instructions_filename,
     )
 
 
@@ -5982,8 +6043,17 @@ def generate_interview_from_path(
     if artifacts.package_file:
         package_zip_path = artifacts.package_file.path()
 
+    generated_template_paths: List[str] = []
+    if include_next_steps and hasattr(interview, "instructions"):
+        next_steps_output_path = os.path.join(
+            os.path.dirname(yaml_path), interview.instructions.filename
+        )
+        shutil.copyfile(interview.instructions.path(), next_steps_output_path)
+        generated_template_paths.append(next_steps_output_path)
+
     return WeaverGenerationResult(
         yaml_text=artifacts.yaml_text,
         yaml_path=yaml_path,
         package_zip_path=package_zip_path,
+        template_paths=generated_template_paths,
     )

--- a/docassemble/ALWeaver/test_api_utils.py
+++ b/docassemble/ALWeaver/test_api_utils.py
@@ -138,6 +138,7 @@ class test_api_utils(unittest.TestCase):
         self.assertIn("yaml_filename", result)
         self.assertEqual(result["yaml_filename"], "test_docx_no_pdf_field_names.yml")
         self.assertNotIn("package_zip_base64", result)
+        self.assertNotIn("generated_template_files", result)
 
 
 if __name__ == "__main__":

--- a/docassemble/ALWeaver/test_assemblyline_settings.py
+++ b/docassemble/ALWeaver/test_assemblyline_settings.py
@@ -67,6 +67,24 @@ class AssemblyLineSettingsTest(unittest.TestCase):
         self.assertEqual(twice.count(f"id: {MANAGED_BLOCK_ID}"), 1)
         self.assertEqual(read_settings(twice)["values"]["github_user"], "second")
 
+    def test_optional_integer_metadata_round_trips_when_blank(self):
+        source = SOURCE.replace(
+            "  authors:\n    - Original Author\n",
+            "  authors:\n    - Original Author\n  estimated_completion_delta: ''\n",
+        )
+
+        updated = update_settings(
+            source,
+            {
+                **read_settings(source)["values"],
+                "AL_ORGANIZATION_TITLE": "Example Legal Aid",
+            },
+        )
+
+        values = read_settings(updated)["values"]
+        self.assertEqual(values["estimated_completion_delta"], "")
+        self.assertEqual(values["AL_ORGANIZATION_TITLE"], "Example Legal Aid")
+
     def test_rejects_runtime_logic_as_a_setting(self):
         with self.assertRaisesRegex(ValueError, "Unsupported settings"):
             update_settings(SOURCE, {"addresses_to_search": "[broken"})

--- a/docassemble/ALWeaver/test_assemblyline_settings.py
+++ b/docassemble/ALWeaver/test_assemblyline_settings.py
@@ -84,6 +84,7 @@ class AssemblyLineSettingsTest(unittest.TestCase):
         values = read_settings(updated)["values"]
         self.assertEqual(values["estimated_completion_delta"], "")
         self.assertEqual(values["AL_ORGANIZATION_TITLE"], "Example Legal Aid")
+        self.assertNotIn("can_I_use_this_form:", updated)
 
     def test_rejects_runtime_logic_as_a_setting(self):
         with self.assertRaisesRegex(ValueError, "Unsupported settings"):

--- a/docassemble/ALWeaver/test_assemblyline_settings.py
+++ b/docassemble/ALWeaver/test_assemblyline_settings.py
@@ -1,0 +1,76 @@
+import unittest
+
+import yaml
+
+from docassemble.ALWeaver.assemblyline_settings import (
+    MANAGED_BLOCK_ID,
+    read_settings,
+    update_settings,
+)
+
+
+SOURCE = """# keep header
+metadata:
+  title: Original
+  description: |
+    Existing description
+  authors:
+    - Original Author
+---
+# author-owned code remains untouched
+code: |
+  AL_DEFAULT_COUNTRY = "CA"
+---
+id: main order
+mandatory: True
+code: |
+  al_intro_screen
+  interview_order = True
+"""
+
+
+class AssemblyLineSettingsTest(unittest.TestCase):
+    def test_reads_metadata_and_literal_code_variables(self):
+        result = read_settings(SOURCE)
+        self.assertEqual(result["values"]["title"], "Original")
+        self.assertEqual(result["values"]["AL_DEFAULT_COUNTRY"], "CA")
+        self.assertEqual(result["sources"]["AL_DEFAULT_COUNTRY"], "code block")
+
+    def test_update_adds_managed_block_before_mandatory_and_preserves_other_code(self):
+        updated = update_settings(
+            SOURCE,
+            {
+                "title": "Updated",
+                "AL_DEFAULT_COUNTRY": "US",
+                "allowed_courts": ["Housing Court", "Superior Court"],
+                "speak_text": False,
+            },
+        )
+        self.assertIn("# author-owned code remains untouched", updated)
+        self.assertIn('AL_DEFAULT_COUNTRY = "CA"', updated)
+        self.assertLess(
+            updated.index(f"id: {MANAGED_BLOCK_ID}"), updated.index("id: main order")
+        )
+        result = read_settings(updated)
+        self.assertEqual(result["values"]["title"], "Updated")
+        self.assertEqual(result["values"]["AL_DEFAULT_COUNTRY"], "US")
+        self.assertEqual(
+            result["values"]["allowed_courts"],
+            ["Housing Court", "Superior Court"],
+        )
+        self.assertFalse(result["values"]["speak_text"])
+        list(yaml.safe_load_all(updated))
+
+    def test_repeated_update_replaces_one_managed_block(self):
+        once = update_settings(SOURCE, {"github_user": "first"})
+        twice = update_settings(once, {"github_user": "second"})
+        self.assertEqual(twice.count(f"id: {MANAGED_BLOCK_ID}"), 1)
+        self.assertEqual(read_settings(twice)["values"]["github_user"], "second")
+
+    def test_rejects_runtime_logic_as_a_setting(self):
+        with self.assertRaisesRegex(ValueError, "Unsupported settings"):
+            update_settings(SOURCE, {"addresses_to_search": "[broken"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docassemble/ALWeaver/test_assemblyline_settings.py
+++ b/docassemble/ALWeaver/test_assemblyline_settings.py
@@ -61,6 +61,64 @@ class AssemblyLineSettingsTest(unittest.TestCase):
         self.assertFalse(result["values"]["speak_text"])
         list(yaml.safe_load_all(updated))
 
+    def test_metadata_update_preserves_untouched_literal_scalar_bytes(self):
+        updated = update_settings(SOURCE, {"title": "Updated"})
+
+        original_metadata = SOURCE.split("---", 1)[0]
+        updated_metadata = updated.split("---", 1)[0]
+        self.assertEqual(
+            updated_metadata,
+            original_metadata.replace("title: Original", "title: Updated"),
+        )
+        self.assertIn("  description: |\n    Existing description\n", updated)
+
+    def test_changed_multiline_metadata_uses_literal_block_style(self):
+        updated = update_settings(
+            SOURCE,
+            {"description": "First updated line\nSecond updated line"},
+        )
+
+        self.assertIn(
+            "  description: |\n    First updated line\n    Second updated line\n",
+            updated,
+        )
+        self.assertNotIn("description: '", updated)
+        self.assertEqual(
+            read_settings(updated)["values"]["description"].rstrip("\n"),
+            "First updated line\nSecond updated line",
+        )
+
+    def test_new_multiline_metadata_uses_literal_block_style(self):
+        updated = update_settings(
+            SOURCE,
+            {"can_I_use_this_form": "People filing a claim\nPeople responding"},
+        )
+
+        self.assertIn(
+            "  can_I_use_this_form: |-\n"
+            "    People filing a claim\n"
+            "    People responding",
+            updated,
+        )
+
+    def test_multiline_list_items_use_literal_block_style(self):
+        updated = update_settings(
+            SOURCE,
+            {"authors": ["First author\nSecond line"]},
+        )
+
+        self.assertIn(
+            "  authors:\n"
+            "    - |-\n"
+            "      First author\n"
+            "      Second line",
+            updated,
+        )
+        self.assertEqual(
+            read_settings(updated)["values"]["authors"],
+            ["First author\nSecond line"],
+        )
+
     def test_repeated_update_replaces_one_managed_block(self):
         once = update_settings(SOURCE, {"github_user": "first"})
         twice = update_settings(once, {"github_user": "second"})

--- a/docassemble/ALWeaver/test_assemblyline_settings.py
+++ b/docassemble/ALWeaver/test_assemblyline_settings.py
@@ -8,7 +8,6 @@ from docassemble.ALWeaver.assemblyline_settings import (
     update_settings,
 )
 
-
 SOURCE = """# keep header
 metadata:
   title: Original
@@ -108,10 +107,7 @@ class AssemblyLineSettingsTest(unittest.TestCase):
         )
 
         self.assertIn(
-            "  authors:\n"
-            "    - |-\n"
-            "      First author\n"
-            "      Second line",
+            "  authors:\n" "    - |-\n" "      First author\n" "      Second line",
             updated,
         )
         self.assertEqual(

--- a/docassemble/ALWeaver/test_editor_api.py
+++ b/docassemble/ALWeaver/test_editor_api.py
@@ -1268,6 +1268,48 @@ class TestEditorApiFileCreation(unittest.TestCase):
         self.assertEqual(response.get_json()["data"]["raw_yaml"], expected)
         mock_write.assert_called_once_with(7, "default", "test.yml", expected)
 
+    def test_assemblyline_settings_get_returns_schema_and_revision(self):
+        source = "metadata:\n  title: Example\n"
+        with (
+            patch.object(api_editor, "_editor_auth_check", return_value=True),
+            patch.object(api_editor, "_current_user_id", return_value=7),
+            patch.object(api_editor, "playground_read_yaml", return_value=source),
+            patch.object(
+                api_editor,
+                "read_settings",
+                return_value={"schema": [], "values": {"title": "Example"}},
+            ),
+        ):
+            with api_editor.app.test_request_context(
+                "/al/editor/api/assemblyline-settings?project=default&filename=test.yml"
+            ):
+                response = api_editor.editor_api_get_assemblyline_settings()
+
+        payload = response.get_json()["data"]
+        self.assertEqual(payload["values"]["title"], "Example")
+        self.assertEqual(payload["revision"], "test-revision")
+
+    def test_assemblyline_settings_save_rejects_stale_revision(self):
+        with (
+            patch.object(api_editor, "_editor_auth_check", return_value=True),
+            patch.object(api_editor, "_current_user_id", return_value=7),
+            patch.object(api_editor, "playground_read_yaml", return_value="source"),
+        ):
+            with api_editor.app.test_request_context(
+                "/al/editor/api/assemblyline-settings",
+                method="POST",
+                json={
+                    "project": "default",
+                    "filename": "test.yml",
+                    "expected_revision": "old-revision",
+                    "settings": {"title": "Changed"},
+                },
+            ):
+                response = api_editor.editor_api_save_assemblyline_settings()
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(response.get_json()["error"]["code"], "revision_conflict")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/docassemble/ALWeaver/test_editor_api.py
+++ b/docassemble/ALWeaver/test_editor_api.py
@@ -1128,7 +1128,13 @@ class TestEditorApiFileCreation(unittest.TestCase):
         )
         self.assertTrue(start_kwargs["generation_options"]["use_llm_assist"])
         self.assertFalse(start_kwargs["generation_options"]["create_package_zip"])
-        self.assertFalse(start_kwargs["generation_options"]["include_next_steps"])
+        self.assertTrue(start_kwargs["generation_options"]["include_next_steps"])
+        self.assertTrue(start_kwargs["generation_options"]["include_download_screen"])
+        self.assertTrue(
+            start_kwargs["generation_options"]["interview_overrides"][
+                "next_steps_enabled"
+            ]
+        )
         self.assertEqual(len(start_kwargs["uploaded_files"]), 1)
         self.assertEqual(start_kwargs["uploaded_files"][0]["filename"], docx_path.name)
         self.assertIsInstance(start_kwargs["uploaded_files"][0]["content_bytes"], bytes)

--- a/docassemble/ALWeaver/test_editor_frontend.py
+++ b/docassemble/ALWeaver/test_editor_frontend.py
@@ -314,6 +314,10 @@ class TestEditorFrontend(unittest.TestCase):
         self.assertIn("confirm_replace: true", editor)
         self.assertIn('id="new-project-include-next-steps"', editor)
         self.assertIn('id="new-project-output-type"', editor)
+        self.assertIn('id="assemblyline-settings-filter"', editor)
+        self.assertIn("applyAssemblyLineSettingsFilter", editor)
+        self.assertIn("editor-al-setting-key", editor)
+        self.assertIn("field.pair ? 'col-12 col-md-6' : 'col-12'", editor)
 
     def test_navbar_matches_docassemble_and_carries_the_account_menu(self):
         """The editor is a full-page app that sits where a native docassemble

--- a/docassemble/ALWeaver/test_editor_frontend.py
+++ b/docassemble/ALWeaver/test_editor_frontend.py
@@ -303,6 +303,18 @@ class TestEditorFrontend(unittest.TestCase):
         self.assertIn("Unable to save metadata safely: ", editor)
         self.assertIn("Unable to save block: ", editor)
 
+    def test_assemblyline_settings_are_graphical_and_next_steps_reset_is_explicit(self):
+        template = (self.package_dir / "data/templates/editor.html").read_text()
+        editor = (self.package_dir / "data/static/editor.js").read_text()
+
+        self.assertIn('data-action="open-assemblyline-settings"', template)
+        self.assertIn("/api/assemblyline-settings", editor)
+        self.assertIn("data-al-setting", editor)
+        self.assertIn("Back up and replace with standard shell", editor)
+        self.assertIn("confirm_replace: true", editor)
+        self.assertIn('id="new-project-include-next-steps"', editor)
+        self.assertIn('id="new-project-output-type"', editor)
+
     def test_navbar_matches_docassemble_and_carries_the_account_menu(self):
         """The editor is a full-page app that sits where a native docassemble
         page would, so its bar has to be a real Bootstrap navbar at

--- a/docassemble/ALWeaver/test_editor_frontend.py
+++ b/docassemble/ALWeaver/test_editor_frontend.py
@@ -318,6 +318,7 @@ class TestEditorFrontend(unittest.TestCase):
         self.assertIn("applyAssemblyLineSettingsFilter", editor)
         self.assertIn("editor-al-setting-key", editor)
         self.assertIn("field.pair ? 'col-12 col-md-6' : 'col-12'", editor)
+        self.assertIn("input.value === '' ? '' : Number(input.value)", editor)
 
     def test_navbar_matches_docassemble_and_carries_the_account_menu(self):
         """The editor is a full-page app that sits where a native docassemble

--- a/docassemble/ALWeaver/test_generate_from_path.py
+++ b/docassemble/ALWeaver/test_generate_from_path.py
@@ -14,12 +14,27 @@ from .interview_generator import (
     _LocalDAFileAdapter,
     generate_interview_from_path,
     generate_interview_artifacts,
+    _rewrite_next_steps_xml,
     _ensure_unique_question_ids,
     _with_progress_markers,
 )
 
 
 class TestGenerateInterviewFromPath(unittest.TestCase):
+    def test_next_steps_rewrite_handles_expressions_split_across_word_runs(self):
+        xml = (
+            '<w:document xmlns:w="word"><w:body><w:p>'
+            '<w:r><w:t>{% if interview.custom_next_steps_instructions["what_</w:t></w:r>'
+            '<w:r><w:t>happens_if_i_win"] %}</w:t></w:r>'
+            '</w:p></w:body></w:document>'
+        )
+
+        rewritten = _rewrite_next_steps_xml(xml)
+
+        self.assertIn("al_next_steps_what_happens_if_i_win", rewritten)
+        self.assertNotIn("interview.custom_next_steps_instructions", rewritten)
+        self.assertEqual(rewritten.count("<w:r>"), 2)
+
     @staticmethod
     def _offline_cluster_screens(fields, tools_token=None):
         """Deterministic fallback grouping for test runs without OpenAI credentials."""

--- a/docassemble/ALWeaver/test_generate_from_path.py
+++ b/docassemble/ALWeaver/test_generate_from_path.py
@@ -26,7 +26,7 @@ class TestGenerateInterviewFromPath(unittest.TestCase):
             '<w:document xmlns:w="word"><w:body><w:p>'
             '<w:r><w:t>{% if interview.custom_next_steps_instructions["what_</w:t></w:r>'
             '<w:r><w:t>happens_if_i_win"] %}</w:t></w:r>'
-            '</w:p></w:body></w:document>'
+            "</w:p></w:body></w:document>"
         )
 
         rewritten = _rewrite_next_steps_xml(xml)
@@ -263,9 +263,7 @@ question: |
             runtime_template = Path(result.template_paths[0])
             self.assertTrue(runtime_template.exists())
             with zipfile.ZipFile(runtime_template) as generated_docx:
-                document_xml = generated_docx.read("word/document.xml").decode(
-                    "utf-8"
-                )
+                document_xml = generated_docx.read("word/document.xml").decode("utf-8")
             self.assertIn("al_next_steps_document_title", document_xml)
             self.assertIn("al_next_steps_what_happens_if_i_win", document_xml)
             self.assertNotIn("interview.custom_next_steps_instructions", document_xml)

--- a/docassemble/ALWeaver/test_generate_from_path.py
+++ b/docassemble/ALWeaver/test_generate_from_path.py
@@ -244,6 +244,19 @@ question: |
                     for name in names
                 )
             )
+            self.assertEqual(len(result.template_paths), 1)
+            runtime_template = Path(result.template_paths[0])
+            self.assertTrue(runtime_template.exists())
+            with zipfile.ZipFile(runtime_template) as generated_docx:
+                document_xml = generated_docx.read("word/document.xml").decode(
+                    "utf-8"
+                )
+            self.assertIn("al_next_steps_document_title", document_xml)
+            self.assertIn("al_next_steps_what_happens_if_i_win", document_xml)
+            self.assertNotIn("interview.custom_next_steps_instructions", document_xml)
+            yaml_text = Path(result.yaml_path).read_text(encoding="utf-8")
+            self.assertIn("id: alweaver assemblyline settings", yaml_text)
+            self.assertIn("al_next_steps_enabled = True", yaml_text)
             self.assertTrue(
                 any(
                     name.endswith("/data/templates/test_docx_no_pdf_field_names.docx")

--- a/docs/editor_assemblyline_settings.md
+++ b/docs/editor_assemblyline_settings.md
@@ -1,0 +1,87 @@
+# AssemblyLine settings in the graphical Weaver
+
+The question-driven Weaver collected both descriptive metadata and values that
+AssemblyLine resolves by exact Python variable name. The graphical editor keeps
+those concepts separate:
+
+- publishing/discovery values remain in the interview's `metadata` document;
+- supported predefined variables are written to the Weaver-owned
+  `alweaver assemblyline settings` code block;
+- executable logic, objects, events, and derived runtime values remain in their
+  native graphical or YAML/code editors.
+
+The settings endpoint uses an expected source revision and validates the whole
+candidate interview before writing. It replaces only the metadata document and
+the Weaver-owned block; author-owned code blocks are not rewritten.
+
+## Coverage of AssemblyLine special variables
+
+The settings panel directly supports:
+
+- organization/locale: `AL_ORGANIZATION_TITLE`,
+  `AL_ORGANIZATION_HOMEPAGE`, `AL_DEFAULT_COUNTRY`, `AL_DEFAULT_STATE`,
+  `AL_DEFAULT_LANGUAGE`, and `AL_DEFAULT_OVERFLOW_MESSAGE`;
+- interview behavior: `al_form_type`, `user_ask_role`,
+  `al_person_answering`, `allowed_courts`,
+  `al_form_requires_digital_signature`, `al_typed_signature_prefix`,
+  `al_typed_signature_font`, and `speak_text`;
+- languages: `enable_al_language`, `al_user_default_language`, and
+  `al_interview_languages`;
+- repository information: `github_repo_name` and `github_user`;
+- the stable `al_next_steps_*` values used by generated next-steps shells.
+
+The panel explains but does not flatten these into metadata:
+
+- `al_logo` is an object backed by a static file;
+- `addresses_to_search` and dynamic menu items are executable logic;
+- `al_intro_screen` is an interview-order event;
+- `al_user_bundle`, `al_court_bundle`, `signature_fields`, and `trial_court`
+  are runtime structure;
+- `user_role` and `user_started_case` are derived;
+- `users` and `other_parties` are AssemblyLine objects;
+- server-wide settings belong in the Docassemble configuration.
+
+This classification follows the official [AssemblyLine special-variable
+documentation](https://assemblyline.suffolklitlab.org/docs/components/AssemblyLine/magic_variables/).
+
+## Auto-drafting choices
+
+Project creation asks for the choices that materially change generated output:
+
+- downloadable forms or a data-only survey;
+- form type and typical user role, with an automatic option;
+- default state/province;
+- next-steps inclusion; and
+- left navigation.
+
+AI remains responsible for proposed prose, labels, types, and screen grouping.
+All deterministic choices can be reviewed later in AssemblyLine settings.
+
+## Next-steps lifecycle
+
+Form projects always receive the YAML wiring and a reusable form-type-specific
+DOCX shell. Turning next steps off disables its `ALDocument`; it does not delete
+the file, so the author can turn it on later without regeneration.
+
+Ordinary next-steps edits update only `al_next_steps_*` values in YAML and never
+overwrite the DOCX. Changing `al_form_type` also preserves the current DOCX.
+The explicit **Back up and replace with standard shell** action is the only
+graphical operation that replaces it. That action:
+
+1. requires a confirmation flag;
+2. copies the current DOCX to a unique `.pre-weaver-reset` backup; and
+3. installs the standard runtime shell for the selected form type.
+
+Generated shells refer to runtime `al_next_steps_*` values rather than the
+temporary `interview` object used while the original Weaver runs. Generation
+also normalizes the historical `document_concept`/`document_purpose` mismatch
+and corrects the condition guarding the “request granted” instructions.
+
+## Remaining template-ingestion boundary
+
+The editor accepts multiple uploaded files so they can be retained in the
+project, but the generator currently builds attachment and question YAML from
+the first document. Until multi-document generation is implemented in
+`generate_interview_from_path`, the creation screen must describe this boundary
+plainly and must not imply that every uploaded file was automated.
+

--- a/docs/editor_assemblyline_settings.md
+++ b/docs/editor_assemblyline_settings.md
@@ -14,6 +14,31 @@ The settings endpoint uses an expected source revision and validates the whole
 candidate interview before writing. It replaces only the metadata document and
 the Weaver-owned block; author-owned code blocks are not rewritten.
 
+The settings panel is searchable by section, friendly label, or exact metadata
+key/magic-variable name. Each control displays that exact name. Controls use a
+single-column layout by default; only related pairs, such as title/short title,
+country/state, repository owner/name, and the two timing values, share a row.
+
+## Question-driven workflow comparison
+
+| Original Weaver screen or decision | Graphical auto-draft coverage | Graphical access pattern |
+| --- | --- | --- |
+| Form identity, description, eligibility, preparation, and completion prose | AI proposes the descriptive draft; exact publishing fields remain reviewable | **AssemblyLine settings** at any time |
+| Output form versus data-only survey | Changes the generated interview structure and cannot be inferred safely | Deterministic project-creation choice |
+| Form type, typical role, and default state | Auto-draft may infer them, but a wrong value changes downstream AssemblyLine behavior | Deterministic project-creation choices, then **AssemblyLine settings** |
+| Template inspection, field typing, labels, and screen grouping | Core strength of auto-drafting; the graphical field and screen editors expose the result | Auto-draft followed by normal graphical editing |
+| Organization, locale, language, signatures, repository, and accessibility variables | Not all warrant interrupting project creation, but they should not require locating exact-name code assignments | Searchable **AssemblyLine settings** |
+| Next-steps inclusion and prose | Inclusion changes package structure; prose can be edited later | Creation-time include choice plus anytime `al_next_steps_*` settings |
+| Next-steps DOCX selection/customization | A normal settings save must not destroy Word edits | Explicit, confirmed **Back up and replace with standard shell** action only |
+| Bundles, signature fields, court routing, parties, menus, and order events | These are dynamic objects, executable logic, or interview structure—not scalar metadata | Their native object, field, order, data, or code editors |
+| Review and package download | Replaced by continuous graphical review, validation, and project files | Normal editor/project workflow |
+
+The creation dialog is therefore reserved for deterministic choices that alter
+the generated structure. The anytime panel handles scalar publishing metadata
+and literal predefined variables. Dynamic code and objects remain visible as
+advanced coverage boundaries instead of being deceptively flattened into text
+fields.
+
 ## Coverage of AssemblyLine special variables
 
 The settings panel directly supports:
@@ -84,4 +109,3 @@ project, but the generator currently builds attachment and question YAML from
 the first document. Until multi-document generation is implemented in
 `generate_interview_from_path`, the creation screen must describe this boundary
 plainly and must not imply that every uploaded file was automated.
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [build-system]
-requires = ["setuptools==83.0.0"]
+# Docassemble still imports pkg_resources at runtime. setuptools 82+ removed it,
+# and dainstall may promote the build requirement into the server environment.
+requires = ["setuptools>=61,<82"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Work on syncing up more of the original, step-by-step weaver settings into the new graphical /al/editor endpoint's interface, so there's clear feature parity.