### PR TITLE
Copy AssemblyLine person questions into generated interview

### DIFF
--- a/docassemble/ALWeaver/api_editor.py
+++ b/docassemble/ALWeaver/api_editor.py
@@ -7002,6 +7002,9 @@ def _new_project_from_uploads(
         request.form.get("include_next_steps"), default=True
     )
     enable_navigation = parse_bool(request.form.get("enable_navigation"), default=True)
+    copy_baseline_questions = parse_bool(
+        request.form.get("copy_baseline_questions"), default=True
+    )
     # Off by default: renaming rewrites the template that ships in the project,
     # so the author asks for it rather than discovering it happened.
     normalize_field_names = parse_bool(
@@ -7072,6 +7075,7 @@ def _new_project_from_uploads(
             # be turned on later without reconstructing bundle/attachment YAML.
             "include_next_steps": output_type == "form",
             "include_download_screen": output_type == "form",
+            "copy_baseline_questions": copy_baseline_questions,
             "exact_name": uploaded_payloads[0]["filename"],
             "use_llm_assist": use_llm_assist,
             "interview_overrides": interview_overrides,

--- a/docassemble/ALWeaver/api_utils.py
+++ b/docassemble/ALWeaver/api_utils.py
@@ -100,6 +100,7 @@ def coerce_generation_options(raw_options: Mapping[str, Any]) -> Dict[str, Any]:
         "create_package_zip",
         "include_next_steps",
         "include_download_screen",
+        "copy_baseline_questions",
         "use_llm_assist",
         "normalize_field_names",
     ):
@@ -318,6 +319,16 @@ def build_openapi_spec() -> Dict[str, Any]:
                                         "create_package_zip": {"type": "boolean"},
                                         "include_next_steps": {"type": "boolean"},
                                         "include_download_screen": {"type": "boolean"},
+                                        "copy_baseline_questions": {
+                                            "type": "boolean",
+                                            "description": (
+                                                "Copy AssemblyLine's questions about people into "
+                                                "the generated interview, specialized for the "
+                                                "objects it declares, instead of relying on the "
+                                                "generic object questions in ql_baseline.yml. "
+                                                "Defaults to true."
+                                            ),
+                                        },
                                         "use_llm_assist": {"type": "boolean"},
                                         "normalize_field_names": {
                                             "type": "boolean",
@@ -367,6 +378,16 @@ def build_openapi_spec() -> Dict[str, Any]:
                                         "create_package_zip": {"type": "boolean"},
                                         "include_next_steps": {"type": "boolean"},
                                         "include_download_screen": {"type": "boolean"},
+                                        "copy_baseline_questions": {
+                                            "type": "boolean",
+                                            "description": (
+                                                "Copy AssemblyLine's questions about people into "
+                                                "the generated interview, specialized for the "
+                                                "objects it declares, instead of relying on the "
+                                                "generic object questions in ql_baseline.yml. "
+                                                "Defaults to true."
+                                            ),
+                                        },
                                         "use_llm_assist": {"type": "boolean"},
                                         "normalize_field_names": {
                                             "type": "boolean",
@@ -487,6 +508,7 @@ def build_docs_html() -> str:
   -F "use_llm_assist=true" \\
   -F "help_page_url=https://example.com/reference" \\
   -F "include_next_steps=false" \\
+  -F "copy_baseline_questions=true" \\
   -F "create_package_zip=true" \\
   {WEAVER_API_BASE_PATH}</pre>
   <h2>Optional async mode</h2>
@@ -506,6 +528,7 @@ def build_docs_html() -> str:
   "use_llm_assist": true,
   "help_page_url": "https://example.com/reference",
   "include_next_steps": false,
+  "copy_baseline_questions": true,
   "create_package_zip": true,
   "mode": "sync"
 }}</pre>

--- a/docassemble/ALWeaver/data/questions/assembly_line.yml
+++ b/docassemble/ALWeaver/data/questions/assembly_line.yml
@@ -1514,9 +1514,25 @@ subquestion: |
   ${ collapse_template(why_count_people_template) }
 fields:
   - code: people_quantity_question
+  - Copy the AssemblyLine questions about people into my interview?: interview.copy_baseline_questions
+    datatype: yesno
+    default: True
+    help: |
+      ${ copy_baseline_questions_help }
 continue button field: ask_people_quantity_question
 ---
-template: why_count_people_template 
+template: copy_baseline_questions_help
+content: |
+  AssemblyLine asks about names, addresses, and contact information with
+  "generic object" questions that work for any list of people. They are
+  hard to copy and edit, because you have to rewrite every `x` into the name
+  of your own object.
+
+  Leave this checked and the Weaver writes those questions into your interview
+  file for you, already pointing at your own objects. They work exactly the same
+  way until you edit them, and you can delete any you don't want to change.
+---
+template: why_count_people_template
 subject: |
   Why do you need to know?
 content: |
@@ -2629,6 +2645,9 @@ code: |
   interview.original_form = "NA"
   interview.typical_role = "anonymous"
   interview_label_draft = interview.short_title.lower()
+  if not defined("interview.copy_baseline_questions"):
+    # Survey interviews can skip the screen that offers this.
+    interview.copy_baseline_questions = True
 
   no_template_default_values = True
 ---
@@ -2802,6 +2821,9 @@ code: |
   interview.customize_next_steps = (
     True  # Populate next steps with LLM drafts, but don't show preview screens
   )
+  # Auto-drafting skips the screen that offers this, and a draft that copies in
+  # the AssemblyLine questions about people is the more useful starting point.
+  interview.copy_baseline_questions = True
   interview.enable_navigation = True
   interview.has_other_categories = False
   interview_sections_defaults_loaded = True

--- a/docassemble/ALWeaver/data/questions/review_screen.yml
+++ b/docassemble/ALWeaver/data/questions/review_screen.yml
@@ -286,6 +286,11 @@ review:
       % for item in people_quantities:
       - ${ item }: ${ people_quantities[item]  }
       % endfor
+  - Edit: interview.copy_baseline_questions
+    button: |
+      **Copy the AssemblyLine questions about people into the interview**
+
+      ${ word(yesno(interview.copy_baseline_questions)) }
   - raw html: |
       ${ next_accordion("Next steps instructions") }
     show if: |

--- a/docassemble/ALWeaver/data/static/editor.js
+++ b/docassemble/ALWeaver/data/static/editor.js
@@ -7558,6 +7558,7 @@
     html += '<div class="col-md-6"><label class="editor-tiny" for="new-project-user-role">Typical user role</label><select class="form-select form-select-sm mt-1" id="new-project-user-role"><option value="auto">Let Weaver decide</option><option value="plaintiff">Starts the case/request</option><option value="defendant">Responds to it</option><option value="unknown">Ask the user</option></select></div></div>';
     html += '<div class="form-check form-switch m-0"><input class="form-check-input" type="checkbox" id="new-project-include-next-steps" checked><label class="form-check-label editor-tiny" for="new-project-include-next-steps">Include a next steps document</label><div class="text-muted small mt-1">The generated DOCX is a reusable shell. Later settings changes do not overwrite custom Word edits.</div></div>';
     html += '<div class="form-check form-switch m-0"><input class="form-check-input" type="checkbox" id="new-project-enable-navigation" checked><label class="form-check-label editor-tiny" for="new-project-enable-navigation">Enable left navigation</label></div>';
+    html += '<div class="form-check form-switch m-0"><input class="form-check-input" type="checkbox" id="new-project-copy-baseline-questions" checked><label class="form-check-label editor-tiny" for="new-project-copy-baseline-questions">Copy the AssemblyLine questions about people</label><div class="text-muted small mt-1">Writes editable copies of the name, address, and contact questions into your interview instead of leaving them in AssemblyLine\'s generic object blocks.</div></div>';
     html += '<div><label class="editor-tiny" for="new-project-help-page-url">Reference page URL (optional)</label>';
     html += '<input class="form-control form-control-sm mt-1" id="new-project-help-page-url" type="url" placeholder="https://example.com/help"></div>';
     html += '<div><label class="editor-tiny" for="new-project-help-page-title">Reference page title (optional)</label>';
@@ -9467,6 +9468,7 @@
       var userRoleInput = document.getElementById('new-project-user-role');
       var includeNextStepsInput = document.getElementById('new-project-include-next-steps');
       var enableNavigationInput = document.getElementById('new-project-enable-navigation');
+      var copyBaselineQuestionsInput = document.getElementById('new-project-copy-baseline-questions');
       var githubUrlInput = document.getElementById('new-project-github-url');
       var projectName = nameInput ? nameInput.value : 'NewProject';
       var notes = notesInput ? notesInput.value : '';
@@ -9479,6 +9481,7 @@
       var userRole = userRoleInput ? userRoleInput.value : 'auto';
       var includeNextSteps = includeNextStepsInput ? includeNextStepsInput.checked : true;
       var enableNavigation = enableNavigationInput ? enableNavigationInput.checked : true;
+      var copyBaselineQuestions = copyBaselineQuestionsInput ? copyBaselineQuestionsInput.checked : true;
       var githubUrl = githubUrlInput ? githubUrlInput.value.trim() : '';
       if (githubUrl && _uploadedFiles.length > 0) {
         window.alert('Choose either a GitHub repository or uploaded documents, not both.');
@@ -9500,6 +9503,7 @@
         formData.append('typical_role', userRole);
         formData.append('include_next_steps', includeNextSteps ? 'true' : 'false');
         formData.append('enable_navigation', enableNavigation ? 'true' : 'false');
+        formData.append('copy_baseline_questions', copyBaselineQuestions ? 'true' : 'false');
         _uploadedFiles.forEach(function (f) { formData.append('files', f, f.name); });
         apiUploadDetailed('/api/new-project', formData)
           .then(function (response) {

--- a/docassemble/ALWeaver/data/templates/output.mako
+++ b/docassemble/ALWeaver/data/templates/output.mako
@@ -360,6 +360,23 @@ continue button field: ${ varname(question.question_text) }
 <%doc>
     End question loop
 </%doc>\
+<%doc>
+    Editable copies of the AssemblyLine questions about the people in this
+    interview. `question_library.mako` holds the wording; `question_library.py`
+    decides which blocks belong here. The list is empty when the author turned
+    off "Copy the AssemblyLine questions about people into my interview".
+</%doc>\
+% if baseline_questions:
+---
+comment: |
+  The questions below are copies of the questions in AssemblyLine's
+  ql_baseline.yml, rewritten to name this interview's own objects instead of the
+  generic `x`. Edit them freely: they replace the AssemblyLine versions. Delete
+  one to go back to the AssemblyLine wording.
+% for baseline_question in baseline_questions:
+${ baseline_question_yaml(baseline_question) }\
+% endfor
+% endif
 % if generate_download_screen and signature_field_triggers:
 ---
 id: preview ${ interview.interview_label }

--- a/docassemble/ALWeaver/data/templates/question_library.mako
+++ b/docassemble/ALWeaver/data/templates/question_library.mako
@@ -1,0 +1,393 @@
+<%doc>
+
+    Copies of AssemblyLine's baseline questions, specialized for one object.
+
+    Most of the questions in docassemble.AssemblyLine's `ql_baseline.yml` are
+    `generic object:` questions: a single block that serves `users`, `children`,
+    `witnesses` and every other list of people. That is why you cannot copy one out
+    of `ql_baseline.yml` and edit it -- you would first have to delete the
+    `generic object:` line and rewrite every `x` into the name of your own object.
+
+    When the author leaves "Copy the AssemblyLine questions about people into my
+    interview" turned on, the Weaver writes these blocks into the generated YAML
+    instead, already pointed at the objects the interview declares. They behave like
+    the AssemblyLine originals until somebody edits them, and because they live in
+    the generated file they take precedence over the AssemblyLine versions.
+
+    Which blocks get written is decided in `question_library.py`; the wording lives
+    here. Keep this file in sync with `ql_baseline.yml` when the baseline questions
+    change -- each def below names the `ql_baseline.yml` block it came from.
+
+    Writing questions in here: `${ ... }` and a leading `%` belong to *this*
+    template and are resolved while the interview is generated. To put a Mako
+    expression into the generated interview, write `<%text>${</%text> ... }`, and
+    for a Mako control line write `<%text>%</%text> if ...`.
+
+</%doc>\
+<%def name="baseline_question_yaml(entry)">\
+<%
+    kind = entry["kind"]
+    var = entry["var"]
+    singular = entry["singular"]
+    plural = entry["plural"]
+    # Person questions are asked once per list item, so they are written against
+    # `users[i]` rather than `users`. A standalone ALIndividual has no index.
+    item = "%s[i]" % var if entry["is_list"] else var
+%>\
+% if kind == "there_are_any":
+${ baseline_there_are_any(var, plural) }\
+% elif kind == "how_many":
+${ baseline_how_many(var, plural) }\
+% elif kind == "names":
+${ baseline_names(var, singular, plural) }\
+% elif kind == "there_is_another":
+${ baseline_there_is_another(var, singular) }\
+% elif kind == "name":
+${ baseline_name(var) }\
+% elif kind == "address":
+${ baseline_address(var, item, singular) }\
+% elif kind == "mailing_address":
+${ baseline_mailing_address(item, singular) }\
+% elif kind == "birthdate":
+${ baseline_birthdate(item, singular) }\
+% elif kind == "gender":
+${ baseline_gender(item, singular) }\
+% elif kind == "pronouns":
+${ baseline_pronouns(var, item, singular) }\
+% elif kind == "language":
+${ baseline_language(var, item, singular) }\
+% elif kind == "phone_number":
+${ baseline_phone(item, singular, "phone_number", "phone number", "Phone") }\
+% elif kind == "mobile_number":
+${ baseline_phone(item, singular, "mobile_number", "mobile number", "Mobile number") }\
+% elif kind == "email":
+${ baseline_email(item, singular) }\
+% endif
+</%def>\
+<%doc>
+    From `ql_baseline.yml`, id: who will be on this form -- except for
+    `other_parties`, which AssemblyLine asks about in
+    id: is there an opposing party?
+</%doc>\
+<%def name="baseline_there_are_any(var, plural)">\
+---
+id: ${ fix_id("any " + plural) }
+question: |
+% if var == "other_parties":
+  <%text>%</%text> if al_form_type in ['starts_case', 'existing_case', 'appeal'] and user_started_case:
+  Is there a **defendant** or respondent in this case?
+  <%text>%</%text> elif al_form_type in ['starts_case', 'existing_case', 'appeal']:
+  Is there a **plaintiff** or petitioner in this case?
+  <%text>%</%text> else:
+  Is there someone on the other side of your dispute?
+  <%text>%</%text> endif
+subquestion: |
+  <%text>%</%text> if al_form_type in ['starts_case', 'existing_case', 'appeal'] and user_started_case:
+  Answer yes if there is a person or organization you are suing or taking to court.
+  <%text>%</%text> elif al_form_type in ['starts_case', 'existing_case', 'appeal']:
+  You should be able to find out from the paperwork that told you to go to court.
+
+  Answer yes if someone else has sued you or is bringing you to court.
+  <%text>%</%text> endif
+% else:
+  Will this form include any ${ plural }?
+% endif
+fields:
+  - no label: ${ var }.there_are_any
+    datatype: yesnoradio
+</%def>\
+<%doc>
+    From `ql_baseline.yml`, id: how many witnesses
+</%doc>\
+<%def name="baseline_how_many(var, plural)">\
+---
+id: ${ fix_id("how many " + plural) }
+question: |
+  Are there any ${ plural }?
+fields:
+  - "Any ${ plural }?": ${ var }.there_are_any
+    datatype: yesnoradio
+  - "How many <span class='visually-hidden'>${ plural }</span>?": ${ var }.target_number
+    datatype: integer
+    show if: ${ var }.there_are_any
+validation code: |
+  if not ${ var }.there_are_any:
+    ${ var }.target_number = 0
+</%def>\
+<%doc>
+    From `ql_baseline.yml`, id: names of people -- except for `users` and
+    `other_parties`, which AssemblyLine asks about in id: other users names and
+    id: names of opposing parties
+</%doc>\
+<%def name="baseline_names(var, singular, plural)">\
+---
+id: ${ fix_id(plural + " names") }
+sets:
+  - ${ var }[i].name.first
+  - ${ var }[i].name.last
+  - ${ var }[i].name.middle
+  - ${ var }[i].name.suffix
+question: |
+% if var == "users":
+  <%text>%</%text> if i == 0 and al_person_answering == "user":
+  What is your name?
+  <%text>%</%text> elif al_form_type in ['starts_case', 'existing_case', 'appeal']:
+  Who is the <%text>${ ordinal(i) }</%text> person on your side of the case?
+  <%text>%</%text> else:
+  What is the name of the <%text>${ ordinal(i) }</%text> person who is adding their
+  name to this form with you?
+  <%text>%</%text> endif
+% elif var == "other_parties":
+  <%text>%</%text> if user_started_case:
+  Name of <%text>${ ordinal(i) }</%text> **defendant** or respondent in this matter
+  <%text>%</%text> else:
+  Name of <%text>${ ordinal(i) }</%text> **plaintiff** or petitioner in this matter
+  <%text>%</%text> endif
+% else:
+  <%text>%</%text> if hasattr(${ var }, 'ask_number') and ${ var }.ask_number and ${ var }.target_number == 1:
+  Name of ${ singular }
+  <%text>%</%text> else:
+  Name of the <%text>${ ordinal(i) }</%text> ${ singular }
+  <%text>%</%text> endif
+% endif
+fields:
+  - code: |
+% if var == "other_parties":
+      other_parties[i].name_fields(person_or_business="unsure")
+% else:
+      ${ var }[i].name_fields()
+% endif
+</%def>\
+<%doc>
+    From `ql_baseline.yml`, id: any other people -- except for `users` and
+    `other_parties`, which AssemblyLine asks about in id: any other users and
+    id: any other opposing parties
+</%doc>\
+<%def name="baseline_there_is_another(var, singular)">\
+---
+id: ${ fix_id("another " + singular) }
+question: |
+% if var == "users":
+  <%text>%</%text> if al_form_type in ['starts_case', 'existing_case', 'appeal']:
+  Is anyone else on your side of this case?
+  <%text>%</%text> else:
+  Is anyone else adding their name to this form with you?
+  <%text>%</%text> endif
+subquestion: |
+  <%text>%</%text> if len(users.elements) > 1:
+  So far you have told us about <%text>${</%text> comma_and_list(users.complete_elements()) }.
+  <%text>%</%text> endif
+% elif var == "other_parties":
+  <%text>%</%text> if user_started_case:
+  Is there any other **defendant** or respondent in this matter?
+  <%text>%</%text> else:
+  Is there any other **plaintiff** or petitioner in this matter?
+  <%text>%</%text> endif
+% else:
+  Is there another ${ singular } to tell us about?
+% endif
+fields:
+  - no label: ${ var }.there_is_another
+    datatype: yesnoradio
+</%def>\
+<%doc>
+    From `ql_baseline.yml`, id: name of ALIndividual. Used for a standalone
+    ALIndividual rather than a list of people.
+</%doc>\
+<%def name="baseline_name(var)">\
+---
+id: ${ fix_id(var + " name") }
+sets:
+  - ${ var }.name.first
+  - ${ var }.name.last
+  - ${ var }.name.middle
+  - ${ var }.name.suffix
+question: |
+  What is <%text>${</%text> ${ var }.object_possessive('name') }?
+fields:
+  - code: |
+      ${ var }.name_fields()
+</%def>\
+<%doc>
+    From `ql_baseline.yml`, id: persons address -- except for `users`, which
+    AssemblyLine asks about in id: user i's address, where later users can reuse
+    the first user's address.
+</%doc>\
+<%def name="baseline_address(var, item, singular)">\
+---
+id: ${ fix_id(singular + " address") }
+sets:
+  - ${ item }.address.address
+  - ${ item }.address.city
+  - ${ item }.address.state
+  - ${ item }.address.zip
+  - ${ item }.address.unit
+  - ${ item }.address.country
+question: |
+% if var == "users":
+  <%text>%</%text> if i == 0 and al_person_answering == "user":
+  What is your address?
+  <%text>%</%text> else:
+  What is <%text>${ users[i] }</%text>'s address?
+  <%text>%</%text> endif
+fields:
+  - label: |
+      <%text>%</%text> if i > 0 and al_person_answering == "user":
+      Same as your address
+      <%text>%</%text> else:
+      Same as <%text>${ users[0] }</%text>'s address
+      <%text>%</%text> endif
+    field: users[i].address
+    datatype: object_radio
+    choices:
+      - users[0].address if defined("users[0].address.address") else None
+    object labeler: |
+      lambda y: y.on_one_line()
+    none of the above: |
+      Somewhere else
+    disable others: True
+    show if:
+      code: |
+        i > 0 and defined("users[0].address.address")
+  - code: |
+      users[i].address_fields(
+          country_code=AL_DEFAULT_COUNTRY, default_state=AL_DEFAULT_STATE
+      )
+% else:
+  What is <%text>${</%text> ${ item }.possessive('address') }?
+fields:
+  - code: |
+      ${ item }.address_fields(
+          country_code=AL_DEFAULT_COUNTRY, default_state=AL_DEFAULT_STATE
+      )
+% endif
+</%def>\
+<%doc>
+    From `ql_baseline.yml`, id: any mailing address
+</%doc>\
+<%def name="baseline_mailing_address(item, singular)">\
+---
+id: ${ fix_id(singular + " mailing address") }
+sets:
+  - ${ item }.mailing_address.address
+  - ${ item }.mailing_address.city
+  - ${ item }.mailing_address.state
+  - ${ item }.mailing_address.zip
+  - ${ item }.mailing_address.unit
+  - ${ item }.mailing_address.country
+question: |
+  What is <%text>${</%text> ${ item } }'s mailing address?
+fields:
+  - "<%text>${</%text> ${ item } }'s mailing address is": ${ item }.mailing_address
+    datatype: object_radio
+    choices:
+      - ${ item }.address
+    object labeler: |
+      lambda y: y.on_one_line()
+    none of the above: |
+      Somewhere else
+    disable others: True
+  - code: |
+      ${ item }.mailing_address.address_fields(
+          country_code=AL_DEFAULT_COUNTRY, default_state=AL_DEFAULT_STATE
+      )
+</%def>\
+<%doc>
+    From `ql_baseline.yml`, id: birthdate question
+</%doc>\
+<%def name="baseline_birthdate(item, singular)">\
+---
+id: ${ fix_id(singular + " birthdate") }
+question: |
+  When was <%text>${</%text> ${ item } } born?
+fields:
+  - Birthdate: ${ item }.birthdate
+    datatype: BirthDate
+    alMonthLabel: <%text>${ word('Month') }</%text>
+    alDayLabel: <%text>${ word('Day') }</%text>
+    alYearLabel: <%text>${ word('Year') }</%text>
+</%def>\
+<%doc>
+    From `ql_baseline.yml`, id: gender
+</%doc>\
+<%def name="baseline_gender(item, singular)">\
+---
+id: ${ fix_id(singular + " gender") }
+sets:
+  - ${ item }.gender
+question: |
+  What is <%text>${</%text> ${ item }.possessive('gender') }?
+fields:
+  - code: |
+      ${ item }.gender_fields(show_help=True)
+</%def>\
+<%doc>
+    From `ql_baseline.yml`, id: x's pronouns -- except for `users`, which
+    AssemblyLine asks about in id: your pronouns
+</%doc>\
+<%def name="baseline_pronouns(var, item, singular)">\
+---
+id: ${ fix_id(singular + " pronouns") }
+sets:
+  - ${ item }.pronouns
+question: |
+% if var == "users":
+  <%text>%</%text> if i == 0 and al_person_answering == "user":
+  What are your pronouns?
+  <%text>%</%text> else:
+  What are <%text>${ users[i] }</%text>'s pronouns?
+  <%text>%</%text> endif
+% else:
+  What are <%text>${</%text> ${ item } }'s pronouns?
+% endif
+fields:
+  - code: |
+      ${ item }.pronoun_fields(show_help=True, required=False)
+</%def>\
+<%doc>
+    From `ql_baseline.yml`, id: language of individual -- except for `users`,
+    which AssemblyLine asks about in id: language of user
+</%doc>\
+<%def name="baseline_language(var, item, singular)">\
+---
+id: ${ fix_id(singular + " language") }
+sets:
+  - ${ item }.language
+question: |
+% if var == "users":
+  <%text>%</%text> if i == 0 and al_person_answering == "user":
+  What language do you speak?
+  <%text>%</%text> else:
+  What language does <%text>${ users[i] }</%text> speak?
+  <%text>%</%text> endif
+% else:
+  What language does <%text>${</%text> ${ item } } speak?
+% endif
+fields:
+  - code: |
+      ${ item }.language_fields(choices=al_language_user_choices)
+</%def>\
+<%doc>
+    From `ql_baseline.yml`, id: persons phone number and id: persons mobile number
+</%doc>\
+<%def name="baseline_phone(item, singular, attribute, description, label)">\
+---
+id: ${ fix_id(singular + " " + description) }
+question: |
+  What is <%text>${</%text> ${ item } }'s ${ description }?
+fields:
+  - ${ label }: ${ item }.${ attribute }
+    datatype: al_international_phone
+</%def>\
+<%doc>
+    From `ql_baseline.yml`, id: email
+</%doc>\
+<%def name="baseline_email(item, singular)">\
+---
+id: ${ fix_id(singular + " email") }
+question: |
+  What is <%text>${</%text> ${ item } }'s email address?
+fields:
+  - Email: ${ item }.email
+    datatype: email
+</%def>\

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -1,5 +1,6 @@
 from .custom_values import get_matching_deps, get_output_mako_package_and_path
 from .generator_constants import generator_constants
+from .question_library import baseline_question_specs
 from .validate_template_files import matching_reserved_names, has_fields
 from collections import defaultdict
 from dataclasses import field
@@ -6592,14 +6593,22 @@ def _render_interview_yaml(
     )
 
     output_defs_path = _resolve_template_path("output_defs.mako")
+    question_library_path = _resolve_template_path("question_library.mako")
     output_mako_ref = get_output_mako_package_and_path(output_mako_choice)
     output_mako_path = _resolve_template_path(output_mako_ref)
     with open(output_defs_path, "r", encoding="utf-8") as defs_handle:
         output_defs_text = defs_handle.read()
+    with open(question_library_path, "r", encoding="utf-8") as library_handle:
+        question_library_text = library_handle.read()
     with open(output_mako_path, "r", encoding="utf-8") as mako_handle:
         output_mako_text = mako_handle.read()
 
-    template_text = output_defs_text + "\n" + output_mako_text
+    # The question library ships as its own file so authors can keep it in sync
+    # with AssemblyLine's ql_baseline.yml, but its defs have to be part of the same
+    # Mako template as the output template that calls them.
+    template_text = (
+        output_defs_text + "\n" + question_library_text + "\n" + output_mako_text
+    )
     # This template renders docassemble YAML, not HTML output.
     template = mako.template.Template(
         template_text, input_encoding="utf-8"
@@ -6661,6 +6670,7 @@ def _render_interview_yaml(
     context = {
         "interview": interview,
         "objects": objects or [],
+        "baseline_questions": baseline_question_specs(interview, objects or []),
         "generate_download_screen": include_download_screen,
         "screen_reordered": screen_reordered,
         "review_collections": interview.all_fields.review_collections(screen_reordered),
@@ -7028,6 +7038,7 @@ def generate_interview_from_path(
     create_package_zip: bool = True,
     include_next_steps: bool = True,
     include_download_screen: bool = True,
+    copy_baseline_questions: bool = True,
     use_llm_assist: bool = False,
     help_page_url: Optional[str] = None,
     help_page_title: Optional[str] = None,
@@ -7086,6 +7097,7 @@ def generate_interview_from_path(
 
     interview.output_mako_choice = output_mako_choice
     interview.include_next_steps = include_next_steps
+    interview.copy_baseline_questions = bool(copy_baseline_questions)
     interview.use_llm_assist = bool(use_llm_assist)
     if help_page_url is not None:
         interview.help_page_url = str(help_page_url).strip()

--- a/docassemble/ALWeaver/question_library.py
+++ b/docassemble/ALWeaver/question_library.py
@@ -1,0 +1,201 @@
+"""Work out which AssemblyLine baseline questions to copy into a generated interview.
+
+AssemblyLine asks about people with `generic object:` questions in
+``ql_baseline.yml``: one question serves ``users``, ``parents``, ``witnesses`` and
+every other ``ALPeopleList``.  That is efficient for AssemblyLine, but it makes the
+questions hard to *edit*.  Somebody who wants to reword "Name of the 2nd child"
+cannot copy the block out of ``ql_baseline.yml`` as-is -- they have to know to drop
+the ``generic object:`` line and rewrite every ``x`` into ``children``.  New
+authors reliably get stuck here.
+
+So the Weaver can copy the questions in for them, already specialized to the
+objects the interview actually declares.  This module decides *which* questions to
+copy; ``data/templates/question_library.mako`` holds the question text itself, so
+the copies can be kept in sync with ``ql_baseline.yml`` by editing that template.
+
+The entry point is :func:`baseline_question_specs`.
+"""
+
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple
+import re
+
+from .generator_constants import generator_constants
+
+__all__ = [
+    "baseline_question_specs",
+    "singular_label",
+    "plural_label",
+]
+
+
+# Plural object name -> the singular AssemblyLine uses for it, e.g. "children" ->
+# "child".  RESERVED_PERSON_PLURALIZERS_MAP is keyed the other way around and
+# includes identity entries ("users" -> "users") that say nothing about the
+# singular, so those are skipped.
+_PLURAL_TO_SINGULAR: Dict[str, str] = {
+    plural: singular
+    for singular, plural in generator_constants.RESERVED_PERSON_PLURALIZERS_MAP.items()
+    if singular != plural
+}
+
+
+# The attribute questions worth copying, in the order they are emitted.  The key is
+# the first segment of the attribute (``users[0].address.zip`` -> ``address``) and
+# the value is the ``kind`` the Mako template dispatches on.
+#
+# Deliberately left out: ``name`` (the gather flow already asks it), ``signature``
+# (AssemblyLine's `basic_questions_signature_flow` owns those screens), and
+# anything AssemblyLine does not have a reusable question for.
+_ATTRIBUTE_KINDS: List[Tuple[str, str]] = [
+    ("address", "address"),
+    ("mailing_address", "mailing_address"),
+    ("birthdate", "birthdate"),
+    ("gender", "gender"),
+    ("pronouns", "pronouns"),
+    ("language", "language"),
+    ("phone_number", "phone_number"),
+    ("mobile_number", "mobile_number"),
+    ("email", "email"),
+]
+
+_ATTRIBUTE_KIND_BY_SEGMENT: Dict[str, str] = dict(_ATTRIBUTE_KINDS)
+
+_VARIABLE_PATTERN = re.compile(
+    r"^([A-Za-z_][A-Za-z0-9_]*)(\[[^\]]+\])?(?:\.(.+))?$",
+)
+
+
+def _split_variable(variable: str) -> Optional[Tuple[str, bool, str]]:
+    """Break ``users[0].address.zip`` into ``("users", True, "address.zip")``.
+
+    Returns ``None`` for anything that is not a plain object reference, such as
+    the method calls (``plaintiffs[0].address.on_one_line()``) that show up among
+    the built-in fields.
+    """
+    match = _VARIABLE_PATTERN.match(variable.strip())
+    if not match:
+        return None
+    prefix, index, attribute = match.group(1), match.group(2), match.group(3) or ""
+    if "(" in attribute or ")" in attribute:
+        return None
+    return prefix, bool(index), attribute
+
+
+def singular_label(name: str) -> str:
+    """A human-readable singular for an object name, e.g. ``parents`` -> ``parent``."""
+    base = _PLURAL_TO_SINGULAR.get(name)
+    if base is None:
+        base = _naive_singular(name)
+    return base.replace("_", " ")
+
+
+def plural_label(name: str) -> str:
+    """A human-readable plural for an object name, e.g. ``other_parties`` -> ``other parties``."""
+    return name.replace("_", " ")
+
+
+def _naive_singular(name: str) -> str:
+    """Best-effort singular for list names AssemblyLine does not know about."""
+    if name.endswith("ies") and len(name) > 3:
+        return name[:-3] + "y"
+    if name.endswith("sses") or name.endswith("ches") or name.endswith("shes"):
+        return name[:-2]
+    if name.endswith("s") and not name.endswith("ss"):
+        return name[:-1]
+    return name
+
+
+def _attribute_kinds_for(attributes: Iterable[str]) -> List[str]:
+    """The attribute question kinds implied by a set of attribute paths."""
+    segments: Set[str] = set()
+    for attribute in attributes:
+        if not attribute:
+            continue
+        segment = attribute.split(".", 1)[0]
+        if segment.startswith("gender"):
+            segment = "gender"
+        if segment in _ATTRIBUTE_KIND_BY_SEGMENT:
+            segments.add(segment)
+    return [kind for segment, kind in _ATTRIBUTE_KINDS if segment in segments]
+
+
+def _gather_kinds(params: Dict[str, Any]) -> List[str]:
+    """The gather-flow questions a list still needs, given its ``objects:`` params.
+
+    A list declared as ``ALPeopleList.using(there_are_any=True)`` never asks
+    ``there_are_any``, and one declared with ``ask_number=True`` asks
+    ``target_number`` instead of ``there_is_another``.  Copying in a question
+    Docassemble will never reach is just noise, so each one is conditional.
+    """
+    asks_number = bool(params.get("ask_number"))
+    knows_target = "target_number" in params
+    knows_there_are_any = "there_are_any" in params
+
+    kinds: List[str] = []
+    if asks_number:
+        if not knows_target:
+            kinds.append("how_many")
+    elif not knows_there_are_any:
+        kinds.append("there_are_any")
+    kinds.append("names")
+    if not asks_number:
+        kinds.append("there_is_another")
+    return kinds
+
+
+def baseline_question_specs(
+    interview: Any,
+    objects: Optional[Sequence[Any]] = None,
+) -> List[Dict[str, Any]]:
+    """Describe the baseline questions to copy into ``interview``'s generated YAML.
+
+    Args:
+      interview: the ``DAInterview`` being generated.
+      objects: the entries of the generated ``objects:`` block.  Only objects
+        declared there get copies -- names like ``plaintiffs`` that AssemblyLine
+        derives and manages itself are left to AssemblyLine.
+
+    Returns:
+      A list of plain dicts, one per question block to emit, each with a ``kind``
+      the Mako template dispatches on plus the labels that template needs.  Empty
+      when the author turned the option off.
+    """
+    if not bool(getattr(interview, "copy_baseline_questions", True)):
+        return []
+    if not objects:
+        return []
+
+    all_fields = getattr(interview, "all_fields", None)
+    builtins = list(all_fields.builtins()) if all_fields is not None else []
+
+    attributes_by_prefix: Dict[str, Set[str]] = {}
+    for field in builtins:
+        parsed = _split_variable(str(getattr(field, "final_display_var", "") or ""))
+        if parsed is None:
+            continue
+        prefix, _indexed, attribute = parsed
+        attributes_by_prefix.setdefault(prefix, set()).add(attribute)
+
+    specs: List[Dict[str, Any]] = []
+    for spec in objects:
+        name = str(getattr(spec, "name", "") or "")
+        if not name.isidentifier():
+            continue
+        object_type = str(getattr(spec, "type", "ALPeopleList") or "ALPeopleList")
+        params = dict(getattr(spec, "params", None) or {})
+        is_list = object_type.endswith("List")
+
+        common = {
+            "var": name,
+            "is_list": is_list,
+            "singular": singular_label(name) if is_list else plural_label(name),
+            "plural": plural_label(name),
+        }
+
+        kinds = _gather_kinds(params) if is_list else ["name"]
+        kinds.extend(_attribute_kinds_for(attributes_by_prefix.get(name, set())))
+
+        for kind in kinds:
+            specs.append({"kind": kind, **common})
+
+    return specs

--- a/docassemble/ALWeaver/test_editor_frontend.py
+++ b/docassemble/ALWeaver/test_editor_frontend.py
@@ -396,6 +396,20 @@ class TestEditorFrontend(unittest.TestCase):
         self.assertIn("field.pair ? 'col-12 col-md-6' : 'col-12'", editor)
         self.assertIn("input.value === '' ? '' : Number(input.value)", editor)
 
+    def test_new_project_offers_to_copy_the_assemblyline_person_questions(self):
+        editor = (self.package_dir / "data/static/editor.js").read_text()
+
+        self.assertIn('id="new-project-copy-baseline-questions"', editor)
+        self.assertIn(
+            "formData.append('copy_baseline_questions', copyBaselineQuestions ? 'true' : 'false')",
+            editor,
+        )
+        # The point of the option is that it is on unless somebody turns it off.
+        self.assertIn(
+            "copyBaselineQuestionsInput ? copyBaselineQuestionsInput.checked : true",
+            editor,
+        )
+
     def test_navbar_matches_docassemble_and_carries_the_account_menu(self):
         """The editor is a full-page app that sits where a native docassemble
         page would, so its bar has to be a real Bootstrap navbar at

--- a/docassemble/ALWeaver/test_question_library.py
+++ b/docassemble/ALWeaver/test_question_library.py
@@ -1,0 +1,359 @@
+import re
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import mako.template
+
+import docassemble.ALWeaver.interview_generator as interview_generator_module
+from docassemble.ALWeaver.interview_generator import (
+    _resolve_template_path,
+    fix_id,
+    generate_interview_from_path,
+)
+from docassemble.ALWeaver.question_library import (
+    baseline_question_specs,
+    singular_label,
+)
+
+
+class FakeField:
+    def __init__(self, final_display_var):
+        self.final_display_var = final_display_var
+
+
+class FakeFieldList:
+    def __init__(self, fields):
+        self._fields = fields
+
+    def builtins(self):
+        return self._fields
+
+
+def fake_interview(builtin_vars, copy_baseline_questions=True):
+    return SimpleNamespace(
+        all_fields=FakeFieldList([FakeField(var) for var in builtin_vars]),
+        copy_baseline_questions=copy_baseline_questions,
+    )
+
+
+def person_object(name, params=None, object_type="ALPeopleList"):
+    return SimpleNamespace(name=name, type=object_type, params=params or {})
+
+
+def kinds_for(specs, var):
+    return [spec["kind"] for spec in specs if spec["var"] == var]
+
+
+class TestSingularLabel(unittest.TestCase):
+    def test_assembly_line_names_use_assembly_lines_own_singular(self):
+        self.assertEqual(singular_label("children"), "child")
+        self.assertEqual(singular_label("other_parties"), "other party")
+        self.assertEqual(singular_label("witnesses"), "witness")
+        self.assertEqual(singular_label("users"), "user")
+
+    def test_unknown_names_fall_back_to_a_guess(self):
+        self.assertEqual(singular_label("landlords"), "landlord")
+        self.assertEqual(singular_label("agencies"), "agency")
+
+    def test_a_name_that_is_already_singular_is_left_alone(self):
+        self.assertEqual(singular_label("my_user"), "my user")
+
+
+class TestWhichQuestionsGetCopied(unittest.TestCase):
+    def test_a_plain_list_gets_the_whole_gather_flow(self):
+        specs = baseline_question_specs(
+            fake_interview(["parents[0].name.first"]),
+            [person_object("parents")],
+        )
+        self.assertEqual(
+            kinds_for(specs, "parents"),
+            ["there_are_any", "names", "there_is_another"],
+        )
+
+    def test_a_list_that_already_knows_it_has_members_skips_there_are_any(self):
+        specs = baseline_question_specs(
+            fake_interview(["users[0].name.first"]),
+            [person_object("users", {"there_are_any": True})],
+        )
+        self.assertEqual(kinds_for(specs, "users"), ["names", "there_is_another"])
+
+    def test_a_list_of_exactly_one_only_asks_for_the_name(self):
+        specs = baseline_question_specs(
+            fake_interview(["decedents[0].name.first"]),
+            [person_object("decedents", {"ask_number": True, "target_number": 1})],
+        )
+        self.assertEqual(kinds_for(specs, "decedents"), ["names"])
+
+    def test_a_counted_list_asks_how_many_instead_of_there_is_another(self):
+        specs = baseline_question_specs(
+            fake_interview(["children[0].name.first"]),
+            [person_object("children", {"ask_number": True})],
+        )
+        self.assertEqual(kinds_for(specs, "children"), ["how_many", "names"])
+
+    def test_attribute_questions_follow_the_fields_the_form_uses(self):
+        specs = baseline_question_specs(
+            fake_interview(
+                [
+                    "users[0].name.first",
+                    "users[0].address.zip",
+                    "users[0].birthdate",
+                    "users[0].gender_female",
+                    "users[0].pronouns",
+                    "users[0].language",
+                    "users[0].email",
+                    "users[0].phone_number",
+                ]
+            ),
+            [person_object("users", {"there_are_any": True})],
+        )
+        self.assertEqual(
+            kinds_for(specs, "users"),
+            [
+                "names",
+                "there_is_another",
+                "address",
+                "birthdate",
+                "gender",
+                "pronouns",
+                "language",
+                "phone_number",
+                "email",
+            ],
+        )
+
+    def test_attributes_assembly_line_has_no_reusable_question_for_are_skipped(self):
+        specs = baseline_question_specs(
+            fake_interview(["users[0].signature", "users[0].favorite_color"]),
+            [person_object("users", {"there_are_any": True})],
+        )
+        self.assertEqual(kinds_for(specs, "users"), ["names", "there_is_another"])
+
+    def test_method_calls_among_the_built_ins_are_ignored(self):
+        specs = baseline_question_specs(
+            fake_interview(["users[0].address.on_one_line()"]),
+            [person_object("users", {"there_are_any": True})],
+        )
+        self.assertEqual(kinds_for(specs, "users"), ["names", "there_is_another"])
+
+    def test_a_standalone_individual_gets_a_name_question_not_a_gather_flow(self):
+        specs = baseline_question_specs(
+            fake_interview(["landlord.name.first", "landlord.address.city"]),
+            [person_object("landlord", object_type="ALIndividual")],
+        )
+        self.assertEqual(kinds_for(specs, "landlord"), ["name", "address"])
+
+    def test_objects_assembly_line_manages_itself_are_left_alone(self):
+        # `plaintiffs` never reaches the generated `objects:` block, so nothing
+        # about it should be copied in even though fields reference it.
+        specs = baseline_question_specs(
+            fake_interview(["plaintiffs[0].name.first", "users[0].name.first"]),
+            [person_object("users", {"there_are_any": True})],
+        )
+        self.assertEqual({spec["var"] for spec in specs}, {"users"})
+
+    def test_turning_the_option_off_copies_nothing(self):
+        specs = baseline_question_specs(
+            fake_interview(["users[0].name.first"], copy_baseline_questions=False),
+            [person_object("users")],
+        )
+        self.assertEqual(specs, [])
+
+
+class TestRenderedQuestions(unittest.TestCase):
+    """Render every question kind and check the YAML it produces."""
+
+    @classmethod
+    def setUpClass(cls):
+        defs_text = Path(_resolve_template_path("output_defs.mako")).read_text(
+            encoding="utf-8"
+        )
+        library_text = Path(_resolve_template_path("question_library.mako")).read_text(
+            encoding="utf-8"
+        )
+        cls.template = mako.template.Template(  # nosec B702
+            defs_text + "\n" + library_text, input_encoding="utf-8"
+        )
+
+    def render(self, kind, var="parents", is_list=True):
+        entry = {
+            "kind": kind,
+            "var": var,
+            "is_list": is_list,
+            "singular": singular_label(var) if is_list else var.replace("_", " "),
+            "plural": var.replace("_", " "),
+        }
+        return self.template.get_def("baseline_question_yaml").render(
+            entry=entry, fix_id=fix_id
+        )
+
+    def all_kinds(self):
+        return [
+            "there_are_any",
+            "how_many",
+            "names",
+            "there_is_another",
+            "address",
+            "mailing_address",
+            "birthdate",
+            "gender",
+            "pronouns",
+            "language",
+            "phone_number",
+            "mobile_number",
+            "email",
+        ]
+
+    def test_every_kind_produces_a_docassemble_block(self):
+        from dayamlchecker.yaml_structure import find_errors_from_string
+
+        for var, is_list in (
+            ("parents", True),
+            ("users", True),
+            ("other_parties", True),
+            ("landlord", False),
+        ):
+            kinds = self.all_kinds() if is_list else ["name", "address", "email"]
+            for kind in kinds:
+                with self.subTest(kind=kind, var=var):
+                    rendered = self.render(kind, var=var, is_list=is_list)
+                    self.assertTrue(rendered.startswith("---\n"), rendered)
+                    self.assertIn("id: ", rendered)
+                    errors = find_errors_from_string(rendered, input_file="copy.yml")
+                    self.assertFalse(
+                        errors,
+                        "\n".join(
+                            str(getattr(error, "err_str", "") or error)
+                            for error in errors
+                        ),
+                    )
+
+    def test_nothing_generic_survives_the_copy(self):
+        for kind in self.all_kinds():
+            with self.subTest(kind=kind):
+                rendered = self.render(kind)
+                self.assertNotIn("generic object", rendered)
+                # A bare `x` is what makes the AssemblyLine originals uneditable.
+                self.assertIsNone(re.search(r"(?<![\w.])x[.\[]", rendered), rendered)
+                self.assertIn("parents", rendered)
+
+    def test_questions_call_assembly_lines_field_helpers_rather_than_inlining_them(
+        self,
+    ):
+        """The `_fields()` methods stay in the copies.
+
+        Expanding them by hand would freeze today's address/name/gender/pronoun
+        markup into every generated interview and lose the AssemblyLine upgrades
+        that flow through those methods.
+        """
+        expected_helper = {
+            "names": "name_fields(",
+            "address": "address_fields(",
+            "mailing_address": "address_fields(",
+            "gender": "gender_fields(",
+            "pronouns": "pronoun_fields(",
+            "language": "language_fields(",
+        }
+        for var in ("parents", "users", "other_parties"):
+            for kind, helper in expected_helper.items():
+                with self.subTest(kind=kind, var=var):
+                    rendered = self.render(kind, var=var)
+                    self.assertIn(helper, rendered)
+                    # The pieces a helper is responsible for must not also be
+                    # spelled out field by field.
+                    self.assertNotIn("address_label", rendered)
+                    self.assertNotIn("states_list(", rendered)
+
+    def test_list_questions_are_written_against_the_indexed_item(self):
+        self.assertIn("parents[i].name_fields()", self.render("names"))
+        self.assertIn("parents[i].address_fields(", self.render("address"))
+        self.assertIn("parents.there_is_another", self.render("there_is_another"))
+
+    def test_a_standalone_individual_is_written_without_an_index(self):
+        rendered = self.render("name", var="landlord", is_list=False)
+        self.assertIn("landlord.name_fields()", rendered)
+        self.assertNotIn("landlord[i]", rendered)
+
+    def test_users_get_assembly_lines_user_specific_wording(self):
+        self.assertIn("What is your name?", self.render("names", var="users"))
+        self.assertIn(
+            "Is anyone else on your side of this case?",
+            self.render("there_is_another", var="users"),
+        )
+        self.assertIn("What is your address?", self.render("address", var="users"))
+
+    def test_other_parties_get_assembly_lines_opposing_party_wording(self):
+        self.assertIn(
+            "**defendant** or respondent",
+            self.render("names", var="other_parties"),
+        )
+        self.assertIn(
+            'name_fields(person_or_business="unsure")',
+            self.render("names", var="other_parties"),
+        )
+        self.assertIn(
+            "Is there a **defendant** or respondent in this case?",
+            self.render("there_are_any", var="other_parties"),
+        )
+
+    def test_other_lists_do_not_get_the_user_specific_wording(self):
+        self.assertNotIn("al_person_answering", self.render("names"))
+        self.assertNotIn("al_person_answering", self.render("address"))
+        self.assertNotIn("user_started_case", self.render("names"))
+
+
+class TestGeneratedInterviewIncludesTheCopies(unittest.TestCase):
+    @staticmethod
+    def _offline_cluster_screens(fields, tools_token=None):
+        del tools_token
+        unique_fields = list(dict.fromkeys(fields or []))
+        return {
+            f"Screen {index // 4 + 1}": unique_fields[index : index + 4]
+            for index in range(0, len(unique_fields), 4)
+        }
+
+    def _generate(self, **kwargs):
+        pdf_path = (
+            Path(__file__).parent / "test/test_petition_to_enforce_sanitary_code.pdf"
+        )
+        with patch.object(
+            interview_generator_module.formfyxer,
+            "cluster_screens",
+            side_effect=self._offline_cluster_screens,
+        ):
+            with tempfile.TemporaryDirectory() as tmpdir:
+                result = generate_interview_from_path(
+                    str(pdf_path),
+                    output_dir=tmpdir,
+                    create_package_zip=False,
+                    include_next_steps=False,
+                    **kwargs,
+                )
+                return Path(result.yaml_path).read_text(encoding="utf-8")
+
+    def test_the_copies_are_written_in_by_default(self):
+        yaml_text = self._generate()
+        self.assertIn("users[i].name_fields()", yaml_text)
+        self.assertIn("users.there_is_another", yaml_text)
+        self.assertIn("other_parties[i].address_fields(", yaml_text)
+
+    def test_every_copied_object_is_declared_in_the_objects_block(self):
+        yaml_text = self._generate()
+        declared = set(re.findall(r"^  - (\w+): ALPeopleList", yaml_text, re.MULTILINE))
+        copied = set(
+            re.findall(r"^      (\w+)\[i\]\.name_fields\(\)", yaml_text, re.MULTILINE)
+        )
+        self.assertTrue(copied)
+        self.assertTrue(copied <= declared, copied - declared)
+
+    def test_turning_the_option_off_leaves_the_interview_as_it_was(self):
+        yaml_text = self._generate(copy_baseline_questions=False)
+        self.assertNotIn("name_fields()", yaml_text)
+        self.assertNotIn("copies of the questions in AssemblyLine", yaml_text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
AssemblyLine asks about people using generic object questions in ql_baseline.yml, which makes editing them difficult for authors who have to drop generic object lines and rewrite variable references.

Add an option (enabled by default) to specialize and copy baseline questions into generated interviews:
- Add question_library.py to determine which baseline questions to copy based on declared objects and their attributes.
- Add question_library.mako with editable question templates for names, addresses, contact info, and demographics.
- Integrate question library into interview_generator and output templates.
- Add toggle in the Weaver interview wizard, review screen, and visual editor new project modal/API.
- Add comprehensive unit tests.

Fixes #359