### PR TITLE
Pass the measured line width to generated safe_value() calls

### DIFF
--- a/docassemble/ALWeaver/data/templates/output_defs.mako
+++ b/docassemble/ALWeaver/data/templates/output_defs.mako
@@ -154,7 +154,7 @@ confirm: True\
       % endif 
     % else: # all other variable types including text
       % if hasattr(field, "send_to_addendum") and field.send_to_addendum and attachment_name:
-      - "${ raw_name }": <%text>${</%text> ${ attachment_name }.safe_value("${ field.final_display_var }") }
+      - "${ raw_name }": <%text>${</%text> ${ attachment_name }.safe_value("${ field.final_display_var }"${ field.safe_value_kwargs() }) }
       % else:
       - "${ raw_name }": <%text>${</%text> ${ field.final_display_var } }
       % endif

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -146,6 +146,7 @@ __all__ = [
     "generate_interview_from_path",
     "generate_interview_artifacts",
     "get_character_limit",
+    "get_input_dimensions",
     "get_court_choices",
     "get_docx_validation_errors",
     "get_docx_variables",
@@ -241,6 +242,31 @@ def get_character_limit(pdf_field_tuple, char_width=6, row_height=12) -> Optiona
     2: horizontal end
     3: vertical end
     """
+    dimensions = get_input_dimensions(pdf_field_tuple, char_width, row_height)
+    if not dimensions:
+        return None
+    num_rows, num_cols = dimensions
+    return num_rows * num_cols
+
+
+def get_input_dimensions(
+    pdf_field_tuple, char_width=6, row_height=12
+) -> Optional[Tuple[int, int]]:
+    """Estimate a PDF field's size in rows and characters per row.
+
+    The character limit is just the product of the two, but the addendum needs
+    the shape as well: `safe_value()` only preserves line breaks when it knows
+    how wide a line is.
+
+    Args:
+        pdf_field_tuple: a field tuple as returned by `get_pdf_fields`.
+        char_width (int): approximate pixels per character.
+        row_height (int): approximate pixels per row.
+
+    Returns:
+        Optional[Tuple[int, int]]: (rows, characters per row), or None when the
+        field has no usable bounding box.
+    """
     # Make sure it's the right kind of tuple
     if (
         len(pdf_field_tuple) < 4
@@ -254,14 +280,13 @@ def get_character_limit(pdf_field_tuple, char_width=6, row_height=12) -> Optiona
     # 121 = 17-22
     # Average about 6 pixels width per character
     # about 12 pixels high is one row
-
     length = pdf_field_tuple[3][2] - pdf_field_tuple[3][0]
     height = pdf_field_tuple[3][3] - pdf_field_tuple[3][1]
     num_rows = int(height / row_height) if height > 12 else 1
     num_cols = int(length / char_width)
-
-    max_chars = num_rows * num_cols
-    return max_chars
+    if num_rows < 1 or num_cols < 1:
+        return None
+    return num_rows, num_cols
 
 
 def varname(var_name: str) -> str:
@@ -612,7 +637,12 @@ class DAField(DAObject):
 
         variable_name_guess = self.variable.replace("_", " ").capitalize()
         self.has_label = True
-        self.maxlength = get_character_limit(pdf_field_tuple)
+        dimensions = get_input_dimensions(pdf_field_tuple)
+        if dimensions:
+            self.input_rows, self.input_width = dimensions
+            self.maxlength: Optional[int] = self.input_rows * self.input_width
+        else:
+            self.maxlength = None
         self.variable_name_guess = variable_name_guess
 
         self.export_value = pdf_field_tuple[5] if len(pdf_field_tuple) >= 6 else ""
@@ -696,6 +726,21 @@ class DAField(DAObject):
             and bool(self.maxlength)
             and not (hasattr(self, "send_to_addendum") and self.send_to_addendum)
         )
+
+    def safe_value_kwargs(self) -> str:
+        """Extra arguments for the generated `safe_value()` call, as YAML text.
+
+        `safe_value()` measures a multi-line answer in lines rather than
+        characters, and it works out how many lines fit by dividing the
+        overflow trigger by the input width. Left at its default of 80, a field
+        that is 25 characters wide over 3 rows looks like it holds no complete
+        lines at all, so passing the width we measured off the PDF is what makes
+        the split land in the right place.
+        """
+        input_width = getattr(self, "input_width", None)
+        if not input_width:
+            return ""
+        return f", input_width={input_width}"
 
     def _maxlength_str(self) -> str:
         if (

--- a/docassemble/ALWeaver/test_fill_in_field_attributes.py
+++ b/docassemble/ALWeaver/test_fill_in_field_attributes.py
@@ -1,6 +1,11 @@
 # do not pre-load
 import unittest
-from .interview_generator import DAField, varname
+from .interview_generator import (
+    DAField,
+    get_character_limit,
+    get_input_dimensions,
+    varname,
+)
 
 
 class test_fill_in_pdf_attributes(unittest.TestCase):
@@ -104,3 +109,40 @@ class test_varname(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class test_input_dimensions(unittest.TestCase):
+    def test_single_row_field(self):
+        # 90 pixels wide, 20 tall: one row of 15 characters
+        self.assertEqual(
+            get_input_dimensions(("f", "", 0, [10, 10, 100, 30], "/Tx")), (1, 15)
+        )
+
+    def test_multi_row_field(self):
+        # 150 wide, 48 tall: 4 rows of 25 characters
+        self.assertEqual(
+            get_input_dimensions(("f", "", 0, [0, 0, 150, 48], "/Tx")), (4, 25)
+        )
+        self.assertEqual(get_character_limit(("f", "", 0, [0, 0, 150, 48], "/Tx")), 100)
+
+    def test_field_without_a_bounding_box(self):
+        self.assertIsNone(get_input_dimensions(("f", "", 0, None, "/Tx")))
+        self.assertIsNone(get_character_limit(("f", "", 0, None, "/Tx")))
+
+    def test_field_too_small_to_hold_a_character(self):
+        self.assertIsNone(get_input_dimensions(("f", "", 0, [0, 0, 3, 10], "/Tx")))
+
+
+class test_safe_value_kwargs(unittest.TestCase):
+    def test_line_width_comes_from_the_pdf_geometry(self):
+        field = DAField()
+        field.fill_in_pdf_attributes(("story", "", 0, [0, 0, 150, 48], "/Tx"), {})
+        self.assertEqual(field.input_width, 25)
+        self.assertEqual(field.input_rows, 4)
+        self.assertEqual(field.maxlength, 100)
+        self.assertEqual(field.safe_value_kwargs(), ", input_width=25")
+
+    def test_no_kwargs_without_a_measurable_field(self):
+        field = DAField()
+        field.fill_in_pdf_attributes(("story", "", 0, None, "/Tx"), {})
+        self.assertEqual(field.safe_value_kwargs(), "")


### PR DESCRIPTION
`safe_value()` only keeps an answer's line breaks when it can work out how many lines fit, which it does by dividing the overflow trigger by `input_width`. Left at the default of 80, a field measured as 3 rows of 25 characters looks like it holds no complete lines at all:

```python
max_lines = floor(overflow_trigger / input_width)   # floor(75 / 80) == 0
```

So the addendum split ignored the shape of the field entirely.

`get_input_dimensions()` now exposes the rows and characters-per-row that `get_character_limit()` was already computing and throwing away. `fill_in_pdf_attributes` keeps them on the field, and the attachment block emits `input_width=` alongside the field name:

```yaml
- "story": ${ attachment.safe_value("story", input_width=25) }
```

Because `maxlength` is `rows × cols`, the width is always an exact divisor of the overflow trigger, which is what AssemblyLine's docstring asks for.

**This is groundwork.** `input_width` has no effect until `preserve_newlines` is on, which is #718 — and #718 can't land from this repo alone. AssemblyLine's `al_basic_addendum.docx`, `ALAddendumFieldDict.defined_fields()` and `has_overflow()` all call `overflow_value()` with the defaults, so the PDF and the addendum would compute different split points and drop text between them. The exact AssemblyLine change needed is written up in https://github.com/SuffolkLITLab/docassemble-ALWeaver/issues/718#issuecomment-5307443811.

Fixes #717

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Addendum stack** — merge in this order: #1006 (#717) → #1007 (#785)