### PR TITLE
Parse DOCX variables that are wrapped in function calls

### DIFF
--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -3912,7 +3912,8 @@ JINJA_ANY_TAG = re.compile(r"\{\{(.*?)\}\}|\{%(.*?)%\}", re.DOTALL)
 JINJA_SIMPLE_OUTPUT = re.compile(r"^ *([^\} ]+) *$")
 # A chain we can safely index into, i.e. `mylist` or `user.children`
 JINJA_INDEXABLE_CHAIN = re.compile(r"^[A-Za-z_]\w*(?:\[[^\[\]]*\]|\.[A-Za-z_]\w*)*$")
-JINJA_STRING_LITERAL = re.compile(r"'[^']*'|\"[^\"]*\"")
+# Straight and curly quotes -- Word likes to autocorrect the ones an author types
+JINJA_STRING_LITERAL = re.compile(r"'[^']*'|\"[^\"]*\"|‘[^’]*’|“[^”]*”")
 # A dotted/subscripted chain like `users[0].name.first` or `child.name.full()`
 JINJA_VARIABLE_CHAIN = re.compile(
     r"[A-Za-z_]\w*(?:\[[^\[\]]*\]|\.[A-Za-z_]\w*(?:\(\s*\))?)*"
@@ -3994,6 +3995,16 @@ def _variables_in_jinja_expression(expression: str) -> Set[str]:
     return found
 
 
+def _has_identifier_root(chain: str) -> bool:
+    """True if the text up to the first `.` is a usable variable name.
+
+    `users[0].name.first` qualifies; `currency(some_amount)` does not, because
+    its root is a call rather than something the interview can assign to.
+    """
+    root = re.sub(r"\[.+\]", "", chain.split(".", 1)[0])
+    return root.isidentifier()
+
+
 def _resolve_loop_variable(
     chain: str, loop_scopes: Sequence[Dict[str, Optional[str]]]
 ) -> Optional[str]:
@@ -4071,8 +4082,12 @@ def _raw_variables_from_template(text: str) -> Set[str]:
         if output is not None:
             # Simple single variable use, i.e. `{{ users[0].name.first }}`
             simple = JINJA_SIMPLE_OUTPUT.match(output)
-            if simple:
+            if simple and _has_identifier_root(simple.group(1)):
                 keep([simple.group(1)])
+            else:
+                # Something more involved, i.e. `{{ currency(some_amount) }}`.
+                # Pull the variables out of the expression instead of dropping it.
+                keep(_variables_in_jinja_expression(output))
             continue
         statement = JINJA_STATEMENT_PREFIX.sub("", raw_statement.strip())
         statement = JINJA_STATEMENT_SUFFIX.sub("", statement)

--- a/docassemble/ALWeaver/test_docx_files.py
+++ b/docassemble/ALWeaver/test_docx_files.py
@@ -155,6 +155,42 @@ class test_docxs(unittest.TestCase):
             {"mylist"},
         )
 
+    def test_variables_wrapped_in_function_calls(self):
+        """`{{ currency(some_amount) }}` still needs `some_amount` gathered."""
+        self.assertEqual(
+            get_docx_variables("{{ currency(some_amount) }}"), {"some_amount"}
+        )
+        self.assertEqual(
+            get_docx_variables("{{ currency(users[0].income) }}"), {"users[0].income"}
+        )
+        self.assertEqual(
+            get_docx_variables("{{ fix_punctuation(first_var, second_var) }}"),
+            {"first_var", "second_var"},
+        )
+        self.assertEqual(
+            get_docx_variables("{{ currency(round(raw_amount)) }}"), {"raw_amount"}
+        )
+
+    def test_function_call_arguments_inside_a_loop(self):
+        self.assertEqual(
+            get_docx_variables(
+                "{% for item in mylist %}{{ currency(item.amount) }}{% endfor %}"
+            ),
+            {"mylist", "mylist[0].amount"},
+        )
+
+    def test_inline_conditional_output(self):
+        self.assertEqual(
+            get_docx_variables("{{ a_var if b_var else c_var }}"),
+            {"a_var", "b_var", "c_var"},
+        )
+
+    def test_curly_quoted_arguments_are_not_variables(self):
+        """Word autocorrects quotes, and the text inside them is not a variable."""
+        self.assertEqual(
+            get_docx_variables("{{ format_date(some_date, “MMddyy”) }}"), {"some_date"}
+        )
+
     def test_reserved_docx_labels(self):
         reserved_labels_files = (
             Path(__file__).parent / "test/reserved_docx_variables.docx"


### PR DESCRIPTION
`{{ currency(some_amount) }}` produced **no field at all**. The whole tag was read as one token, and `currency(some_amount)` isn't a valid variable name, so it was dropped silently.

Output tags that don't hold a plain variable now fall through to the expression parser, which finds `some_amount` — along with the arguments of nested calls (`currency(round(raw_amount))` → `raw_amount`) and the operands of an inline conditional (`{{ a if b else c }}`).

Plain `{{ obj.method(arg) }}` tags still go through the existing suffix mapping, so `children[0].formatted_age(...)` continues to resolve to `children[0].birthdate`.

String literals now include curly quotes, since Word autocorrects the ones an author types — without that, `format_date(some_date, "MMddyy")` would have turned `MMddyy` into a field.

Fixes #730

**Stacked on #1002** — review the last commit only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**DOCX parsing stack** — merge in this order, each builds on the last:
#1001 (#503) → #1002 (#258) → #1003 (#730) → #1004 (#621) → #1005 (#745)

All five rewrite the same function (`get_docx_variables`), which is why they're stacked rather than independent.