### PR TITLE
Warn about PDF drop-downs and other unfillable field types

### DIFF
--- a/docassemble/ALWeaver/data/questions/template_validation.yml
+++ b/docassemble/ALWeaver/data/questions/template_validation.yml
@@ -340,19 +340,21 @@ subquestion: |
   Name (bold if {reserved}) | Type |  Max length
   --------------------------|------|--------------
   % for field in interview.all_fields:
-  ${":exclamation-triangle: " if ' ' in field.variable else ''} ${":exclamation-circle: " if len(remove_multiple_appearance_indicator(varname(field.variable))) == 0 else ''} ${'**' + str(field.variable) + '**' if is_reserved_label(field.variable) or field.variable in possible_custom else field.variable} ${ ':question:' if field.variable in possible_custom else ''} | ${ field.field_type_guess } | ${ field.maxlength if hasattr(field, "maxlength") else 'n/a' }
+  ${":exclamation-triangle: " if ' ' in field.variable else ''} ${":exclamation-circle: " if len(remove_multiple_appearance_indicator(varname(field.variable))) == 0 else ''} ${":skull-crossbones: " if getattr(field, "field_type_not_handled", False) else ''} ${'**' + str(field.variable) + '**' if is_reserved_label(field.variable) or field.variable in possible_custom else field.variable} ${ ':question:' if field.variable in possible_custom else ''} | ${ field.field_type_guess } | ${ field.maxlength if hasattr(field, "maxlength") else 'n/a' }
   % endfor
-  
+
   % if 'space' in warnings:
   :exclamation-triangle: Indicates that the field name has a space in it.
   Replace any spaces with underscores in the PDF field name before continuing.
   % endif
-  
+
   % if 'not handled' in warnings:
-  :skull-crossbones: Indicates it's a field type that our interview generator
-  does not currently handle. 
-  If you can, make the field into a checkbox, text input, 
-  or digital signature field.
+  :skull-crossbones: Indicates a field type that our interview generator
+  does not handle:
+
+  % for reason in get_unhandled_field_type_warnings(interview.all_fields):
+  * ${ reason }
+  % endfor
   % endif
   
   % if len(possible_custom) > 0:

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -155,6 +155,7 @@ __all__ = [
     "get_pdf_validation_errors",
     "get_pdf_variable_name_matches",
     "get_variable_name_warnings",
+    "get_unhandled_field_type_warnings",
     "indent_by",
     "is_reserved_docx_label",
     "is_reserved_label",
@@ -652,8 +653,37 @@ class DAField(DAObject):
         else:
             self.field_type_guess = "text"
 
-        if pdf_field_tuple[4] not in ["/Sig", "/Btn", "/Tx"]:
-            self.field_type_unhandled = True
+        # `/Ch` is a drop-down or list box. Docassemble can't fill one reliably,
+        # so it needs to be called out rather than silently treated as text.
+        self.pdf_field_type = str(pdf_field_tuple[4])
+        if self.pdf_field_type not in ["/Sig", "/Btn", "/Tx"]:
+            self.field_type_not_handled = True
+
+    def mark_type_not_handled(self) -> None:
+        """Flag a field whose PDF type Docassemble can't fill.
+
+        Some PDFs declare a field's type on a parent field rather than on the
+        widget, so the field arrives here looking like plain text. Reading the
+        real type back out of the PDF catches those.
+        """
+        self.field_type_not_handled = True
+
+    def unhandled_type_reason(self) -> Optional[str]:
+        """A short explanation of why this field's PDF type won't work, if it won't."""
+        if not getattr(self, "field_type_not_handled", False):
+            return None
+        if getattr(self, "pdf_field_type", "") == "/Ch":
+            return (
+                f"`{ self.variable }` is a drop-down or list box. Docassemble cannot "
+                "fill those reliably, so it will be treated as a plain text field. "
+                "Change it to a text field, a checkbox, or a group of radio buttons."
+            )
+        return (
+            f"`{ self.variable }` uses a PDF field type "
+            f"(`{ getattr(self, 'pdf_field_type', 'unknown') }`) that the interview "
+            "generator does not handle. Change it to a text field, a checkbox, or a "
+            "digital signature field."
+        )
 
     def mark_as_paired_yesno(self, paired_field_names: List[str]):
         """Marks this field as actually representing multiple template fields:
@@ -1314,6 +1344,16 @@ class DAFieldList(DAList):
                 new_field.fill_in_pdf_attributes(
                     pdf_field_tuple, self.custom_people_plurals
                 )
+                # Some PDFs declare the field type on a parent field, so a
+                # drop-down can reach us looking like plain text. pikepdf sees
+                # the type the PDF actually recorded.
+                if (
+                    pdf_field_name in pike_fields
+                    and hasattr(pike_fields[pdf_field_name], "FT")
+                    and str(pike_fields[pdf_field_name].FT) == "/Ch"
+                ):
+                    new_field.pdf_field_type = "/Ch"
+                    new_field.mark_type_not_handled()
                 if new_field.group == DAFieldGroup.BUILT_IN:
                     new_field.label = new_field.variable_name_guess
         else:
@@ -4051,7 +4091,8 @@ def using_string(params: dict, elements_as_variable_list: bool = False) -> str:
 
 def pdf_field_type_str(field) -> str:
     """Gets a human readable string from a PDF field code, like '/Btn'"""
-    if not isinstance(field, tuple) or len(field) < 4 or not isinstance(field[4], str):
+    # The type lives at index 4, so a shorter tuple has nothing to report
+    if not isinstance(field, tuple) or len(field) < 5 or not isinstance(field[4], str):
         return ""
     else:
         if field[4] == "/Sig":
@@ -4060,6 +4101,8 @@ def pdf_field_type_str(field) -> str:
             return "Checkbox"
         elif field[4] == "/Tx":
             return "Text"
+        elif field[4] == "/Ch":
+            return "Drop-down or list box :skull-crossbones:"
         else:
             return ":skull-crossbones:"
 
@@ -4190,6 +4233,26 @@ def get_variable_name_warnings(fields: Iterable[DAField]) -> Iterable[str]:
     return [
         reason
         for reason in (bad_name_reason(field) for field in fields)
+        if reason is not None
+    ]
+
+
+def get_unhandled_field_type_warnings(fields: Iterable[DAField]) -> List[str]:
+    """Explain any fields whose PDF input type Docassemble can't fill.
+
+    Drop-downs and list boxes are the common case: they look like ordinary text
+    fields once the interview runs, so without a warning the author only finds
+    out when the finished PDF comes back blank.
+
+    Args:
+        fields (Iterable[DAField]): the fields read from the uploaded templates.
+
+    Returns:
+        List[str]: one sentence per problem field.
+    """
+    return [
+        reason
+        for reason in (field.unhandled_type_reason() for field in fields)
         if reason is not None
     ]
 

--- a/docassemble/ALWeaver/test/test_dropdown_fields.pdf
+++ b/docassemble/ALWeaver/test/test_dropdown_fields.pdf
@@ -1,0 +1,44 @@
+%PDF-1.3
+%¿÷¢þ
+1 0 obj
+<< /AcroForm 2 0 R /Pages 3 0 R /Type /Catalog >>
+endobj
+2 0 obj
+<< /DA (/Helv 0 Tf 0 g) /Fields [ 4 0 R 5 0 R 6 0 R ] /NeedAppearances true >>
+endobj
+3 0 obj
+<< /Count 1 /Kids [ 7 0 R ] /Type /Pages >>
+endobj
+4 0 obj
+<< /DA (/Helv 0 Tf 0 g) /F 4 /FT /Tx /Ff 0 /Rect [ 50 700 300 720 ] /Subtype /Widget /T (plain_text) /Type /Annot /V () >>
+endobj
+5 0 obj
+<< /DA (/Helv 0 Tf 0 g) /F 4 /FT /Ch /Ff 131072 /Opt [ (Red) (Green) (Blue) ] /Rect [ 50 650 300 670 ] /Subtype /Widget /T (favorite_color) /Type /Annot /V () >>
+endobj
+6 0 obj
+<< /DA (/Helv 0 Tf 0 g) /F 4 /FT /Ch /Ff 0 /Opt [ (A) (B) ] /Rect [ 50 600 300 640 ] /Subtype /Widget /T (pick_one) /Type /Annot /V () >>
+endobj
+7 0 obj
+<< /Annots [ 4 0 R 5 0 R 6 0 R ] /Contents 8 0 R /MediaBox [ 0 0 612 792 ] /Parent 3 0 R /Resources << >> /Type /Page >>
+endobj
+8 0 obj
+<< /Length 0 /Filter /FlateDecode >>
+stream
+
+endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000015 00000 n 
+0000000080 00000 n 
+0000000174 00000 n 
+0000000233 00000 n 
+0000000371 00000 n 
+0000000548 00000 n 
+0000000701 00000 n 
+0000000837 00000 n 
+trailer << /Root 1 0 R /Size 9 /ID [<a188e0e6566d4b8ce451f26ba9623492><a188e0e6566d4b8ce451f26ba9623492>] >>
+startxref
+907
+%%EOF

--- a/docassemble/ALWeaver/test_pdf_files.py
+++ b/docassemble/ALWeaver/test_pdf_files.py
@@ -4,6 +4,8 @@ from .interview_generator import (
     DAFieldList,
     get_variable_name_warnings,
     get_pdf_validation_errors,
+    get_unhandled_field_type_warnings,
+    pdf_field_type_str,
 )
 from docassemble.base.util import DAStaticFile
 import docassemble.base.functions
@@ -92,3 +94,73 @@ class test_pdfs(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class test_unhandled_pdf_field_types(unittest.TestCase):
+    """Drop-downs and list boxes have to be called out, not silently accepted.
+
+    Docassemble cannot fill a PDF `/Ch` field reliably, and the finished form
+    just comes back blank, so the author needs to hear about it while they can
+    still change the PDF.
+    """
+
+    def _fields(self):
+        dropdown_pdf = Path(__file__).parent / "test/test_dropdown_fields.pdf"
+        docassemble.base.functions.this_thread.current_question = type("", (), {})
+        docassemble.base.functions.this_thread.current_question.package = "ALWeaver"
+        fields = DAFieldList()
+        fields.add_fields_from_file(
+            MockDAStaticFile(
+                full_path=str(dropdown_pdf),
+                extension="pdf",
+                mimetype="application/pdf",
+            )
+        )
+        fields.gathered = True
+        return fields
+
+    def test_choice_fields_are_flagged(self):
+        by_variable = {field.variable: field for field in self._fields()}
+        self.assertTrue(by_variable["favorite_color"].field_type_not_handled)
+        self.assertTrue(by_variable["pick_one"].field_type_not_handled)
+
+    def test_text_fields_are_not_flagged(self):
+        by_variable = {field.variable: field for field in self._fields()}
+        self.assertFalse(
+            getattr(by_variable["plain_text"], "field_type_not_handled", False)
+        )
+
+    def test_warnings_name_the_field_and_the_problem(self):
+        warnings = get_unhandled_field_type_warnings(self._fields())
+        self.assertEqual(len(warnings), 2)
+        self.assertTrue(any("favorite_color" in warning for warning in warnings))
+        self.assertTrue(all("drop-down" in warning for warning in warnings))
+
+    def test_no_warnings_for_an_ordinary_form(self):
+        push_button_pdf = Path(__file__).parent / "test/test_push_button.pdf"
+        docassemble.base.functions.this_thread.current_question = type("", (), {})
+        docassemble.base.functions.this_thread.current_question.package = "ALWeaver"
+        fields = DAFieldList()
+        fields.add_fields_from_file(
+            MockDAStaticFile(
+                full_path=str(push_button_pdf),
+                extension="pdf",
+                mimetype="application/pdf",
+            )
+        )
+        fields.gathered = True
+        self.assertEqual(get_unhandled_field_type_warnings(fields), [])
+
+
+class test_pdf_field_type_str(unittest.TestCase):
+    def test_known_types(self):
+        self.assertEqual(pdf_field_type_str(("f", "", 0, [], "/Tx")), "Text")
+        self.assertEqual(pdf_field_type_str(("f", "", 0, [], "/Btn")), "Checkbox")
+        self.assertEqual(pdf_field_type_str(("f", "", 0, [], "/Sig")), "Signature")
+
+    def test_choice_type_is_called_out(self):
+        self.assertIn("Drop-down", pdf_field_type_str(("f", "", 0, [], "/Ch")))
+
+    def test_short_tuple_does_not_raise(self):
+        """The type lives at index 4, so a 4-item tuple used to IndexError."""
+        self.assertEqual(pdf_field_type_str(("f", "", 0, [])), "")


### PR DESCRIPTION
The warning for field types the generator can't handle **never appeared**. `fill_in_pdf_attributes` set `field_type_unhandled`, but the screen that shows the warning reads `field_type_not_handled`:

```python
# interview_generator.py
self.field_type_unhandled = True
```
```yaml
# template_validation.yml
if hasattr(field, "field_type_not_handled") and field.field_type_not_handled:
```

So the check was always false, and the `:skull-crossbones:` legend explained a marker the table never emitted.

This standardises on `field_type_not_handled`, puts the marker on the offending row, and replaces the generic legend with a sentence per field saying what's wrong and what to change it to. Drop-downs and list boxes get their own message, since they're the common case and the finished PDF just comes back blank.

The real PDF field type is also read back through pikepdf, which `add_fields_from_file` already opens, so a `/Ch` field is still flagged if it reaches us looking like plain text — which is the symptom the issue reports.

Also fixes an off-by-one in `pdf_field_type_str`, which indexed `field[4]` after only checking `len(field) < 4`.

Verified against a running docassemble: the heading flips to "Correct warnings in field labels", both `/Ch` rows get the marker, the per-field explanations render, and the previously-dead "Will you fix the shown warnings yourself?" field now appears.

Fixes #639

🤖 Generated with [Claude Code](https://claude.com/claude-code)
