### PR TITLE
Guess yes/no for DOCX variables tested inside an `if`

### DIFF
--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -153,6 +153,7 @@ __all__ = [
     "get_court_choices",
     "get_docx_validation_errors",
     "get_docx_variables",
+    "get_docx_boolean_variables",
     "get_fields",
     "get_help_document_text",
     "get_question_file_variables",
@@ -639,11 +640,13 @@ class DAField(DAObject):
         self,
         new_field_name: str,
         reserved_pluralizers_map=generator_constants.RESERVED_PLURALIZERS_MAP,
+        used_as_condition: bool = False,
     ):
         """The DAField class expects a few attributes to be filled in.
-        In a future version of this, maybe we can use context to identify
-        true/false variables. For now, we can only use the name.
-        We have a lot less info than for PDF fields.
+        We have a lot less info than for PDF fields, so the name carries most
+        of the guess; `used_as_condition` adds the one piece of context we can
+        read off the template, which is whether it tests the variable for
+        truthiness.
         """
         self.raw_field_names: List[str] = [new_field_name]
         # For docx, we can't change the field name from the document itself, has to be the same
@@ -664,6 +667,9 @@ class DAField(DAObject):
             self.field_type_guess = "currency"
         elif self.variable.endswith(".signature"):
             self.field_type_guess = "signature"
+        elif used_as_condition:
+            # The template only ever asks "is this set?", so it's a yes/no
+            self.field_type_guess = "yesno"
         else:
             self.field_type_guess = "text"
 
@@ -1427,7 +1433,6 @@ class DAFieldList(DAList):
                 self.add_fields_from_file(document)
             return None
 
-        all_fields = get_fields(document)
         if document.filename.lower().endswith("pdf"):
             document_type = "pdf"
         elif document.filename.lower().endswith("docx"):
@@ -1436,6 +1441,16 @@ class DAFieldList(DAList):
             raise Exception(
                 f"{document.filename} doesn't appear to be a PDF or DOCX file. Check the filename extension."
             )
+
+        boolean_fields: Set[str] = set()
+        if document_type == "docx":
+            # Read the template once so the variables and the "used as a
+            # condition" hints come from the same pass over the text
+            docx_text = docx2python(document.path()).text
+            all_fields: Iterable = get_docx_variables(docx_text)
+            boolean_fields = get_docx_boolean_variables(docx_text)
+        else:
+            all_fields = get_fields(document)
 
         if document_type == "pdf":
             # Use pikepdf to get more info about each field
@@ -1496,7 +1511,9 @@ class DAFieldList(DAList):
                     new_field.group = DAFieldGroup.SIGNATURE
                 else:
                     new_field.group = DAFieldGroup.CUSTOM
-                new_field.fill_in_docx_attributes(field)
+                new_field.fill_in_docx_attributes(
+                    field, used_as_condition=field in boolean_fields
+                )
                 if new_field.group in [DAFieldGroup.BUILT_IN, DAFieldGroup.RESERVED]:
                     new_field.label = new_field.variable_name_guess
 
@@ -4109,6 +4126,86 @@ def _raw_variables_from_template(text: str) -> Set[str]:
     return found
 
 
+def get_docx_boolean_variables(text: str) -> Set[str]:
+    """Find the variables a DOCX template tests for truthiness.
+
+    `{%p if applicant_is_veteran %}` only makes sense if the variable is a
+    yes/no answer, so the Weaver can offer a better datatype guess than "text".
+    Only conditions made up entirely of plain variables joined by `and`/`or`
+    and negated with `not` count. Anything with a comparison, a literal, a
+    filter or an `in`/`is` test is left alone, because `{% if count > 2 %}`
+    says nothing about `count` being a boolean.
+
+    Args:
+        text (str): the full text of a DOCX template.
+
+    Returns:
+        Set[str]: the settable variable names used as bare truthiness tests.
+    """
+    booleans: Set[str] = set()
+    loop_scopes: List[Dict[str, Optional[str]]] = []
+    for match in JINJA_ANY_TAG.finditer(text):
+        if match.group(1) is not None:
+            continue
+        statement = JINJA_STATEMENT_PREFIX.sub("", match.group(2).strip())
+        statement = JINJA_STATEMENT_SUFFIX.sub("", statement)
+        for_match = JINJA_FOR_STATEMENT.match(statement)
+        if for_match:
+            loop_scopes.append(
+                _loop_target_replacements(
+                    for_match.group(1), for_match.group(2), loop_scopes
+                )
+            )
+            continue
+        if statement == "endfor":
+            if loop_scopes:
+                loop_scopes.pop()
+            continue
+        conditional_match = JINJA_CONDITIONAL_STATEMENT.match(statement)
+        if not conditional_match:
+            continue
+        condition = conditional_match.group(1)
+        # Strip out the boolean operators and grouping we do allow; whatever is
+        # left has to be nothing but variable chains for the guess to hold.
+        remainder = re.sub(r"\b(?:not|and|or)\b|[()]", " ", condition)
+        chains = JINJA_VARIABLE_CHAIN.findall(remainder)
+        # Anything left over once the chains are removed is an operator, a
+        # literal or a filter, and the guess no longer holds
+        if not chains or re.sub(r"\s+", "", remainder) != "".join(chains):
+            continue
+        # A leftover reserved word means a test or membership check, i.e.
+        # `x is defined` or `x in y`, which says nothing about x being boolean
+        if any(
+            re.split(r"[.\[]", chain, maxsplit=1)[0] in JINJA_NON_VARIABLE_WORDS
+            or keyword.iskeyword(re.split(r"[.\[]", chain, maxsplit=1)[0])
+            for chain in chains
+        ):
+            continue
+        for chain in chains:
+            resolved = _resolve_loop_variable(chain, loop_scopes)
+            if not resolved:
+                continue
+            settable = _settable_docx_variable(resolved)
+            if settable and not _has_known_person_suffix(settable):
+                booleans.add(settable)
+    return booleans
+
+
+def _has_known_person_suffix(
+    variable: str,
+    reserved_suffixes_map=generator_constants.RESERVED_SUFFIXES_MAP,
+) -> bool:
+    """True if the variable ends in an AssemblyLine attribute we already know the type of.
+
+    `{% if users[0].name.first %}` is a template guarding against a missing
+    name, not a sign that `users[0].name.first` is a yes/no answer.
+    """
+    return any(
+        suffix.startswith(".") and variable.endswith(suffix)
+        for suffix in set(reserved_suffixes_map.values())
+    )
+
+
 def get_docx_variables(text: str) -> set:
     """
     Given the string from a docx file with fairly simple
@@ -4126,55 +4223,59 @@ def get_docx_variables(text: str) -> set:
     fields = set()
 
     for possible_var in minimally_filtered:
-        # If no suffix exists, it's just the whole string
-        prefix = re.findall(r"([^.]*)(?:\..+)*", possible_var)
-        if not prefix[0]:
-            continue  # This should never occur as they're all strings
-        prefix_with_key = prefix[0]  # might have brackets
-
-        prefix_root = re.sub(r"\[.+\]", "", prefix_with_key)  # no brackets
-        # Filter out non-identifiers (invalid variable names), like functions
-        if not prefix_root.isidentifier():
-            continue
-
-        if ".mailing_address" in possible_var:  # a mailing address
-            if ".mailing_address.county" in possible_var:  # a county is special
-                fields.add(possible_var)
-            else:  # all other mailing addresses (replaces .zip and such)
-                fields.add(
-                    re.sub(
-                        r"\.mailing_address.*", ".mailing_address.address", possible_var
-                    )
-                )
-            continue
-
-        # Help gathering actual address as an attribute when document says something
-        # like address.block()
-        if ".address" in possible_var:  # an address
-            if ".address.county" in possible_var:  # a county is special
-                fields.add(possible_var)
-            else:  # all other addresses and methods on addresses (replaces .address_block() and .address.block())
-                fields.add(re.sub(r"\.address.*", ".address.address", possible_var))
-            # fields.add( prefix_with_key ) # Can't recall who added or what was this supposed to do?
-            # It will add an extra, erroneous entry of the object root, which usually doesn't
-            # make sense for a docassemble question
-            continue
-
-        if ".name" in possible_var:  # a name
-            if ".name.text" in possible_var:  # Names for non-Individuals
-                fields.add(possible_var)
-            else:  # Names for Individuals
-                fields.add(re.sub(r"\.name.*", ".name.first", possible_var))
-            continue
-
-        # Replace any methods at the end of the variable with the attributes they use
-        possible_var = substitute_suffix(
-            possible_var, generator_constants.DISPLAY_SUFFIX_TO_SETTABLE_SUFFIX
-        )
-        methods_removed = re.sub(r"(.*)\..*\(.*\)", "\\1", possible_var)
-        fields.add(methods_removed)
+        settable_var = _settable_docx_variable(possible_var)
+        if settable_var:
+            fields.add(settable_var)
 
     return fields
+
+
+def _settable_docx_variable(possible_var: str) -> Optional[str]:
+    """Turn one raw template reference into the variable an interview can set.
+
+    Args:
+        possible_var (str): a variable chain as it appears in the template.
+
+    Returns:
+        Optional[str]: the settable variable name, or None if the chain isn't
+        something a question could define.
+    """
+    # If no suffix exists, it's just the whole string
+    prefix = re.findall(r"([^.]*)(?:\..+)*", possible_var)
+    if not prefix[0]:
+        return None  # This should never occur as they're all strings
+    prefix_with_key = prefix[0]  # might have brackets
+
+    prefix_root = re.sub(r"\[.+\]", "", prefix_with_key)  # no brackets
+    # Filter out non-identifiers (invalid variable names), like functions
+    if not prefix_root.isidentifier():
+        return None
+
+    if ".mailing_address" in possible_var:  # a mailing address
+        if ".mailing_address.county" in possible_var:  # a county is special
+            return possible_var
+        # all other mailing addresses (replaces .zip and such)
+        return re.sub(r"\.mailing_address.*", ".mailing_address.address", possible_var)
+
+    # Help gathering actual address as an attribute when document says something
+    # like address.block()
+    if ".address" in possible_var:  # an address
+        if ".address.county" in possible_var:  # a county is special
+            return possible_var
+        # all other addresses and methods on addresses (replaces .address_block() and .address.block())
+        return re.sub(r"\.address.*", ".address.address", possible_var)
+
+    if ".name" in possible_var:  # a name
+        if ".name.text" in possible_var:  # Names for non-Individuals
+            return possible_var
+        # Names for Individuals
+        return re.sub(r"\.name.*", ".name.first", possible_var)
+
+    # Replace any methods at the end of the variable with the attributes they use
+    possible_var = substitute_suffix(
+        possible_var, generator_constants.DISPLAY_SUFFIX_TO_SETTABLE_SUFFIX
+    )
+    return re.sub(r"(.*)\..*\(.*\)", "\\1", possible_var)
 
 
 ########################################################

--- a/docassemble/ALWeaver/test_docx_files.py
+++ b/docassemble/ALWeaver/test_docx_files.py
@@ -3,6 +3,7 @@ import unittest
 from .interview_generator import (
     DAFieldList,
     get_docx_variables,
+    get_docx_boolean_variables,
     is_reserved_docx_label,
     get_pdf_variable_name_matches,
 )
@@ -244,3 +245,58 @@ class test_docxs(unittest.TestCase):
 
         matching_fields = get_pdf_variable_name_matches(pdf_variables_file)
         self.assertEqual(len(matching_fields), 0)
+
+
+class test_docx_boolean_guesses(unittest.TestCase):
+    def test_bare_condition_is_a_boolean(self):
+        self.assertEqual(
+            get_docx_boolean_variables("{%p if applicant_is_veteran %}{% endif %}"),
+            {"applicant_is_veteran"},
+        )
+        self.assertEqual(
+            get_docx_boolean_variables("{%p if not applicant_is_veteran %}{% endif %}"),
+            {"applicant_is_veteran"},
+        )
+
+    def test_boolean_operators_still_count(self):
+        self.assertEqual(
+            get_docx_boolean_variables(
+                "{%p if (a_var or b_var) and not c_var %}{% endif %}"
+                "{%p elif d_var %}{% endif %}"
+            ),
+            {"a_var", "b_var", "c_var", "d_var"},
+        )
+
+    def test_conditions_that_prove_nothing(self):
+        for template in (
+            "{%p if count_var > 2 %}{% endif %}",
+            '{% if i == "final" %}{% endif %}',
+            "{% if x_var is defined %}{% endif %}",
+            "{% if x_var | length %}{% endif %}",
+            "{% if a_var in b_var %}{% endif %}",
+        ):
+            with self.subTest(template=template):
+                self.assertEqual(get_docx_boolean_variables(template), set())
+
+    def test_known_assemblyline_attributes_keep_their_own_type(self):
+        for template in (
+            "{% if users[0].name.first %}{% endif %}",
+            "{% if users[0].address.address %}{% endif %}",
+            "{% if users[0].signature %}{% endif %}",
+        ):
+            with self.subTest(template=template):
+                self.assertEqual(get_docx_boolean_variables(template), set())
+
+    def test_custom_attribute_of_a_person_can_be_a_boolean(self):
+        self.assertEqual(
+            get_docx_boolean_variables("{% if users[0].is_veteran %}{% endif %}"),
+            {"users[0].is_veteran"},
+        )
+
+    def test_conditions_inside_a_loop_use_the_list(self):
+        self.assertEqual(
+            get_docx_boolean_variables(
+                "{% for item in mylist %}{% if item.flag %}{% endif %}{% endfor %}"
+            ),
+            {"mylist[0].flag"},
+        )


### PR DESCRIPTION
A template that only ever says `{%p if applicant_is_veteran %}` is describing a yes/no answer, but the Weaver had nothing but the variable name to go on and guessed "text".

`get_docx_boolean_variables` collects the variables a template tests for truthiness, and `fill_in_docx_attributes` uses it as a fallback guess.

The check is deliberately narrow — only conditions built from plain variables, `not`, `and`, `or` and parentheses count. These prove nothing and are left alone:

| Condition | Why it doesn't count |
|---|---|
| `{% if count > 2 %}` | a comparison, so `count` is a number |
| `{% if x is defined %}` | a test, not a truthiness check |
| `{% if x \| length %}` | a filter |
| `{% if a in b %}` | membership |

AssemblyLine attributes whose type we already know (`.name.first`, `.address.address`, `.signature`) keep their existing guess, and name-based guesses like `_date` still win.

Fixes #621

**Stacked on #1003** — review the last commit only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**DOCX parsing stack** — merge in this order, each builds on the last:
#1001 (#503) → #1002 (#258) → #1003 (#730) → #1004 (#621) → #1005 (#745)

All five rewrite the same function (`get_docx_variables`), which is why they're stacked rather than independent.