### PR TITLE
Guard interview order lines that reach past the first list item

### DIFF
--- a/docassemble/ALWeaver/data/templates/output.mako
+++ b/docassemble/ALWeaver/data/templates/output.mako
@@ -260,7 +260,7 @@ code: |
   user_ask_role = "${ interview.typical_role }"
   % endif
   % for line in interview_order_lines:
-  ${ line }
+${ indent_by(line, 2) }\
   % endfor
   % if not generate_download_screen:
   saved_report_data

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -33,6 +33,7 @@ from pdfminer.psparser import PSEOF
 from pikepdf import Pdf
 from typing import (
     Any,
+    Container,
     Dict,
     List,
     NotRequired,
@@ -961,6 +962,35 @@ class DAField(DAObject):
         return f"{self.variable} ({self.raw_field_names}, {self.final_display_var})"
 
 
+INDEXED_LIST_REFERENCE = re.compile(r"^([A-Za-z_]\w*)\[(\d+)\]")
+
+
+def _guard_indexed_reference(line: str, known_lists: Container[str]) -> str:
+    """Wrap an interview order line that reaches past the first list item.
+
+    A form with a `users1_email` field wants a second user's email, but the
+    interview shouldn't force someone to add a second user just to get through
+    the order block. `users[1].email` becomes::
+
+        if users.number() > 1:
+          users[1].email
+
+    Args:
+        line (str): one line of the interview order block.
+        known_lists (Container[str]): names the interview gathers as lists.
+
+    Returns:
+        str: the line, guarded if it needed guarding.
+    """
+    match = INDEXED_LIST_REFERENCE.match(line)
+    if not match:
+        return line
+    list_name, index = match.group(1), int(match.group(2))
+    if index < 1 or list_name not in known_lists:
+        return line
+    return f"if {list_name}.number() > {index}:\n  {line}"
+
+
 def _with_progress_markers(entries: List[Tuple[str, bool]]) -> List[str]:
     """Interleave ``set_progress()`` calls through an interview order block.
 
@@ -1799,6 +1829,14 @@ class DAQuestionList(DAList):
             unique_entries.append((line, is_screen))
         while unique_entries and unique_entries[-1][0].startswith('nav.set_section("'):
             unique_entries.pop()
+
+        known_lists = set(generator_constants.RESERVED_PLURALIZERS_MAP.values()) | set(
+            all_fields.custom_people_plurals.values()
+        )
+        unique_entries = [
+            (_guard_indexed_reference(line, known_lists), is_screen)
+            for line, is_screen in unique_entries
+        ]
 
         if not set_progress:
             return [line for line, _ in unique_entries]

--- a/docassemble/ALWeaver/test_generate_from_path.py
+++ b/docassemble/ALWeaver/test_generate_from_path.py
@@ -16,6 +16,7 @@ from .interview_generator import (
     generate_interview_artifacts,
     _ensure_unique_question_ids,
     _with_progress_markers,
+    _guard_indexed_reference,
 )
 
 
@@ -146,8 +147,9 @@ question: |
             self.assertIn("docket_number", yaml_text)
             # This specific DOCX template includes a reference to users[1].email.
             # Ensure it shows up in the interview order so the generated interview
-            # actually collects it.
-            self.assertIn("users[1].email", yaml_text)
+            # actually collects it, guarded so a lone user isn't forced to add a
+            # second one just to get past the order block.
+            self.assertIn("if users.number() > 1:\n    users[1].email", yaml_text)
             # Deterministic generation guards.
             self.assertIn("id: edit users", yaml_text)
             self.assertIn("docassemble.MassAccess:massaccess.yml", yaml_text)
@@ -519,3 +521,29 @@ question: |
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestGuardIndexedReference(unittest.TestCase):
+    KNOWN_LISTS = {"users", "other_parties"}
+
+    def test_second_item_gets_a_guard(self):
+        self.assertEqual(
+            _guard_indexed_reference("users[1].email", self.KNOWN_LISTS),
+            "if users.number() > 1:\n  users[1].email",
+        )
+        self.assertEqual(
+            _guard_indexed_reference("users[2].address.address", self.KNOWN_LISTS),
+            "if users.number() > 2:\n  users[2].address.address",
+        )
+
+    def test_first_item_is_left_alone(self):
+        for line in ("users[0].email", "users.gather()", "docket_number"):
+            with self.subTest(line=line):
+                self.assertEqual(_guard_indexed_reference(line, self.KNOWN_LISTS), line)
+
+    def test_unknown_lists_are_left_alone(self):
+        """We can only call `.number()` on something we know is a list."""
+        self.assertEqual(
+            _guard_indexed_reference("previous_names[1].first", self.KNOWN_LISTS),
+            "previous_names[1].first",
+        )


### PR DESCRIPTION
A form with a `users1_email` field produces `users[1].email` in the interview order block. With only one user, that line forces a second one to be added before the interview can continue.

Lines starting with a known list and an index of 1 or more are now wrapped:

```python
if users.number() > 1:
  users[1].email
```

`.number()` triggers the gather itself, so this is safe even when nothing else has gathered the list yet.

The order block template indents through `indent_by` so the guarded line lands inside the block rather than at column 0.

Fixes #744

🤖 Generated with [Claude Code](https://claude.com/claude-code)
