### PR TITLE
Parse more Jinja statements out of DOCX templates

### DIFF
--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -3728,6 +3728,121 @@ def get_question_file_variables(screens: List[Screen]) -> List[str]:
     return list(dict.fromkeys(fields))
 
 
+# A Jinja statement tag, with the whole inside captured. docxtpl adds `p`, `r`,
+# `tr` and `tc` prefixes, and Jinja itself allows `-`/`+` whitespace control on
+# either end, so the modifiers are stripped from the captured text separately.
+JINJA_STATEMENT_TAG = re.compile(r"\{%(.*?)%\}", re.DOTALL)
+JINJA_STATEMENT_PREFIX = re.compile(r"^(?:tr|tc|p|r)?[+\-]?\s*")
+JINJA_STATEMENT_SUFFIX = re.compile(r"\s*[+\-]?$")
+JINJA_FOR_STATEMENT = re.compile(r"^for\s+.+?\s+in\s+(.+)$", re.DOTALL)
+JINJA_CONDITIONAL_STATEMENT = re.compile(r"^(?:el)?if\s+(.+)$", re.DOTALL)
+JINJA_STRING_LITERAL = re.compile(r"'[^']*'|\"[^\"]*\"")
+# A dotted/subscripted chain like `users[0].name.first` or `child.name.full()`
+JINJA_VARIABLE_CHAIN = re.compile(
+    r"[A-Za-z_]\w*(?:\[[^\[\]]*\]|\.[A-Za-z_]\w*(?:\(\s*\))?)*"
+)
+# Words that can start a chain but never name a variable we could gather. Jinja
+# operators and literals, plus the built-in tests that follow `is`.
+JINJA_NON_VARIABLE_WORDS = frozenset(
+    {
+        "and",
+        "boolean",
+        "callable",
+        "defined",
+        "divisibleby",
+        "else",
+        "eq",
+        "escaped",
+        "even",
+        "false",
+        "filter",
+        "float",
+        "ge",
+        "gt",
+        "in",
+        "integer",
+        "is",
+        "iterable",
+        "le",
+        "loop",
+        "lower",
+        "lt",
+        "mapping",
+        "ne",
+        "none",
+        "not",
+        "number",
+        "odd",
+        "or",
+        "recursive",
+        "sameas",
+        "sequence",
+        "string",
+        "true",
+        "undefined",
+        "upper",
+    }
+)
+
+
+def _variables_in_jinja_expression(expression: str) -> Set[str]:
+    """Pull everything that looks like a variable out of a Jinja expression.
+
+    Unlike a simple "first word wins" match, this finds variables wherever they
+    appear, so both sides of a comparison and both operands of `in` are picked
+    up.
+
+    Args:
+        expression (str): the inside of a Jinja `if`/`elif` test or the iterable
+            half of a `for` statement.
+
+    Returns:
+        Set[str]: the variable chains found in the expression.
+    """
+    # Blank out string literals so their contents are never read as variables
+    expression = JINJA_STRING_LITERAL.sub(" ", expression)
+    found = set()
+    for match in JINJA_VARIABLE_CHAIN.finditer(expression):
+        preceding = expression[: match.start()].rstrip()
+        # `.attribute` and `|filter` continue the chain before them
+        if preceding.endswith(".") or preceding.endswith("|"):
+            continue
+        # `some_function(x)` is a call, not something we can ask the user for
+        if expression[match.end() :].lstrip().startswith("("):
+            continue
+        chain = match.group(0)
+        root = re.split(r"[.\[]", chain, maxsplit=1)[0]
+        if root in JINJA_NON_VARIABLE_WORDS or keyword.iskeyword(root):
+            continue
+        found.add(chain)
+    return found
+
+
+def _variables_in_jinja_statements(text: str) -> Set[str]:
+    """Find the variables used in the `{% ... %}` statements in a template.
+
+    Handles the `for`, `if` and `elif` statements the Weaver knows how to turn
+    into questions, along with docxtpl's `{%p`/`{%r`/`{%tr`/`{%tc` prefixes and
+    Jinja's `-`/`+` whitespace control markers.
+
+    Args:
+        text (str): the full text of a DOCX template.
+
+    Returns:
+        Set[str]: the variable chains found in those statements.
+    """
+    found: Set[str] = set()
+    for raw_statement in JINJA_STATEMENT_TAG.findall(text):
+        statement = JINJA_STATEMENT_PREFIX.sub("", raw_statement.strip())
+        statement = JINJA_STATEMENT_SUFFIX.sub("", statement)
+        for pattern in (JINJA_FOR_STATEMENT, JINJA_CONDITIONAL_STATEMENT):
+            match = pattern.match(statement)
+            if match:
+                found.update(_variables_in_jinja_expression(match.group(1)))
+                break
+    return found
+
+
 def get_docx_variables(text: str) -> set:
     """
     Given the string from a docx file with fairly simple
@@ -3745,19 +3860,8 @@ def get_docx_variables(text: str) -> set:
         r"{{ *([^\} ]+) *}}", text
     ):  # Simple single variable use
         minimally_filtered.add(possible_variable)
-    # Variables in the second parts of for loops (allow paragraph and whitespace flags)
-    for possible_variable in re.findall(
-        r"\{%[^ \t]* +for [A-Za-z\_][A-Za-z0-9\_]* in ([^\} ]+) +[^ \t]*%}", text
-    ):
-        minimally_filtered.add(possible_variable)
-    # Variables in very simple `if` statements (allow paragraph and whitespace flags)
-    for possible_variable in re.findall(r"{%[^ \t]* +if ([^\} ]+) +[^ \t]*%}", text):
-        minimally_filtered.add(possible_variable)
-    # Capture variables in `if` statements that contain a comparison
-    for possible_variable in re.findall(
-        r"{%[^ \t]* +if ([^\} ]+) ==|is|>|<|!=|<=|>= .* +[^ \t]*%}", text
-    ):
-        minimally_filtered.add(possible_variable)
+    # Variables inside `{% ... %}` statements: `for`, `if`, and `elif`
+    minimally_filtered.update(_variables_in_jinja_statements(text))
 
     fields = set()
 

--- a/docassemble/ALWeaver/test_docx_files.py
+++ b/docassemble/ALWeaver/test_docx_files.py
@@ -51,6 +51,52 @@ class test_docxs(unittest.TestCase):
         self.assertIn("children[0].address.county", all_vars)
         self.assertIn("milkman.attorney.firm", all_vars)
 
+    def test_whitespace_control_markers(self):
+        """`-` and `+` right next to the `%` shouldn't hide the statement."""
+        all_vars = get_docx_variables(
+            "{%- if trimmed_var -%}{% endif %}"
+            "{%+ if untrimmed_var +%}{% endif %}"
+            "{%p- if paragraph_var -%}{% endif %}"
+            "{%tr for row in table_rows %}{% endfor %}"
+        )
+        self.assertEqual(
+            all_vars,
+            {"trimmed_var", "untrimmed_var", "paragraph_var", "table_rows"},
+        )
+
+    def test_elif_statements(self):
+        all_vars = get_docx_variables(
+            "{%p if first_var %}{%p elif second_var %}{%p else %}{%p endif %}"
+        )
+        self.assertEqual(all_vars, {"first_var", "second_var"})
+
+    def test_in_operator(self):
+        all_vars = get_docx_variables("{%p if needle_var in haystack_var %}{% endif %}")
+        self.assertEqual(all_vars, {"needle_var", "haystack_var"})
+
+    def test_variables_on_either_side_of_a_comparison(self):
+        all_vars = get_docx_variables(
+            "{%p if 5 == right_side_var %}{% endif %}"
+            "{%p if left_side_var != other_side_var %}{% endif %}"
+        )
+        self.assertEqual(
+            all_vars, {"right_side_var", "left_side_var", "other_side_var"}
+        )
+
+    def test_operators_and_literals_are_not_variables(self):
+        all_vars = get_docx_variables(
+            "{%p if not a_var and b_var is defined %}{% endif %}"
+            '{%p if c_var == "final" and d_var != None %}{% endif %}'
+        )
+        self.assertEqual(all_vars, {"a_var", "b_var", "c_var", "d_var"})
+
+    def test_attributes_and_filters_do_not_start_new_variables(self):
+        all_vars = get_docx_variables(
+            "{%p if users[0].name.first %}{% endif %}"
+            "{%p if some_var | length %}{% endif %}"
+        )
+        self.assertEqual(all_vars, {"users[0].name.first", "some_var"})
+
     def test_reserved_docx_labels(self):
         reserved_labels_files = (
             Path(__file__).parent / "test/reserved_docx_variables.docx"


### PR DESCRIPTION
The `{% ... %}` scanning in `get_docx_variables` missed several kinds of Jinja statement, so the variables in them never became questions.

Fixed here:

* `-` and `+` whitespace-control markers directly against the `%` — `{%- if x -%}`
* `elif` branches
* the `in` operator — `{% if needle in haystack %}`
* variables on the **right-hand** side of a comparison — `{% if 5 == x %}`

The old "comparison" regex was also broken outright:

```python
r"{%[^ \t]* +if ([^\} ]+) ==|is|>|<|!=|<=|>= .* +[^ \t]*%}"
```

Top-level alternation makes that read as `(if X ==)|(is)|(>)|(<)|…`, so it mostly matched empty strings and contributed nothing.

Statement bodies are now scanned for every variable-looking chain, with string literals blanked out first and Jinja's operators, built-in tests and function calls filtered out. That also removes the old assumption that the variable is always the first thing in the expression, which was one of the bullets on the issue.

Fixes #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**DOCX parsing stack** — merge in this order, each builds on the last:
#1001 (#503) → #1002 (#258) → #1003 (#730) → #1004 (#621) → #1005 (#745)

All five rewrite the same function (`get_docx_variables`), which is why they're stacked rather than independent.