### PR TITLE
Group PDF checkboxes into one question with `parent+option` names

### DIFF
--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -2782,12 +2782,7 @@ code: |
   interview.state = ""
   for field in interview.all_fields:
     if field.field_type == "multiple choice radio":
-      field.choices = "\n".join(
-        [
-          f"{opt.capitalize().replace('_', ' ')}: {opt}"
-          for opt in field.choice_options
-        ]
-      )
+      field.choices = field.choices_string()
   # Skip some screens we don't need
   ask_people_quantity_question = choose_field_types = show_screen_order = (
     review_fields_to_add_template

--- a/docassemble/ALWeaver/data/templates/output_defs.mako
+++ b/docassemble/ALWeaver/data/templates/output_defs.mako
@@ -129,7 +129,11 @@ edit:
 confirm: True\
 </%def>\
 <%def name="attachment_yaml(field, attachment_name)">\
-% if hasattr(field, "paired_yesno") and field.paired_yesno:
+% if field.is_option_group():
+      % for raw_name in field.raw_field_names:
+      - "${ raw_name }": <%text>${</%text> ${ field.option_fill_expression(raw_name) } }
+      % endfor
+% elif hasattr(field, "paired_yesno") and field.paired_yesno:
       % for raw_name in field.raw_field_names:
         % if remove_multiple_appearance_indicator(varname(raw_name)).endswith("_yes"):
       - "${ raw_name }": <%text>${</%text> ${ field.final_display_var } }

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -169,6 +169,8 @@ __all__ = [
     "to_yaml_file",
     "using_string",
     "varname",
+    "split_option_field_name",
+    "option_label",
     "logic_to_code_block",
     "WeaverGenerationResult",
     "WeaverInterviewArtifacts",
@@ -262,6 +264,50 @@ def get_character_limit(pdf_field_tuple, char_width=6, row_height=12) -> Optiona
 
     max_chars = num_rows * num_cols
     return max_chars
+
+
+# A PDF field named `service_method+by_mail` says "this checkbox is the `by_mail`
+# option of a question called `service_method`". `+` is deliberately not legal in
+# a Python identifier, so it can never be confused with part of a variable name.
+OPTION_SEPARATOR = "+"
+
+# Field types that ask with a list of `choices`
+CHOICE_FIELD_TYPES = [
+    "multiple choice radio",
+    "multiple choice checkboxes",
+    "multiple choice dropdown",
+    "multiple choice combobox",
+    "multiselect",
+]
+# The ones whose answer is a dict of ticked options rather than a single value
+MULTI_ANSWER_FIELD_TYPES = ["multiple choice checkboxes", "multiselect"]
+
+
+def split_option_field_name(raw_field_name: str) -> Optional[Tuple[str, str]]:
+    """Split a `parent+option` PDF field name into its two halves.
+
+    Args:
+        raw_field_name (str): a field name straight out of the PDF.
+
+    Returns:
+        Optional[Tuple[str, str]]: `(parent name, option value)`, or None if
+        this isn't an option field. Both halves have to be usable: a name like
+        `+mail` or `service_method+` is not a grouping, just an odd name.
+    """
+    if OPTION_SEPARATOR not in raw_field_name:
+        return None
+    parent, _, option = raw_field_name.partition(OPTION_SEPARATOR)
+    # Only the first `+` separates; anything after it is part of the option
+    parent_name = remove_multiple_appearance_indicator(varname(parent))
+    option_value = varname(remove_multiple_appearance_indicator(option))
+    if not parent_name or not option_value:
+        return None
+    return parent_name, option_value
+
+
+def option_label(option_value: str) -> str:
+    """A human-readable label for a `parent+option` choice."""
+    return option_value.replace("_", " ").capitalize()
 
 
 def varname(var_name: str) -> str:
@@ -601,10 +647,14 @@ class DAField(DAObject):
             custom_plurals = {}
         # The raw name of the field from the PDF: must go in attachment block
         self.raw_field_names = [pdf_field_tuple[0]]
-        # turns field_name into a valid python identifier: must be one per field
-        self.variable = remove_multiple_appearance_indicator(
-            varname(self.raw_field_names[0])
+        # `parent+option` says this field is one choice of a bigger question, so
+        # the variable is the parent and the part after the `+` is the answer
+        parent_and_option = split_option_field_name(self.raw_field_names[0])
+        name_for_variable = (
+            parent_and_option[0] if parent_and_option else self.raw_field_names[0]
         )
+        # turns field_name into a valid python identifier: must be one per field
+        self.variable = remove_multiple_appearance_indicator(varname(name_for_variable))
         # the variable, in python: i.e., users[1].name.first
         self.final_display_var = map_raw_to_final_display(
             self.variable, custom_people_plurals_map=custom_plurals
@@ -616,6 +666,13 @@ class DAField(DAObject):
         self.variable_name_guess = variable_name_guess
 
         self.export_value = pdf_field_tuple[5] if len(pdf_field_tuple) >= 6 else ""
+        if parent_and_option:
+            option_value = parent_and_option[1]
+            self.option_value = option_value
+            self.option_values = {self.raw_field_names[0]: option_value}
+            self.field_type_guess = "multiple choice radio"
+            self.choice_options = [option_value]
+            return
         if self.variable.endswith("_date"):
             self.field_type_guess = "date"
             self.variable_name_guess = "Date of " + self.variable[:-5].replace("_", " ")
@@ -654,6 +711,37 @@ class DAField(DAObject):
 
         if pdf_field_tuple[4] not in ["/Sig", "/Btn", "/Tx"]:
             self.field_type_unhandled = True
+
+    def is_option_group(self) -> bool:
+        """True if several `parent+option` PDF fields collapsed into this one."""
+        return bool(getattr(self, "option_values", None))
+
+    def choices_string(self) -> str:
+        """The newline-separated `Label: value` list a choice field asks with."""
+        return "\n".join(
+            f"{option_label(option)}: {option}"
+            for option in getattr(self, "choice_options", [])
+        )
+
+    def option_fill_expression(self, raw_field_name: str) -> str:
+        """What to write into one PDF field of a `parent+option` group.
+
+        A single-answer question (radio, dropdown, combobox) stores the chosen
+        option, so each box is ticked by comparing against it. A multi-answer
+        question (checkboxes, multiselect) stores a dict, so each box reads its
+        own key.
+
+        Args:
+            raw_field_name (str): the PDF field name to fill.
+
+        Returns:
+            str: a Python expression for the attachment block.
+        """
+        option = self.option_values[raw_field_name]
+        field_type = getattr(self, "field_type", None) or self.field_type_guess
+        if field_type in MULTI_ANSWER_FIELD_TYPES:
+            return f"{self.final_display_var}[{option!r}]"
+        return f"{self.final_display_var} == {option!r}"
 
     def mark_as_paired_yesno(self, paired_field_names: List[str]):
         """Marks this field as actually representing multiple template fields:
@@ -1133,12 +1221,43 @@ class DAFieldList(DAList):
         self.delitem(*mark_to_remove)
         self.there_are_any = len(self.elements) > 0
 
+    def consolidate_options(self) -> None:
+        """Combine `parent+option` fields into one multiple-choice variable.
+
+        A form that has separate checkboxes for each way of serving papers can
+        name them `service_method+by_mail`, `service_method+in_hand` and so on.
+        Those are three PDF fields but one question, so they collapse into a
+        single `service_method` variable whose choices are the options. Each
+        original field keeps its place in `option_values` so the attachment can
+        tick the right box.
+        """
+        option_map: Dict[str, DAField] = {}
+        mark_to_remove: List[int] = []
+        for idx, field in enumerate(self.elements):
+            if not hasattr(field, "option_value"):
+                continue
+            first_field = option_map.get(field.variable)
+            if first_field is None:
+                option_map[field.variable] = field
+                continue
+            if field.option_value not in first_field.choice_options:
+                first_field.choice_options.append(field.option_value)
+            first_field.option_values.update(field.option_values)
+            first_field.raw_field_names += field.raw_field_names
+            mark_to_remove.append(idx)
+
+        self.delitem(*mark_to_remove)
+        self.there_are_any = len(self.elements) > 0
+
     def consolidate_radios(self) -> None:
         """Combines separate radio buttons into a single variable"""
         radio_map: Dict[str, Any] = defaultdict(list)
         mark_to_remove: List[int] = []
         for idx, field in enumerate(self.elements):
             if field.field_type_guess != "multiple choice radio":
+                continue
+            if hasattr(field, "option_values"):
+                # Already grouped by name; its choices are not PDF export values
                 continue
 
             if len(radio_map[field.variable_name_guess]) > 0:
@@ -1333,6 +1452,7 @@ class DAFieldList(DAList):
                 if new_field.group in [DAFieldGroup.BUILT_IN, DAFieldGroup.RESERVED]:
                     new_field.label = new_field.variable_name_guess
 
+        self.consolidate_options()
         self.consolidate_radios()
         self.consolidate_duplicate_fields(document_type)
         self.consolidate_yesnos()
@@ -1538,6 +1658,9 @@ class DAFieldList(DAList):
                 field.field_type_guess if hasattr(field, "field_type_guess") else "text"
             )
             field.label = field.variable_name_guess
+            # A choice field with no `choices` renders an incomplete question
+            if field.field_type in CHOICE_FIELD_TYPES and not hasattr(field, "choices"):
+                field.choices = field.choices_string()
 
     def builtins(self):
         """Returns "built-in" fields, including ones the user indicated contain
@@ -5890,20 +6013,10 @@ def generate_interview_from_path(
     for field in interview.all_fields:
         if (
             hasattr(field, "field_type")
-            and field.field_type
-            in [
-                "multiple choice radio",
-                "multiple choice checkboxes",
-                "multiple choice dropdown",
-                "multiple choice combobox",
-                "multiselect",
-            ]
+            and field.field_type in CHOICE_FIELD_TYPES
             and not hasattr(field, "choices")
         ):
-            if hasattr(field, "choice_options"):
-                field.choices = "\n".join(field.choice_options)
-            else:
-                field.choices = ""
+            field.choices = field.choices_string()
     if screen_definitions:
         for screen in merged_screens or []:
             for field_entry in screen.get("fields", []) or []:

--- a/docassemble/ALWeaver/test/test_option_groups.pdf
+++ b/docassemble/ALWeaver/test/test_option_groups.pdf
@@ -1,0 +1,56 @@
+%PDF-1.3
+%¿÷¢þ
+1 0 obj
+<< /AcroForm 2 0 R /Pages 3 0 R /Type /Catalog >>
+endobj
+2 0 obj
+<< /DA (/Helv 0 Tf 0 g) /Fields [ 4 0 R 5 0 R 6 0 R 7 0 R 8 0 R 9 0 R ] /NeedAppearances true >>
+endobj
+3 0 obj
+<< /Count 1 /Kids [ 10 0 R ] /Type /Pages >>
+endobj
+4 0 obj
+<< /AP << /N << /Off << >> /On << >> >> >> /AS /Off /DA (/Helv 0 Tf 0 g) /F 4 /FT /Btn /Ff 0 /Rect [ 50 700 65 715 ] /Subtype /Widget /T (service_method+by_mail) /Type /Annot /V /Off >>
+endobj
+5 0 obj
+<< /AP << /N << /Off << >> /On << >> >> >> /AS /Off /DA (/Helv 0 Tf 0 g) /F 4 /FT /Btn /Ff 0 /Rect [ 50 675 65 690 ] /Subtype /Widget /T (service_method+in_hand) /Type /Annot /V /Off >>
+endobj
+6 0 obj
+<< /AP << /N << /Off << >> /On << >> >> >> /AS /Off /DA (/Helv 0 Tf 0 g) /F 4 /FT /Btn /Ff 0 /Rect [ 50 650 65 665 ] /Subtype /Widget /T (service_method+by_email) /Type /Annot /V /Off >>
+endobj
+7 0 obj
+<< /DA (/Helv 0 Tf 0 g) /F 4 /FT /Tx /Ff 0 /Rect [ 50 600 300 620 ] /Subtype /Widget /T (users1_name_first) /Type /Annot >>
+endobj
+8 0 obj
+<< /AP << /N << /Off << >> /On << >> >> >> /AS /Off /DA (/Helv 0 Tf 0 g) /F 4 /FT /Btn /Ff 0 /Rect [ 50 560 65 575 ] /Subtype /Widget /T (relief_sought+rent) /Type /Annot /V /Off >>
+endobj
+9 0 obj
+<< /AP << /N << /Off << >> /On << >> >> >> /AS /Off /DA (/Helv 0 Tf 0 g) /F 4 /FT /Btn /Ff 0 /Rect [ 50 535 65 550 ] /Subtype /Widget /T (relief_sought+utilities) /Type /Annot /V /Off >>
+endobj
+10 0 obj
+<< /Annots [ 4 0 R 5 0 R 6 0 R 7 0 R 8 0 R 9 0 R ] /Contents 11 0 R /MediaBox [ 0 0 612 792 ] /Parent 3 0 R /Resources << >> /Type /Page >>
+endobj
+11 0 obj
+<< /Length 0 /Filter /FlateDecode >>
+stream
+
+endstream
+endobj
+xref
+0 12
+0000000000 65535 f 
+0000000015 00000 n 
+0000000080 00000 n 
+0000000192 00000 n 
+0000000252 00000 n 
+0000000453 00000 n 
+0000000654 00000 n 
+0000000856 00000 n 
+0000000995 00000 n 
+0000001192 00000 n 
+0000001394 00000 n 
+0000001550 00000 n 
+trailer << /Root 1 0 R /Size 12 /ID [<5c678451bb36a18d781e770bbb9a9edf><5c678451bb36a18d781e770bbb9a9edf>] >>
+startxref
+1621
+%%EOF

--- a/docassemble/ALWeaver/test_option_groups.py
+++ b/docassemble/ALWeaver/test_option_groups.py
@@ -1,0 +1,188 @@
+# do not pre-load
+"""Grouping PDF checkboxes into one multiple-choice question.
+
+A form that offers three ways to serve papers usually has three separate
+checkboxes. Naming them `service_method+by_mail`, `service_method+in_hand` and
+`service_method+by_email` tells the Weaver they are one question, so the
+interview asks once and the attachment ticks the right box.
+
+`+` is not legal in a Python identifier, so it can never be mistaken for part
+of a variable name.
+"""
+
+import os
+import unittest
+from pathlib import Path
+
+from .interview_generator import (
+    DAField,
+    DAFieldList,
+    option_label,
+    split_option_field_name,
+)
+from docassemble.base.util import DAStaticFile
+import docassemble.base.functions
+
+
+class MockDAStaticFile(DAStaticFile):
+    def init(self, *pargs, **kwargs):
+        self.full_path = str(kwargs.pop("full_path"))
+        kwargs["filename"] = os.path.basename(self.full_path)
+        kwargs["extension"] = "pdf"
+        kwargs["mimetype"] = "application/pdf"
+        super().init(*pargs, **kwargs)
+
+    def path(self):
+        return self.full_path
+
+
+class TestSplitOptionFieldName(unittest.TestCase):
+    def test_splits_on_the_first_plus(self):
+        self.assertEqual(
+            split_option_field_name("service_method+by_mail"),
+            ("service_method", "by_mail"),
+        )
+
+    def test_later_pluses_belong_to_the_option(self):
+        self.assertEqual(
+            split_option_field_name("relief+rent+and+utilities"),
+            ("relief", "rentandutilities"),
+        )
+
+    def test_ordinary_names_are_not_option_fields(self):
+        self.assertIsNone(split_option_field_name("users1_name_first"))
+        self.assertIsNone(split_option_field_name("docket_number"))
+
+    def test_a_missing_half_is_not_a_grouping(self):
+        self.assertIsNone(split_option_field_name("+by_mail"))
+        self.assertIsNone(split_option_field_name("service_method+"))
+
+    def test_multiple_appearance_indicators_are_stripped(self):
+        self.assertEqual(
+            split_option_field_name("service_method__2+by_mail"),
+            ("service_method", "by_mail"),
+        )
+
+    def test_option_labels_are_readable(self):
+        self.assertEqual(option_label("by_mail"), "By mail")
+
+
+class TestOptionGroupFields(unittest.TestCase):
+    @staticmethod
+    def _fields_from(*raw_field_names):
+        fields = DAFieldList()
+        for raw_field_name in raw_field_names:
+            field = fields.appendObject()
+            field.source_document_type = "pdf"
+            field.fill_in_pdf_attributes(
+                (raw_field_name, "", 0, [0, 0, 100, 20], "/Btn", "On"), {}
+            )
+        fields.consolidate_options()
+        fields.gathered = True
+        return fields
+
+    def test_options_collapse_into_one_field(self):
+        fields = self._fields_from(
+            "service_method+by_mail",
+            "service_method+in_hand",
+            "docket_number",
+        )
+        by_variable = {field.variable: field for field in fields}
+        self.assertEqual(sorted(by_variable), ["docket_number", "service_method"])
+        service_method = by_variable["service_method"]
+        self.assertEqual(service_method.field_type_guess, "multiple choice radio")
+        self.assertEqual(service_method.choice_options, ["by_mail", "in_hand"])
+        self.assertEqual(
+            service_method.raw_field_names,
+            ["service_method+by_mail", "service_method+in_hand"],
+        )
+
+    def test_separate_parents_stay_separate(self):
+        fields = self._fields_from(
+            "service_method+by_mail", "relief_sought+rent", "relief_sought+utilities"
+        )
+        self.assertEqual(
+            sorted(field.variable for field in fields),
+            ["relief_sought", "service_method"],
+        )
+
+    def test_choices_get_readable_labels(self):
+        fields = self._fields_from("service_method+by_mail", "service_method+in_hand")
+        self.assertEqual(
+            fields[0].choices_string(), "By mail: by_mail\nIn hand: in_hand"
+        )
+
+    def test_single_answer_questions_compare_against_the_choice(self):
+        fields = self._fields_from("service_method+by_mail", "service_method+in_hand")
+        field = fields[0]
+        self.assertEqual(
+            field.option_fill_expression("service_method+by_mail"),
+            "service_method == 'by_mail'",
+        )
+
+    def test_multi_answer_questions_read_their_own_key(self):
+        fields = self._fields_from("relief_sought+rent", "relief_sought+utilities")
+        field = fields[0]
+        field.field_type = "multiple choice checkboxes"
+        self.assertEqual(
+            field.option_fill_expression("relief_sought+rent"),
+            "relief_sought['rent']",
+        )
+
+    def test_ordinary_fields_are_not_option_groups(self):
+        fields = self._fields_from("docket_number")
+        self.assertFalse(fields[0].is_option_group())
+
+    def test_parent_name_still_maps_to_assemblyline_variables(self):
+        """Only the half before the `+` is a variable name, so it still maps."""
+        fields = self._fields_from(
+            "user_address_county+suffolk", "user_address_county+norfolk"
+        )
+        self.assertEqual(fields[0].final_display_var, "users[0].address.county")
+        self.assertEqual(
+            fields[0].option_fill_expression("user_address_county+suffolk"),
+            "users[0].address.county == 'suffolk'",
+        )
+
+
+class TestOptionGroupsFromAPdf(unittest.TestCase):
+    def _fields(self):
+        option_pdf = Path(__file__).parent / "test/test_option_groups.pdf"
+        docassemble.base.functions.this_thread.current_question = type("", (), {})
+        docassemble.base.functions.this_thread.current_question.package = "ALWeaver"
+        fields = DAFieldList()
+        fields.add_fields_from_file(MockDAStaticFile(full_path=option_pdf))
+        fields.gathered = True
+        return fields
+
+    def test_grouping_happens_when_reading_the_file(self):
+        by_variable = {field.variable: field for field in self._fields()}
+        self.assertEqual(
+            sorted(by_variable),
+            ["relief_sought", "service_method", "users1_name_first"],
+        )
+        self.assertEqual(
+            by_variable["service_method"].choice_options,
+            ["by_mail", "in_hand", "by_email"],
+        )
+        self.assertFalse(by_variable["users1_name_first"].is_option_group())
+
+    def test_export_values_do_not_become_choices(self):
+        """These are checkboxes, so their `/On` export value is not an answer."""
+        by_variable = {field.variable: field for field in self._fields()}
+        self.assertNotIn("On", by_variable["service_method"].choice_options)
+
+    def test_auto_labelling_fills_in_the_choices(self):
+        fields = self._fields()
+        fields.auto_label_fields()
+        by_variable = {field.variable: field for field in fields}
+        self.assertEqual(
+            by_variable["relief_sought"].choices, "Rent: rent\nUtilities: utilities"
+        )
+        self.assertFalse(hasattr(by_variable["users1_name_first"], "choices"))
+
+
+class TestDAFieldChoicesString(unittest.TestCase):
+    def test_no_choice_options_gives_an_empty_string(self):
+        field = DAField()
+        self.assertEqual(field.choices_string(), "")

--- a/docs/option_groups.md
+++ b/docs/option_groups.md
@@ -1,0 +1,61 @@
+# Grouping PDF checkboxes into one question
+
+Most court forms offer a choice as a row of separate checkboxes: three boxes for
+three ways of serving papers, one box per kind of relief. Each box is its own
+PDF field, so the Weaver used to write a separate yes/no question for each one,
+and the finished interview asked three questions where the form asks one.
+
+Name the fields `parent+option` and the Weaver treats them as a single
+question:
+
+| PDF field name             | Meaning                                       |
+|----------------------------|-----------------------------------------------|
+| `service_method+by_mail`   | the `by_mail` option of `service_method`      |
+| `service_method+in_hand`   | the `in_hand` option of `service_method`      |
+| `service_method+by_email`  | the `by_email` option of `service_method`     |
+
+The Weaver reads those three fields as one variable, `service_method`, with
+three choices:
+
+```yaml
+- "Service method": service_method
+  input type: radio
+  choices:
+    - By mail: by_mail
+    - In hand: in_hand
+    - By email: by_email
+```
+
+and ticks the right box in the attachment:
+
+```yaml
+- "service_method+by_mail": ${ service_method == 'by_mail' }
+- "service_method+in_hand": ${ service_method == 'in_hand' }
+- "service_method+by_email": ${ service_method == 'by_email' }
+```
+
+## Letting the user pick more than one
+
+The guess is a radio button, because most grouped checkboxes on a form are
+mutually exclusive. If more than one can be true, change the field's type to
+**Checkboxes** on the "Choose field types" screen. The attachment switches to
+reading each option out of the answer:
+
+```yaml
+- "relief_sought+rent": ${ relief_sought['rent'] }
+- "relief_sought+utilities": ${ relief_sought['utilities'] }
+```
+
+## Notes
+
+* `+` is not legal in a Python identifier, so it can never be confused with
+  part of a variable name. Only the first `+` separates; anything after it is
+  part of the option.
+* Only the half before the `+` is a variable name, so the usual AssemblyLine
+  labels still work: `user_address_county+suffolk` fills
+  `users[0].address.county`.
+* The option becomes both the stored value and, title-cased with underscores
+  turned into spaces, the label the user sees. `by_mail` shows as "By mail".
+  Edit the choices on the field-types screen if you want different wording.
+* Turn off "normalize field names" when you upload, or FormFyxer may rewrite
+  the names before the Weaver sees them.


### PR DESCRIPTION
Implements the `parent+option` syntax you proposed on #135 and #96.

Court forms offer a choice as a row of separate checkboxes. The Weaver wrote a separate yes/no question for each one — three questions where the form asks one, with nothing stopping the user ticking all three.

Naming the fields `service_method+by_mail`, `service_method+in_hand`, `service_method+by_email` now collapses them into a single variable:

```yaml
- "Service method": service_method
  input type: radio
  choices:
    - By mail: by_mail
    - In hand: in_hand
    - By email: by_email
```

and the attachment ticks the right box:

```yaml
- "service_method+by_mail": ${ service_method == 'by_mail' }
```

Switching the field to **Checkboxes** makes the attachment read each option out of the answer dict instead (`${ relief_sought['rent'] }`), for the cases where more than one can be true.

`+` is deliberately not legal in a Python identifier, so it can never be mistaken for part of a variable name, and only the half before it is treated as one — `user_address_county+suffolk` still maps to `users[0].address.county`.

Your own note on #135 was that a DSL has risks. Two things limit the blast radius: a field name without `+` behaves exactly as before, and `+` can't collide with anything valid.

Also fixes a latent bug: `auto_label_fields` now fills in `choices` for any choice field that lacks them. A generated question with `datatype: checkboxes` and no `choices` is incomplete, which any PDF with real radio buttons could already produce.

Docs in `docs/option_groups.md`.

Fixes #514
Fixes #563

🤖 Generated with [Claude Code](https://claude.com/claude-code)
