### PR TITLE
Save Python modules safely, and restart the server only when it actually helps

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -254,6 +254,47 @@ that may bypass earlier questions. Question-to-source links are shown only when 
 stable returned `questionName` matches a known block; otherwise the UI says that
 no confident match is available.
 
+Saving a Playground Python module is the one editor action that cannot take
+effect on its own. Docassemble does not import modules from where the Playground
+saves them: an interview referring to `docassemble.playground7Housing.util`
+resolves that against `site-packages/docassemble/playground7Housing/`, and the
+copy between the two happens only in the server's `copy_playground_modules()` at
+startup — in 1.9.x from `server.py`, in 1.10.x from `webapp/develop/helpers.py`.
+That is why the stock Playground redirects to `/restart` after every module save.
+
+`editor_modules.py` implements a less disruptive version of the same contract,
+and imports nothing from Docassemble so it can be tested on its own. A module
+whose name Docassemble would skip — `copy_playground_modules()` only copies
+`^[A-Za-z].*\.py$` — is refused at creation, save, rename, and upload rather
+than saved and silently never loaded. Source that does not compile is refused
+too, with the line and offset, unless the developer passes `force` to keep
+unfinished work; forced saves are deliberately not installed. A module that does
+not yet exist in the package directory cannot be in any worker's `sys.modules`,
+so it is copied across and goes live with no restart at all. Changing, renaming,
+or deleting an installed module records a per-project pending-restart flag in
+Redis instead.
+
+The restart is then deferred to the point the developer runs the interview,
+starts a test session, or opens the stock Playground, where they are already
+waiting on a new tab — so several module edits cost one restart rather than one
+each. `weaver: restart on module save` chooses between `prompt` (the default:
+ask, quoting the ten-to-thirty-second server-wide disruption, and let the
+developer decline), `auto`, and `never`. `POST /al/editor/api/server/restart`
+writes its polling record to Redis before calling the server's own
+`restart_all()`, which takes down the worker handling the request; the status
+endpoint reads the same `da:restart_status:` record shape as Docassemble's
+`check_restart_status` so the two agree about what finished means. A pending
+flag also clears itself whenever the server has restarted since it was set, so a
+restart triggered from anywhere counts. Servers that cannot restart — restarting
+disabled, or a read-only file system, where `reset.sh` refuses — get the
+explanation and no button.
+
+Starting a runtime test session bumps the interview's `da:interviewsource:`
+index first. Docassemble does this itself for `/interview` requests carrying
+`cache=0`, which is what "Run the interview" sends, but the session API does
+not, and without it the inspector can run against a parse from before the
+developer's last save.
+
 Uploaded-file project generation runs as the named
 `weaver_editor_new_project_task` in Docassemble's configured Celery worker.
 Redis stores an owner-scoped job record with queued, start, finish, progress,
@@ -286,6 +327,7 @@ kinds of interviews that the Weaver can produce.
 - `editor_agent_rename.py` classifies every appearance of a variable name and renames only the references it can positively recognise
 - `editor_agent_context.py` assembles the compact interview context a turn is given, fencing untrusted reference material
 - `editor_agent.py` runs the bounded agent loop and the explicit final validation pass
+- `editor_modules.py` decides what saving a Playground Python module means: which names Docassemble will actually load, whether the source compiles, whether the module can go live immediately, and which projects are waiting on a restart
 
 ## Testing
 

--- a/docassemble/ALWeaver/api_editor.py
+++ b/docassemble/ALWeaver/api_editor.py
@@ -35,10 +35,14 @@ Provides:
     POST /al/editor/api/agent/sessions/<id>/cancel — stop a running turn
     POST /al/editor/api/agent/sessions/<id>/reset — restore the original candidate
     POST /al/editor/api/agent/sessions/<id>/apply — return the candidate source
+    GET  /al/editor/api/server/restart-state — pending module changes, if any
+    POST /al/editor/api/server/restart — restart Docassemble so modules load
+    GET  /al/editor/api/server/restart-status — poll a restart in progress
 """
 
 from __future__ import annotations
 
+import importlib
 import importlib.resources
 import hashlib
 import json
@@ -46,6 +50,7 @@ import mimetypes
 import os
 import re
 import shutil
+import sys
 import traceback
 import textwrap
 import tempfile
@@ -65,8 +70,13 @@ from flask_login import current_user
 from docassemble.base.util import log
 
 from .docassemble_compat import (
+    bump_interview_source_index,
     create_target_session,
     create_saved_file,
+    full_package_directory,
+    reset_process_is_running,
+    restart_docassemble,
+    server_start_time,
     GithubCredentialError,
     get_target_question,
     get_target_variables,
@@ -101,6 +111,21 @@ from .api_utils import (
     generate_interview_from_bytes,
     parse_bool,
     validate_upload_metadata,
+)
+from .editor_modules import (
+    MODULE_FILENAME_PATTERN,
+    RESTART_DISRUPTION_SECONDS,
+    ModuleSyntaxError,
+    check_module_syntax,
+    clear_modules_dirty,
+    mark_modules_dirty,
+    module_package_directory,
+    normalize_restart_policy,
+    publish_module_source,
+    read_modules_dirty,
+    restart_status_key,
+    unpublish_module,
+    validate_module_filename,
 )
 from .assemblyline_settings import read_settings, update_settings
 
@@ -790,6 +815,8 @@ def _write_project_text_file(
     ) as fh:
         fh.write(content)
     area.finalize()
+    if normalized_section == "modules":
+        _sync_module_after_write(user_id, project, normalized_filename, content)
 
 
 def _project_text_files(
@@ -952,15 +979,24 @@ def _editor_feature_bootstrap() -> Dict[str, Any]:
     runtime_inspector = _runtime_inspector_enabled()
     agent_editor = _agent_editor_enabled()
     status = _assistant_status()
+    capability = _restart_capability()
+    module_restart = {
+        "policy": _module_restart_policy(),
+        "allowed": capability["allowed"],
+        "blocked_reason": capability["reason"],
+        "disruption_seconds": list(RESTART_DISRUPTION_SECONDS),
+    }
     return {
         "patch_model": patch_model,
         "runtime_inspector": runtime_inspector,
         "agent_editor": agent_editor,
         "assistant_status": status,
+        "module_restart": module_restart,
         "patchModel": patch_model,
         "runtimeInspector": runtime_inspector,
         "agentEditor": agent_editor,
         "assistantStatus": status,
+        "moduleRestart": module_restart,
     }
 
 
@@ -1562,11 +1598,16 @@ def editor_api_github_pull() -> Response:
                 },
                 409,
             )
+        _reconcile_project_modules(uid, project)
         return jsonify(
             {
                 "success": True,
                 "request_id": request_id,
-                "data": {"project": project, **result},
+                "data": {
+                    "project": project,
+                    **result,
+                    "restart_state": _restart_state_payload(uid, project),
+                },
             }
         )
     except ValueError as exc:
@@ -2353,22 +2394,52 @@ def editor_api_save_section_file() -> Response:
         mimetype_value = guessed_mimetype or "application/octet-stream"
         if not _is_text_editable(filename, mimetype_value):
             raise ValueError("File is not text-editable")
+        # A module that does not compile is refused rather than saved, because
+        # the failure would otherwise surface much later, in whichever
+        # interview imports it. "force" lets the developer keep unfinished work
+        # anyway; it is saved but deliberately not published.
+        force = parse_bool(post_data.get("force"), default=False)
+        module_info: Optional[Dict[str, Any]] = None
+        if section == "modules":
+            validate_module_filename(filename)
+            if not force:
+                check_module_syntax(filename, content)
         path = os.path.join(directory, filename)
         with open(path, "w", encoding="utf-8") as fh:
             fh.write(content)
         area.finalize()
+        if section == "modules":
+            try:
+                check_module_syntax(filename, content)
+            except ModuleSyntaxError as syntax_exc:
+                module_info = {
+                    "status": "not_published",
+                    "restart_required": False,
+                    "message": (
+                        f"{filename} was saved but not installed, because it "
+                        f"does not compile: {syntax_exc}"
+                    ),
+                }
+            else:
+                module_info = _save_module_file(uid, project, filename, content)
+        data: Dict[str, Any] = {
+            "project": project,
+            "section": section,
+            "filename": filename,
+            "size": len(content),
+        }
+        if module_info is not None:
+            data["module"] = module_info
+            data["restart_state"] = _restart_state_payload(uid, project)
         return jsonify(
             {
                 "success": True,
                 "request_id": request_id,
-                "data": {
-                    "project": project,
-                    "section": section,
-                    "filename": filename,
-                    "size": len(content),
-                },
+                "data": data,
             }
         )
+    except ModuleSyntaxError as exc:
+        return _module_error_response(request_id, exc)
     except ValueError as exc:
         return jsonify_with_status(
             {
@@ -2407,24 +2478,36 @@ def editor_api_new_section_file() -> Response:
             raise ValueError("content must be a text string")
         storage_section = EDITOR_SECTION_TO_STORAGE[section]
         area, directory = _editor_storage_directory(uid, project, storage_section)
+        # Rejected here rather than at first save: a module whose name
+        # Docassemble will not import is worth catching before the developer
+        # writes any code in it.
+        if section == "modules":
+            validate_module_filename(filename)
+            check_module_syntax(filename, content)
         path = os.path.join(directory, filename)
         if os.path.exists(path):
             raise ValueError(f"{filename} already exists")
         with open(path, "w", encoding="utf-8") as fh:
             fh.write(content)
         area.finalize()
+        data: Dict[str, Any] = {
+            "project": project,
+            "section": section,
+            "filename": filename,
+            "size": len(content),
+        }
+        if section == "modules":
+            data["module"] = _save_module_file(uid, project, filename, content)
+            data["restart_state"] = _restart_state_payload(uid, project)
         return jsonify(
             {
                 "success": True,
                 "request_id": request_id,
-                "data": {
-                    "project": project,
-                    "section": section,
-                    "filename": filename,
-                    "size": len(content),
-                },
+                "data": data,
             }
         )
+    except ModuleSyntaxError as exc:
+        return _module_error_response(request_id, exc)
     except ValueError as exc:
         return jsonify_with_status(
             {
@@ -2462,8 +2545,11 @@ def editor_api_upload_section_file() -> Response:
         storage_section = EDITOR_SECTION_TO_STORAGE[section]
         area, directory = _editor_storage_directory(uid, project, storage_section)
         saved_files: List[str] = []
+        modules: List[Dict[str, Any]] = []
         for upload in uploads:
             candidate_name = _normalize_storage_filename(upload.filename)
+            if section == "modules":
+                validate_module_filename(candidate_name)
             path = os.path.join(directory, candidate_name)
             if os.path.exists(path):
                 stem, ext = os.path.splitext(candidate_name)
@@ -2472,18 +2558,47 @@ def editor_api_upload_section_file() -> Response:
                     candidate_name = f"{stem}_{counter}{ext}"
                     path = os.path.join(directory, candidate_name)
                     counter += 1
+                # De-duplicating the name can produce one Docassemble would
+                # skip, e.g. util_1.py is fine but a leading digit would not be.
+                if section == "modules":
+                    validate_module_filename(candidate_name)
             upload.save(path)
             saved_files.append(candidate_name)
         area.finalize()
+        for candidate_name in saved_files if section == "modules" else []:
+            with open(os.path.join(directory, candidate_name), encoding="utf-8") as fh:
+                uploaded_source = fh.read()
+            try:
+                check_module_syntax(candidate_name, uploaded_source)
+            except ModuleSyntaxError as syntax_exc:
+                modules.append(
+                    {
+                        "filename": candidate_name,
+                        "status": "not_published",
+                        "restart_required": False,
+                        "message": (
+                            f"{candidate_name} was uploaded but not installed, "
+                            f"because it does not compile: {syntax_exc}"
+                        ),
+                    }
+                )
+                continue
+            result = _save_module_file(uid, project, candidate_name, uploaded_source)
+            result["filename"] = candidate_name
+            modules.append(result)
+        data: Dict[str, Any] = {
+            "project": project,
+            "section": section,
+            "saved_files": saved_files,
+        }
+        if section == "modules":
+            data["modules"] = modules
+            data["restart_state"] = _restart_state_payload(uid, project)
         return jsonify(
             {
                 "success": True,
                 "request_id": request_id,
-                "data": {
-                    "project": project,
-                    "section": section,
-                    "saved_files": saved_files,
-                },
+                "data": data,
             }
         )
     except ValueError as exc:
@@ -3084,6 +3199,7 @@ def editor_api_save_file() -> Response:
 #       assistant: False
 #       assistant model: gpt-5-mini
 #       runtime inspector: True
+#       restart on module save: prompt
 #
 # Each setting maps to the older UPPER_SNAKE spelling as well, so installs that
 # already set one of those keys — or the matching environment variable — keep
@@ -3102,12 +3218,20 @@ _FALSY = {"0", "false", "no", "off"}
 
 
 def _daconfig() -> Dict[str, Any]:
-    try:
-        from docassemble.base.config import daconfig
+    """Docassemble's loaded configuration, or an empty one outside a server.
 
-        return daconfig if isinstance(daconfig, dict) else {}
-    except (ImportError, AttributeError):
-        return {}
+    Read out of the already-imported module where possible: importing
+    ``docassemble.base.config`` loads the server configuration as a side
+    effect, and calls ``sys.exit`` when there is no config file to load.
+    """
+    module = sys.modules.get("docassemble.base.config")
+    if module is None:
+        try:
+            module = importlib.import_module("docassemble.base.config")
+        except BaseException:  # pylint: disable=broad-except
+            return {}
+    config = getattr(module, "daconfig", None)
+    return config if isinstance(config, dict) else {}
 
 
 def _legacy_config_spellings(legacy: str) -> List[str]:
@@ -3195,6 +3319,299 @@ def _agent_editor_enabled() -> bool:
     range operations in process and never calls that endpoint.
     """
     return _weaver_flag("assistant", True)
+
+
+# ---------------------------------------------------------------------------
+# Playground module safety
+#
+# Saving a module is the one editor action that cannot take effect on its own.
+# See editor_modules.py for why; the helpers below decide what to tell the
+# developer about it and when to offer the restart.
+# ---------------------------------------------------------------------------
+
+
+def _module_restart_policy() -> str:
+    """How the editor should handle a module change that needs a restart.
+
+    ``prompt`` (the default) asks before restarting, ``auto`` restarts without
+    asking when the developer runs the interview, and ``never`` only ever shows
+    the banner and leaves the restart to the developer.
+    """
+    return normalize_restart_policy(_weaver_setting("restart on module save"))
+
+
+def _filesystem_is_read_only() -> bool:
+    """``reset.sh`` refuses to restart on a read-only file system."""
+    return bool(_daconfig().get("read only file system", False))
+
+
+def _restarting_is_allowed() -> bool:
+    """Whether this server permits restarts at all.
+
+    Docassemble sets ``ALLOW_RESTARTING`` from whether the Playground, package
+    updates, or configuration editing are enabled.
+    """
+    try:
+        return bool(app.config.get("ALLOW_RESTARTING", False))
+    except Exception:
+        return False
+
+
+def _restart_capability() -> Dict[str, Any]:
+    """Whether this server can restart itself, and why not when it cannot."""
+    if _filesystem_is_read_only():
+        return {
+            "allowed": False,
+            "reason": (
+                "This server runs on a read-only file system, so it cannot "
+                "restart itself. Module changes will load the next time it is "
+                "redeployed."
+            ),
+        }
+    if not _restarting_is_allowed():
+        return {
+            "allowed": False,
+            "reason": (
+                "Restarting is disabled on this server. Ask an administrator "
+                "to restart it so your module changes load."
+            ),
+        }
+    return {"allowed": True, "reason": None}
+
+
+def _pending_module_changes(uid: int, project: str) -> Optional[Dict[str, Any]]:
+    try:
+        return read_modules_dirty(
+            r, uid, project, server_start_time=server_start_time()
+        )
+    except Exception as exc:  # a broken flag must not break the editor
+        log(f"ALWeaver editor: could not read pending module state: {exc!r}", "error")
+        return None
+
+
+def _flag_module_change(uid: int, project: str, filename: str, reason: str) -> None:
+    try:
+        mark_modules_dirty(
+            r,
+            uid,
+            project,
+            filename,
+            server_start_time=server_start_time(),
+            reason=reason,
+        )
+    except Exception as exc:
+        log(f"ALWeaver editor: could not record pending module state: {exc!r}", "error")
+
+
+def _restart_state_payload(uid: int, project: str) -> Dict[str, Any]:
+    """Everything the editor needs to decide what to say about restarting."""
+    pending = _pending_module_changes(uid, project)
+    capability = _restart_capability()
+    return {
+        "project": project,
+        "pending": bool(pending),
+        "files": (pending or {}).get("files", []),
+        "since": (pending or {}).get("since"),
+        "policy": _module_restart_policy(),
+        "restart_allowed": capability["allowed"],
+        "restart_blocked_reason": capability["reason"],
+        "disruption_seconds": list(RESTART_DISRUPTION_SECONDS),
+    }
+
+
+def _save_module_file(
+    uid: int, project: str, filename: str, content: str
+) -> Dict[str, Any]:
+    """Validate, publish, and report on one module save.
+
+    Returns the ``module`` half of the save response: whether the module is
+    live already or the project now needs a restart.
+    """
+    validate_module_filename(filename)
+    check_module_syntax(filename, content)
+    outcome = publish_module_source(
+        package_root=full_package_directory(),
+        user_id=uid,
+        project=project,
+        filename=filename,
+        content=content,
+    )
+    if outcome == "live":
+        return {
+            "status": "live",
+            "restart_required": False,
+            "message": f"{filename} is available to your interviews now.",
+        }
+    if outcome == "unavailable":
+        _flag_module_change(uid, project, filename, "changed")
+        return {
+            "status": "restart_required",
+            "restart_required": True,
+            "message": (
+                f"{filename} was saved. This server would not let the editor "
+                "install it directly, so it will load when the server restarts."
+            ),
+        }
+    _flag_module_change(uid, project, filename, "changed")
+    return {
+        "status": "restart_required",
+        "restart_required": True,
+        "message": (
+            f"{filename} was saved. Because an earlier version may already be "
+            "loaded, the server has to restart before your changes take effect."
+        ),
+    }
+
+
+def _sync_module_after_write(
+    uid: int, project: str, filename: str, content: str
+) -> None:
+    """Keep the installed copy in step with a module written elsewhere.
+
+    Project-wide find/replace writes module files directly, and must not be
+    turned into a save that can fail: a module that will not compile, or whose
+    name Docassemble would skip, simply is not installed.
+    """
+    try:
+        validate_module_filename(filename)
+    except ValueError:
+        return
+    try:
+        check_module_syntax(filename, content)
+    except ModuleSyntaxError:
+        _flag_module_change(uid, project, filename, "changed")
+        return
+    try:
+        _save_module_file(uid, project, filename, content)
+    except Exception as exc:
+        log(f"ALWeaver editor: could not install {filename}: {exc!r}", "error")
+        _flag_module_change(uid, project, filename, "changed")
+
+
+def _reconcile_project_modules(uid: int, project: str) -> None:
+    """Bring the installed modules back in line with the saved ones.
+
+    Used after a bulk change that replaces files behind the editor's back — a
+    GitHub pull or import — where individual saves never happened.
+    """
+    # Reconciling is bookkeeping on top of an import or pull that already
+    # succeeded; it must never turn that into a failure.
+    try:
+        package_root = full_package_directory()
+        _area, directory = _editor_storage_directory(
+            uid, project, EDITOR_SECTION_TO_STORAGE["modules"]
+        )
+        saved = {
+            name
+            for name in os.listdir(directory)
+            if MODULE_FILENAME_PATTERN.match(name)
+        }
+    except (Exception, SystemExit) as exc:
+        log(f"ALWeaver editor: could not list saved modules: {exc!r}", "error")
+        return
+    for filename in sorted(saved):
+        try:
+            with open(os.path.join(directory, filename), encoding="utf-8") as fh:
+                content = fh.read()
+        except OSError:
+            continue
+        _sync_module_after_write(uid, project, filename, content)
+    installed_dir = module_package_directory(package_root, uid, project)
+    if not installed_dir or not os.path.isdir(installed_dir):
+        return
+    for filename in sorted(os.listdir(installed_dir)):
+        if not MODULE_FILENAME_PATTERN.match(filename) or filename in saved:
+            continue
+        if unpublish_module(
+            package_root=package_root,
+            user_id=uid,
+            project=project,
+            filename=filename,
+        ):
+            _flag_module_change(uid, project, filename, "deleted")
+
+
+def _rename_module_file(
+    uid: int, project: str, old_filename: str, new_filename: str, directory: str
+) -> Dict[str, Any]:
+    """Move a module's installed copy to follow a rename.
+
+    Dropping the old copy stops new imports of it, but a worker that already
+    imported the old name still holds it, so a rename always needs a restart
+    unless the module had never been installed in the first place.
+    """
+    package_root = full_package_directory()
+    was_installed = unpublish_module(
+        package_root=package_root,
+        user_id=uid,
+        project=project,
+        filename=old_filename,
+    )
+    try:
+        with open(os.path.join(directory, new_filename), encoding="utf-8") as fh:
+            content = fh.read()
+    except OSError:
+        content = ""
+    try:
+        check_module_syntax(new_filename, content)
+        published = publish_module_source(
+            package_root=package_root,
+            user_id=uid,
+            project=project,
+            filename=new_filename,
+            content=content,
+        )
+    except ModuleSyntaxError:
+        published = "unavailable"
+    if not was_installed and published == "live":
+        return {
+            "status": "live",
+            "restart_required": False,
+            "message": f"{new_filename} is available to your interviews now.",
+        }
+    _flag_module_change(uid, project, old_filename, "renamed")
+    return {
+        "status": "restart_required",
+        "restart_required": True,
+        "message": (
+            f"{old_filename} was renamed to {new_filename}. The server has to "
+            "restart before interviews stop seeing the old name."
+        ),
+    }
+
+
+def _delete_module_file(uid: int, project: str, filename: str) -> Dict[str, Any]:
+    """Remove a module's installed copy after the source file is deleted."""
+    was_installed = unpublish_module(
+        package_root=full_package_directory(),
+        user_id=uid,
+        project=project,
+        filename=filename,
+    )
+    if not was_installed:
+        return {
+            "status": "live",
+            "restart_required": False,
+            "message": f"{filename} was deleted.",
+        }
+    _flag_module_change(uid, project, filename, "deleted")
+    return {
+        "status": "restart_required",
+        "restart_required": True,
+        "message": (
+            f"{filename} was deleted. The server has to restart before "
+            "interviews that already loaded it stop using it."
+        ),
+    }
+
+
+def _module_error_response(request_id: str, exc: ModuleSyntaxError) -> Response:
+    payload = exc.to_dict()
+    payload["request_id"] = request_id
+    return jsonify_with_status(
+        {"success": False, "request_id": request_id, "error": payload},
+        400,
+    )
 
 
 ASSISTANT_STATUS_READY = "ready"
@@ -3806,6 +4223,11 @@ def editor_api_runtime_create_session() -> Response:
         # Confirms this developer owns the requested Playground file.
         playground_read_yaml(uid, project, filename)
         yaml_filename = playground_yaml_filename(uid, project, filename)
+        # "Run the interview" reaches Docassemble with cache=0, which makes the
+        # server bump this index itself. Starting a session through the API
+        # does not, so without this the inspector can run against a parse from
+        # before the developer's last save.
+        bump_interview_source_index(yaml_filename)
         target = create_target_session(
             yaml_filename,
             secret=None,
@@ -5153,21 +5575,31 @@ def editor_api_rename_section_file() -> Response:
         )
         if old_filename == new_filename:
             raise ValueError("New filename must be different")
+        if section == "modules":
+            validate_module_filename(new_filename)
         storage_section = EDITOR_SECTION_TO_STORAGE[section]
         area, directory = _editor_storage_directory(uid, project, storage_section)
         rename_saved_file(area, directory, old_filename, new_filename)
+        data: Dict[str, Any] = {
+            "project": project,
+            "section": section,
+            "filename": new_filename,
+            "old_filename": old_filename,
+        }
+        if section == "modules":
+            data["module"] = _rename_module_file(
+                uid, project, old_filename, new_filename, directory
+            )
+            data["restart_state"] = _restart_state_payload(uid, project)
         return jsonify(
             {
                 "success": True,
                 "request_id": request_id,
-                "data": {
-                    "project": project,
-                    "section": section,
-                    "filename": new_filename,
-                    "old_filename": old_filename,
-                },
+                "data": data,
             }
         )
+    except ModuleSyntaxError as exc:
+        return _module_error_response(request_id, exc)
     except (ValueError, FileNotFoundError) as exc:
         status = 404 if isinstance(exc, FileNotFoundError) else 400
         return jsonify_with_status(
@@ -5205,15 +5637,19 @@ def editor_api_delete_section_file() -> Response:
         storage_section = EDITOR_SECTION_TO_STORAGE[section]
         area, directory = _editor_storage_directory(uid, project, storage_section)
         delete_saved_file(area, directory, filename)
+        data: Dict[str, Any] = {
+            "project": project,
+            "section": section,
+            "filename": filename,
+        }
+        if section == "modules":
+            data["module"] = _delete_module_file(uid, project, filename)
+            data["restart_state"] = _restart_state_payload(uid, project)
         return jsonify(
             {
                 "success": True,
                 "request_id": request_id,
-                "data": {
-                    "project": project,
-                    "section": section,
-                    "filename": filename,
-                },
+                "data": data,
             }
         )
     except (ValueError, FileNotFoundError) as exc:
@@ -5228,6 +5664,176 @@ def editor_api_delete_section_file() -> Response:
         )
     except Exception as exc:
         log(f"ALWeaver editor: delete section-file error: {exc!r}", "error")
+        return jsonify_with_status(
+            {
+                "success": False,
+                "request_id": request_id,
+                "error": {"type": "server_error", "message": str(exc)},
+            },
+            500,
+        )
+
+
+@app.route(f"{EDITOR_BASE_PATH}/api/server/restart-state", methods=["GET"])
+def editor_api_restart_state() -> Response:
+    """Report whether this project has module changes awaiting a restart."""
+    request_id = str(uuid.uuid4())
+    if not _editor_auth_check():
+        return _auth_fail(request_id)
+    try:
+        uid = _current_user_id()
+        project = _normalize_project(request.args.get("project"))
+        return jsonify(
+            {
+                "success": True,
+                "request_id": request_id,
+                "data": _restart_state_payload(uid, project),
+            }
+        )
+    except ValueError as exc:
+        return jsonify_with_status(
+            {
+                "success": False,
+                "request_id": request_id,
+                "error": {"type": "validation_error", "message": str(exc)},
+            },
+            400,
+        )
+    except Exception as exc:
+        log(f"ALWeaver editor: restart-state error: {exc!r}", "error")
+        return jsonify_with_status(
+            {
+                "success": False,
+                "request_id": request_id,
+                "error": {"type": "server_error", "message": str(exc)},
+            },
+            500,
+        )
+
+
+@app.route(f"{EDITOR_BASE_PATH}/api/server/restart", methods=["POST"])
+def editor_api_restart_server() -> Response:
+    """Restart every Docassemble process so module changes load.
+
+    The polling record is written before the restart is triggered, exactly as
+    Docassemble's own ``/restart_ajax`` does it: ``restart_all()`` takes down
+    the worker handling this request, so anything that has to survive the call
+    has to be in Redis before it.
+    """
+    request_id = str(uuid.uuid4())
+    if not _editor_auth_check():
+        return _auth_fail(request_id)
+    capability = _restart_capability()
+    if not capability["allowed"]:
+        return jsonify_with_status(
+            {
+                "success": False,
+                "request_id": request_id,
+                "error": {
+                    "type": "validation_error",
+                    "code": "restart_not_allowed",
+                    "message": capability["reason"],
+                },
+            },
+            409,
+        )
+    try:
+        uid = _current_user_id()
+        post_data = request.get_json(silent=True) or {}
+        project = _normalize_project(post_data.get("project"))
+        task_id = uuid.uuid4().hex
+        pipe = r.pipeline()
+        pipe.set(
+            restart_status_key(task_id),
+            json.dumps({"server_start_time": server_start_time()}),
+        )
+        pipe.expire(restart_status_key(task_id), 3600)
+        pipe.execute()
+        restart_docassemble()
+        clear_modules_dirty(r, uid, project)
+        return jsonify(
+            {
+                "success": True,
+                "request_id": request_id,
+                "data": {
+                    "task_id": task_id,
+                    "project": project,
+                    "disruption_seconds": list(RESTART_DISRUPTION_SECONDS),
+                },
+            }
+        )
+    except ValueError as exc:
+        return jsonify_with_status(
+            {
+                "success": False,
+                "request_id": request_id,
+                "error": {"type": "validation_error", "message": str(exc)},
+            },
+            400,
+        )
+    except Exception as exc:
+        log(f"ALWeaver editor: restart failed: {exc!r}", "error")
+        return jsonify_with_status(
+            {
+                "success": False,
+                "request_id": request_id,
+                "error": {
+                    "type": "server_error",
+                    "code": "restart_failed",
+                    "message": "The server could not be restarted.",
+                },
+            },
+            500,
+        )
+
+
+@app.route(f"{EDITOR_BASE_PATH}/api/server/restart-status", methods=["GET"])
+def editor_api_restart_status() -> Response:
+    """Poll a restart started by POST /api/server/restart.
+
+    Reads the same Redis record shape as Docassemble's ``check_restart_status``
+    so the two agree about what "finished" means: this process booted after the
+    restart was requested, and supervisor's reset program is no longer running.
+    """
+    request_id = str(uuid.uuid4())
+    if not _editor_auth_check():
+        return _auth_fail(request_id)
+    task_id = str(request.args.get("task_id") or "").strip()
+    if not task_id:
+        return jsonify_with_status(
+            {
+                "success": False,
+                "request_id": request_id,
+                "error": {"type": "validation_error", "message": "task_id is required"},
+            },
+            400,
+        )
+    try:
+        raw = r.get(restart_status_key(task_id))
+        if raw is None:
+            return jsonify(
+                {
+                    "success": True,
+                    "request_id": request_id,
+                    "data": {"task_id": task_id, "status": "unknown"},
+                }
+            )
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8", "replace")
+        requested_at = float(json.loads(raw).get("server_start_time") or 0)
+        working = server_start_time() <= requested_at or reset_process_is_running()
+        return jsonify(
+            {
+                "success": True,
+                "request_id": request_id,
+                "data": {
+                    "task_id": task_id,
+                    "status": "working" if working else "completed",
+                },
+            }
+        )
+    except Exception as exc:
+        log(f"ALWeaver editor: restart-status error: {exc!r}", "error")
         return jsonify_with_status(
             {
                 "success": False,
@@ -6882,6 +7488,9 @@ def _new_project_from_template(uid: int, request_id: str) -> Response:
             # the user's project chooser.
             delete_project(uid, project_name)
             raise
+        # An imported repository can bring Python modules with it, and no save
+        # went through the editor to install them.
+        _reconcile_project_modules(uid, project_name)
         return jsonify(
             {
                 "success": True,
@@ -6892,6 +7501,7 @@ def _new_project_from_template(uid: int, request_id: str) -> Response:
                     "github_url": snapshot["url"],
                     "github_branch": snapshot["branch"],
                     "files_imported": imported["files_imported"],
+                    "restart_state": _restart_state_payload(uid, project_name),
                 },
             }
         )

--- a/docassemble/ALWeaver/data/static/editor.js
+++ b/docassemble/ALWeaver/data/static/editor.js
@@ -1775,6 +1775,39 @@
     updateProjectSearchMode();
   }
 
+  // Saving a Python module cannot take effect until the server restarts. This
+  // controller keeps track of which projects are waiting for one and offers
+  // the restart at the moment the developer runs the interview.
+  var moduleRestart = window.ALWeaverModuleRestart
+    ? window.ALWeaverModuleRestart.createModuleRestartController({
+      api: { get: apiGet, post: apiPost },
+      document: document,
+      window: window,
+      getProject: function () { return state.project; },
+    })
+    : null;
+
+  function noteModuleSaveResult(data) {
+    if (moduleRestart) moduleRestart.noteSaveResult(data);
+  }
+
+  /* Uploads are the one path that can accept a module the editor would have
+   * refused to save, so the outcome per file is reported afterwards. */
+  function reportUploadedModuleProblems(data) {
+    var modules = (data && data.modules) || [];
+    var problems = modules.filter(function (entry) {
+      return entry && entry.status === 'not_published';
+    });
+    if (!problems.length) return;
+    window.alert(problems.map(function (entry) { return entry.message; }).join('\n\n'));
+  }
+
+  /* Resolves true when the caller should go ahead. */
+  function ensureModulesLoaded(actionLabel) {
+    if (!moduleRestart) return Promise.resolve(true);
+    return moduleRestart.ensureModulesLoaded(actionLabel);
+  }
+
   var runtimeInspector = window.ALWeaverRuntimeInspector.createRuntimeInspector({
     api: {
       get: apiGet,
@@ -1785,6 +1818,7 @@
       return { project: state.project, filename: state.filename };
     },
     getBlocks: function () { return state.blocks || []; },
+    beforeStart: function () { return ensureModulesLoaded('start a test session'); },
     onSessionChange: function (session) {
       state.runtimeTargetSession = session;
     },
@@ -4383,6 +4417,7 @@
 
   function loadFiles() {
     refreshGithubSyncAction();
+    if (moduleRestart) moduleRestart.refresh();
     if (!state.project) {
       state.files = [];
       state.filename = null;
@@ -5040,6 +5075,7 @@
         return false;
       }
       state.sectionDirty = false;
+      noteModuleSaveResult(res.data);
       state.sectionSavedContent[sectionSnapshotKey()] = contentVal;
       updateTopbarSaveState();
       var saveSectionBtn = document.getElementById('save-section-file');
@@ -8435,6 +8471,7 @@
         }
         state.sectionSelectedFile[state.currentView] = inlineNewName;
         state.sectionDirty = false;
+        noteModuleSaveResult(res.data);
         loadSectionFiles(state.currentView);
       });
       return;
@@ -8459,6 +8496,7 @@
           return;
         }
         state.sectionSelectedFile[state.currentView] = res.data && res.data.filename ? res.data.filename : sfNewName;
+        noteModuleSaveResult(res.data);
         loadSectionFiles(state.currentView);
       });
       return;
@@ -8501,6 +8539,7 @@
         if (state.sectionSelectedFile[state.currentView] === delName) {
           state.sectionSelectedFile[state.currentView] = null;
         }
+        noteModuleSaveResult(res.data);
         loadSectionFiles(state.currentView);
       });
       return;
@@ -8594,11 +8633,19 @@
       return;
     }
 
+    if (uiAction === 'restart-for-modules') {
+      if (moduleRestart) moduleRestart.openRestartDialog();
+      return;
+    }
+
     if (uiAction === 'open-standard-playground') {
       var standardPlaygroundUrl = buildStandardPlaygroundUrl();
       if (standardPlaygroundUrl) {
         promptAndSaveUnsavedChanges('open the playground').then(function (saved) {
-          if (saved) window.open(standardPlaygroundUrl, '_blank');
+          if (!saved) return;
+          return ensureModulesLoaded('open the playground').then(function (proceed) {
+            if (proceed) window.open(standardPlaygroundUrl, '_blank');
+          });
         });
       }
       return;
@@ -8631,6 +8678,7 @@
         }
         state.sectionSelectedFile[state.currentView] = filenamePrompt;
         state.sectionDirty = false;
+        noteModuleSaveResult(res.data);
         loadSectionFiles(state.currentView);
       });
       return;
@@ -8654,6 +8702,7 @@
           return;
         }
         state.sectionSelectedFile[state.currentView] = res.data && res.data.filename ? res.data.filename : renamedSectionFile;
+        noteModuleSaveResult(res.data);
         loadSectionFiles(state.currentView);
       });
       return;
@@ -8675,6 +8724,7 @@
           return;
         }
         state.sectionSelectedFile[state.currentView] = null;
+        noteModuleSaveResult(res.data);
         loadSectionFiles(state.currentView);
       });
       return;
@@ -8849,8 +8899,14 @@
       if (!state.filename) return;
       promptAndSaveUnsavedChanges('open the interview').then(function (saved) {
         if (!saved) return;
-        apiGet('/api/preview-url?project=' + encodeURIComponent(state.project) + '&filename=' + encodeURIComponent(state.filename))
-          .then(function (res) { if (res.success && res.data && res.data.url) window.open(res.data.url, '_blank'); });
+        // The restart is deferred to here rather than to the module save, so
+        // several edits cost one restart and it lands while the developer is
+        // already waiting on a new tab.
+        return ensureModulesLoaded('run the interview').then(function (proceed) {
+          if (!proceed) return;
+          return apiGet('/api/preview-url?project=' + encodeURIComponent(state.project) + '&filename=' + encodeURIComponent(state.filename))
+            .then(function (res) { if (res.success && res.data && res.data.url) window.open(res.data.url, '_blank'); });
+        });
       });
       return;
     }
@@ -9673,6 +9729,8 @@
             state.sectionSelectedFile[state.currentView] = res.data.saved_files[0];
           }
           state.sectionDirty = false;
+          noteModuleSaveResult(res.data);
+          reportUploadedModuleProblems(res.data);
           loadSectionFiles(state.currentView);
         })
         .finally(function () {

--- a/docassemble/ALWeaver/data/static/editor_module_restart.js
+++ b/docassemble/ALWeaver/data/static/editor_module_restart.js
@@ -1,0 +1,307 @@
+/* Deferred server restarts for Playground Python module changes.
+ *
+ * Docassemble loads a module once per server process, so editing one has no
+ * effect until every process restarts. The stock Playground restarts the
+ * server the moment you press Save. This controller defers that: saving marks
+ * the project as having pending module changes, and the restart is offered at
+ * the point the developer actually runs the interview, where they are already
+ * waiting on a new tab. Several module edits then cost one restart instead of
+ * one each.
+ *
+ * Restarting is server-wide and disruptive, so the developer is told what it
+ * costs and can always decline and keep working.
+ */
+(function (root, factory) {
+  'use strict';
+  var api = factory();
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  root.ALWeaverModuleRestart = api;
+})(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+  'use strict';
+
+  var POLL_INTERVAL_MS = 3000;
+  var POLL_TIMEOUT_MS = 180000;
+
+  function describeFiles(files) {
+    var names = (files || []).map(function (entry) {
+      return entry && entry.filename ? String(entry.filename) : '';
+    }).filter(Boolean);
+    if (!names.length) return '';
+    if (names.length === 1) return names[0];
+    if (names.length === 2) return names[0] + ' and ' + names[1];
+    return names.slice(0, -1).join(', ') + ', and ' + names[names.length - 1];
+  }
+
+  function createModuleRestartController(options) {
+    options = options || {};
+    var api = options.api;
+    var doc = options.document;
+    var win = options.window;
+    var getProject = options.getProject || function () { return null; };
+    var sleep = options.sleep || function (ms) {
+      return new Promise(function (resolve) { win.setTimeout(resolve, ms); });
+    };
+    var now = options.now || function () { return Date.now(); };
+    var state = null;
+    var restartInFlight = null;
+    // The modal is a single static element, so a second prompt opened before
+    // the first is answered would double-register the button handlers.
+    var promptInFlight = null;
+
+    function el(id) {
+      return doc ? doc.getElementById(id) : null;
+    }
+
+    function currentState() {
+      return state;
+    }
+
+    function renderBanner() {
+      var banner = el('editor-module-restart-banner');
+      if (!banner) return;
+      if (!state || !state.pending) {
+        banner.classList.add('d-none');
+        return;
+      }
+      var message = banner.querySelector('[data-module-restart-banner-message]');
+      if (message) {
+        var listed = describeFiles(state.files);
+        message.textContent = listed
+          ? ('Restart the server to load ' + listed + '.')
+          : 'Restart the server to load them.';
+      }
+      var button = banner.querySelector('[data-action="restart-for-modules"]');
+      if (button) {
+        // A server that cannot restart itself still gets the banner, so the
+        // developer knows why their module has no effect, but no button that
+        // would only fail.
+        button.classList.toggle('d-none', !state.restart_allowed);
+      }
+      banner.classList.remove('d-none');
+    }
+
+    function adopt(payload) {
+      if (payload && typeof payload === 'object') state = payload;
+      renderBanner();
+      return state;
+    }
+
+    /* Pick up the restart_state a save response carries, so the banner appears
+     * the moment a module is saved without a second round trip. */
+    function noteSaveResult(data) {
+      if (data && data.restart_state) adopt(data.restart_state);
+      return state;
+    }
+
+    function refresh() {
+      var project = getProject();
+      if (!project) return Promise.resolve(state);
+      return api.get('/api/server/restart-state?project=' + encodeURIComponent(project))
+        .then(function (response) {
+          return adopt(response && response.data);
+        })
+        .catch(function () {
+          // The banner is advisory; a failed poll must not interrupt editing.
+          return state;
+        });
+    }
+
+    function setProgress(text) {
+      var progress = el('module-restart-progress');
+      var label = el('module-restart-progress-text');
+      if (label && text) label.textContent = text;
+      if (progress) progress.classList.toggle('d-none', !text);
+    }
+
+    function setError(text) {
+      var alertEl = el('module-restart-error');
+      if (!alertEl) return;
+      alertEl.textContent = String(text || '');
+      alertEl.classList.toggle('d-none', !text);
+    }
+
+    function pollUntilRestarted(taskId) {
+      var deadline = now() + POLL_TIMEOUT_MS;
+      function tick() {
+        if (now() > deadline) {
+          // The server is normally back well inside this window. Saying so is
+          // more useful than spinning forever.
+          return Promise.resolve(false);
+        }
+        return sleep(POLL_INTERVAL_MS)
+          .then(function () {
+            return api.get('/api/server/restart-status?task_id=' + encodeURIComponent(taskId));
+          })
+          .then(function (response) {
+            var status = response && response.data ? response.data.status : '';
+            if (status === 'completed') return true;
+            return tick();
+          })
+          .catch(function () {
+            // Requests fail while the workers are down; that is the expected
+            // middle of a restart, not an error worth reporting.
+            return tick();
+          });
+      }
+      return tick();
+    }
+
+    /* Trigger a restart and resolve once the server answers again. */
+    function restartNow() {
+      if (restartInFlight) return restartInFlight;
+      var project = getProject();
+      setError('');
+      setProgress('Restarting the server… this normally takes 10 to 30 seconds.');
+      restartInFlight = api.post('/api/server/restart', { project: project })
+        .then(function (response) {
+          var taskId = response && response.data ? response.data.task_id : null;
+          if (!taskId) return false;
+          return pollUntilRestarted(taskId);
+        })
+        .then(function (completed) {
+          setProgress('');
+          if (completed) {
+            state = null;
+            renderBanner();
+          } else {
+            setProgress('The server is taking longer than usual to come back. It should finish shortly.');
+          }
+          return completed;
+        })
+        .catch(function (error) {
+          setProgress('');
+          setError((error && error.message) || 'The server could not be restarted.');
+          throw error;
+        })
+        .finally(function () {
+          restartInFlight = null;
+        });
+      return restartInFlight;
+    }
+
+    function openModal() {
+      if (!win || !win.bootstrap || !win.bootstrap.Modal) return null;
+      var node = el('module-restart-modal');
+      if (!node) return null;
+      return win.bootstrap.Modal.getOrCreateInstance(node);
+    }
+
+    function fillModal(actionLabel, allowSkip) {
+      var list = el('module-restart-files');
+      if (list) {
+        list.innerHTML = '';
+        (state.files || []).forEach(function (entry) {
+          var item = doc.createElement('li');
+          item.textContent = entry.reason && entry.reason !== 'changed'
+            ? (entry.filename + ' (' + entry.reason + ')')
+            : entry.filename;
+          list.appendChild(item);
+        });
+      }
+      var message = el('module-restart-message');
+      if (message) {
+        message.textContent = actionLabel
+          ? ('Before you ' + actionLabel
+            + ', note that these Python modules have changed since the server last started:')
+          : 'These Python modules have changed since the server last started:';
+      }
+      var restartButton = doc.querySelector('[data-module-restart-choice="restart"]');
+      if (restartButton) restartButton.classList.toggle('d-none', !state.restart_allowed);
+      // Asked from the banner there is no pending action to continue to, so
+      // the only choices are restarting and closing the dialog.
+      var skipButton = doc.querySelector('[data-module-restart-choice="skip"]');
+      if (skipButton) skipButton.classList.toggle('d-none', !allowSkip);
+      var cancelButton = doc.querySelector('[data-module-restart-choice="cancel"]');
+      if (cancelButton) cancelButton.textContent = allowSkip ? 'Cancel' : 'Not now';
+      setError(state.restart_allowed ? '' : state.restart_blocked_reason);
+      setProgress('');
+    }
+
+    /* Resolves true to go ahead with the action, false if the developer
+     * cancelled it. */
+    function promptForRestart(actionLabel, allowSkip) {
+      var modal = openModal();
+      if (!modal) {
+        // Without Bootstrap there is no modal to show; never block the action.
+        return Promise.resolve(true);
+      }
+      if (promptInFlight) return promptInFlight;
+      fillModal(actionLabel, allowSkip !== false);
+      promptInFlight = new Promise(function (resolve) {
+        var buttons = Array.prototype.slice.call(
+          doc.querySelectorAll('[data-module-restart-choice]')
+        );
+
+        function cleanup() {
+          buttons.forEach(function (button) {
+            button.removeEventListener('click', onClick);
+            button.disabled = false;
+          });
+        }
+
+        function finish(result) {
+          cleanup();
+          promptInFlight = null;
+          modal.hide();
+          resolve(result);
+        }
+
+        function onClick(event) {
+          var choice = event.currentTarget.getAttribute('data-module-restart-choice');
+          if (choice === 'cancel') return finish(false);
+          if (choice === 'skip') return finish(true);
+          buttons.forEach(function (button) { button.disabled = true; });
+          restartNow()
+            .then(function () { finish(true); })
+            .catch(function () {
+              // The failure is already shown in the modal; let the developer
+              // decide whether to continue anyway.
+              buttons.forEach(function (button) { button.disabled = false; });
+            });
+        }
+
+        buttons.forEach(function (button) {
+          button.addEventListener('click', onClick);
+        });
+        modal.show();
+      });
+      return promptInFlight;
+    }
+
+    /* Call before anything that runs the interview. Resolves true if the
+     * caller should proceed. */
+    function ensureModulesLoaded(actionLabel) {
+      return refresh().then(function (current) {
+        if (!current || !current.pending) return true;
+        if (current.policy === 'never') return true;
+        if (current.policy === 'auto' && current.restart_allowed) {
+          return restartNow().then(function () { return true; }, function () { return true; });
+        }
+        return promptForRestart(actionLabel, true);
+      });
+    }
+
+    /* The banner's own button: same dialog, but with nothing to continue to. */
+    function openRestartDialog() {
+      return refresh().then(function (current) {
+        if (!current || !current.pending) return false;
+        return promptForRestart(null, false);
+      });
+    }
+
+    return {
+      currentState: currentState,
+      ensureModulesLoaded: ensureModulesLoaded,
+      openRestartDialog: openRestartDialog,
+      noteSaveResult: noteSaveResult,
+      refresh: refresh,
+      renderBanner: renderBanner,
+      restartNow: restartNow,
+    };
+  }
+
+  return {
+    createModuleRestartController: createModuleRestartController,
+    describeFiles: describeFiles,
+  };
+});

--- a/docassemble/ALWeaver/data/static/editor_runtime_inspector.js
+++ b/docassemble/ALWeaver/data/static/editor_runtime_inspector.js
@@ -48,6 +48,9 @@
     var getContext = options.getContext;
     var getBlocks = options.getBlocks || function () { return []; };
     var onSessionChange = options.onSessionChange || function () {};
+    // Runs before a test session is created, so pending Python module changes
+    // can be loaded first. Resolving false abandons the start.
+    var beforeStart = options.beforeStart || function () { return Promise.resolve(true); };
     var session = null;
     var question = null;
     var variables = {};
@@ -71,25 +74,28 @@
 
     function startSession() {
       var context = getContext();
-      setStatus('Starting a separate Docassemble test session...');
-      render(container);
-      return api.post('/api/runtime/sessions', {
-        project: context.project,
-        filename: context.filename,
-        purpose: 'test',
-      }).then(function (response) {
-        session = clone(response.data);
-        question = null;
-        variables = {};
-        previousVariables = {};
-        changed = [];
-        onSessionChange(clone(session));
-        setStatus('Test session started.');
+      return Promise.resolve(beforeStart()).then(function (proceed) {
+        if (proceed === false) return undefined;
+        setStatus('Starting a separate Docassemble test session...');
         render(container);
-        return refreshAll();
-      }).catch(function (requestError) {
-        setStatus(requestError.message || 'Unable to start the test session.', true);
-        render(container);
+        return api.post('/api/runtime/sessions', {
+          project: context.project,
+          filename: context.filename,
+          purpose: 'test',
+        }).then(function (response) {
+          session = clone(response.data);
+          question = null;
+          variables = {};
+          previousVariables = {};
+          changed = [];
+          onSessionChange(clone(session));
+          setStatus('Test session started.');
+          render(container);
+          return refreshAll();
+        }).catch(function (requestError) {
+          setStatus(requestError.message || 'Unable to start the test session.', true);
+          render(container);
+        });
       });
     }
 

--- a/docassemble/ALWeaver/data/templates/editor.html
+++ b/docassemble/ALWeaver/data/templates/editor.html
@@ -62,6 +62,15 @@
     <a data-celery-warning-docs target="_blank" rel="noopener noreferrer">View setup instructions</a>.
   </div>
 
+  <div class="alert alert-info rounded-0 border-start-0 border-end-0 mb-0 d-none d-flex flex-wrap align-items-center gap-2"
+       id="editor-module-restart-banner" role="status" aria-live="polite">
+    <span class="flex-grow-1">
+      <strong>Python module changes are waiting for a server restart.</strong>
+      <span data-module-restart-banner-message></span>
+    </span>
+    <button type="button" class="btn btn-sm btn-primary" data-action="restart-for-modules">Restart now</button>
+  </div>
+
   <!-- ===== MAIN LAYOUT ===== -->
   <div class="editor-layout" id="editor-layout">
 
@@ -329,6 +338,43 @@
   </div>
 </div>
 
+<!-- Pending Python module changes need a server restart -->
+<div class="modal fade" id="module-restart-modal" tabindex="-1"
+     aria-labelledby="module-restart-title" aria-describedby="module-restart-message"
+     data-bs-backdrop="static" data-bs-keyboard="false">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="module-restart-title">Restart to load your module changes?</h5>
+      </div>
+      <div class="modal-body">
+        <p id="module-restart-message">These Python modules have changed since the server last started:</p>
+        <ul class="mb-3" id="module-restart-files"></ul>
+        <p class="mb-3">Docassemble loads a module once per server process, so your
+          changes will not take effect until it restarts.</p>
+        <div class="alert alert-warning" role="alert" id="module-restart-warning">
+          <strong>Restarting interrupts everyone on this server for about 10&ndash;30 seconds.</strong>
+          Pages will be slow to respond while it comes back, and any documents
+          being assembled in the background are cancelled. Nobody loses their
+          saved answers.
+        </div>
+        <div class="alert alert-danger d-none" id="module-restart-error" role="alert"></div>
+        <div class="d-none" id="module-restart-progress">
+          <div class="d-flex align-items-center gap-2">
+            <div class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></div>
+            <span id="module-restart-progress-text">Restarting the server&hellip;</span>
+          </div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-module-restart-choice="cancel">Cancel</button>
+        <button type="button" class="btn btn-outline-secondary" data-module-restart-choice="skip">Continue without restarting</button>
+        <button type="button" class="btn btn-primary" data-module-restart-choice="restart">Restart now</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <!-- Insert Block Modal -->
 <div class="modal fade" id="insert-modal" tabindex="-1">
   <div class="modal-dialog">
@@ -545,6 +591,7 @@
 <script src="/al/editor/static/editor_validation_source.js"></script>
 <script src="/al/editor/static/editor_screen_preview.js"></script>
 <script src="/al/editor/static/editor_runtime_inspector.js"></script>
+<script src="/al/editor/static/editor_module_restart.js"></script>
 <script src="/al/editor/static/editor_agent_chat.js"></script>
 <script src="/al/editor/static/editor.js"></script>
 </body>

--- a/docassemble/ALWeaver/docassemble_compat.py
+++ b/docassemble/ALWeaver/docassemble_compat.py
@@ -374,6 +374,114 @@ def background_context() -> AbstractContextManager[Any]:
     return context_factory()
 
 
+def _optional_webapp_attr(candidates: Sequence[Tuple[str, str]]) -> Any:
+    """Like :func:`_first_webapp_attr` but returns ``None`` instead of raising.
+
+    Used for the restart machinery, which an installation is allowed not to
+    have: a server with restarting disabled should degrade to an explanation,
+    not a 500.
+    """
+    try:
+        return _first_webapp_attr(candidates, "this capability")
+    except BaseException:  # pylint: disable=broad-except
+        # Importing a webapp module can do more than fail: reading the server
+        # configuration calls sys.exit when there is no config file. An
+        # optional capability must not take the caller down with it.
+        return None
+
+
+def full_package_directory() -> Optional[str]:
+    """The site-packages root Docassemble installs packages into.
+
+    1.9.x computes it in ``webapp.server``; 1.10.x moved it to
+    ``webapp.config``.
+    """
+    value = _optional_webapp_attr(
+        (
+            ("docassemble.webapp.config", "FULL_PACKAGE_DIRECTORY"),
+            ("docassemble.webapp.server", "FULL_PACKAGE_DIRECTORY"),
+        )
+    )
+    return str(value) if value else None
+
+
+def server_start_time() -> float:
+    """When the process serving this request booted.
+
+    Read out of the already-imported module where possible. Importing
+    ``docassemble.base.config`` has the side effect of loading the server
+    configuration, which calls ``sys.exit`` when there is no config file — fine
+    inside a real server, fatal anywhere else.
+    """
+    module = sys.modules.get("docassemble.base.config")
+    if module is None:
+        try:
+            module = importlib.import_module("docassemble.base.config")
+        except BaseException:  # pylint: disable=broad-except
+            return 0.0
+    try:
+        return float(getattr(module, "START_TIME", 0.0))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def reset_process_is_running() -> bool:
+    """Whether supervisor's ``reset`` program is still working."""
+    func = _optional_webapp_attr(
+        (
+            ("docassemble.webapp.utils.helpers", "reset_process_running"),
+            ("docassemble.webapp.server", "reset_process_running"),
+        )
+    )
+    if not callable(func):
+        return False
+    try:
+        return bool(func())
+    except Exception:
+        return False
+
+
+def restart_docassemble() -> None:
+    """Restart every Docassemble process, the way ``/restart_ajax`` does.
+
+    1.9.x defines ``restart_all`` in ``webapp.server``; 1.10.x moved it to
+    ``webapp.main.helpers``. It clears the cached interview sources, restarts
+    the other hosts, and then restarts this one, which is why the caller must
+    have already written its polling record before calling this.
+    """
+    func = _optional_webapp_attr(
+        (
+            ("docassemble.webapp.main.helpers", "restart_all"),
+            ("docassemble.webapp.server", "restart_all"),
+        )
+    )
+    if not callable(func):
+        raise DocassembleCompatibilityError(
+            "This Docassemble installation does not expose a way to restart"
+        )
+    func()
+
+
+def bump_interview_source_index(yaml_filename: str) -> None:
+    """Invalidate every worker's cached parse of one interview.
+
+    ``interview_cache`` validates its per-process cache against the Redis
+    counter ``da:interviewsource:<path>``, so without this bump a worker that
+    has already parsed the file keeps serving the old questions. Docassemble
+    does it for ``/interview`` requests carrying ``cache=0``; anything else
+    that starts a session against freshly edited YAML has to do it itself.
+    """
+    try:
+        import docassemble.base.parse  # type: ignore
+
+        docassemble.base.parse.interview_source_from_string(
+            yaml_filename
+        ).update_index()
+    except Exception:
+        # A stale parse is a much smaller problem than a failed session start.
+        pass
+
+
 def create_saved_file(*args: Any, **kwargs: Any) -> Any:
     saved_file = _first_webapp_attr(
         (

--- a/docassemble/ALWeaver/editor_modules.py
+++ b/docassemble/ALWeaver/editor_modules.py
@@ -1,0 +1,373 @@
+# do not pre-load
+
+"""Safe saving of Playground Python modules from the Weaver editor.
+
+Docassemble does not load a Playground module from the place the Playground
+saves it. Saved modules live in the ``playgroundmodules`` storage area, but an
+interview importing ``docassemble.playground7Housing.util`` resolves that name
+against ``site-packages/docassemble/playground7Housing/``. Copying between the
+two happens in the server's ``copy_playground_modules()``, which runs *only at
+startup* — in 1.9.x from ``server.py`` and in 1.10.x from
+``webapp/develop/helpers.py``, called from ``startup.py`` in both.
+
+That is why the stock Playground redirects to ``/restart`` after every module
+save, and why a module saved without a restart has no effect whatsoever: the
+bytes never reach the directory Python imports from.
+
+This module implements a less disruptive version of the same contract:
+
+* **New modules go live immediately.** A file that does not exist in the
+  package directory yet cannot be in any worker's ``sys.modules``, so copying
+  it across and invalidating the import caches is enough — no restart.
+* **Changed, renamed, and deleted modules mark the project dirty.** Those need
+  every worker process to drop its ``sys.modules`` entry, which only a restart
+  does. The flag is recorded and the restart is deferred until the developer
+  actually runs the interview.
+* **Broken modules are refused at save time.** The stock Playground will
+  happily save a module that does not compile and restart the server for it;
+  the failure then surfaces far from the edit. A compile check costs nothing.
+
+Nothing here imports Docassemble, so it is testable on its own; callers pass
+in the Redis client, the package root, and the server start time.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import re
+import time
+from typing import Any, Dict, List, Optional
+
+__all__ = [
+    "MODULE_FILENAME_PATTERN",
+    "ModuleSyntaxError",
+    "RESTART_POLICIES",
+    "check_module_syntax",
+    "clear_modules_dirty",
+    "mark_modules_dirty",
+    "module_package_directory",
+    "modules_dirty_key",
+    "normalize_restart_policy",
+    "publish_module_source",
+    "read_modules_dirty",
+    "restart_status_key",
+    "validate_module_filename",
+]
+
+
+# ``copy_playground_modules`` only ever copies files matching this shape:
+#
+#     [f for f in os.listdir(mod_directory) if re.search(r'^[A-Za-z].*\.py$', f)]
+#
+# A module called ``_helpers.py`` or ``2col.py`` is therefore saved happily and
+# then silently never loaded, in the stock Playground as much as here. We reject
+# those names up front rather than let the developer find out at runtime. The
+# stricter tail (identifier characters only) is ours: a name that is not a
+# Python identifier cannot be written in a ``modules:`` block anyway.
+MODULE_FILENAME_PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9_]*\.py$")
+
+MODULES_DIRTY_KEY_PREFIX = "da:weaver:modules_dirty:"
+MODULES_DIRTY_TTL_SECONDS = 30 * 24 * 60 * 60
+
+# Shared with Docassemble's own /restart machinery, deliberately: the polling
+# endpoint has to agree with whatever else on the server may have started a
+# restart, and the server's own check_restart_status reads this same key shape.
+RESTART_STATUS_KEY_PREFIX = "da:restart_status:"
+RESTART_STATUS_TTL_SECONDS = 3600
+
+RESTART_POLICIES = ("prompt", "auto", "never")
+DEFAULT_RESTART_POLICY = "prompt"
+
+# What a restart actually costs, quoted to the developer before they trigger
+# one. reset.sh stops and starts celery, rabbitmq, and websockets, and touches
+# the wsgi file; ten to thirty seconds is the normal range on a healthy server.
+RESTART_DISRUPTION_SECONDS = (10, 30)
+
+
+class ModuleSyntaxError(ValueError):
+    """A module was saved with source that does not compile.
+
+    Carries the position so the editor can put the cursor on the offending
+    line instead of just showing a message.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        filename: str,
+        line: Optional[int] = None,
+        offset: Optional[int] = None,
+        text: Optional[str] = None,
+    ):
+        super().__init__(message)
+        self.filename = filename
+        self.line = line
+        self.offset = offset
+        self.text = text
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "type": "module_syntax_error",
+            "message": str(self),
+            "filename": self.filename,
+            "line": self.line,
+            "offset": self.offset,
+            "text": self.text,
+        }
+
+
+def validate_module_filename(filename: str) -> None:
+    """Raise ``ValueError`` unless Docassemble will actually load this name."""
+    name = str(filename or "").strip()
+    if not name:
+        raise ValueError("A module needs a filename")
+    if not name.endswith(".py"):
+        raise ValueError(f"{name} is not a Python module: the name must end in .py")
+    if not MODULE_FILENAME_PATTERN.match(name):
+        raise ValueError(
+            f"{name} would be saved but never loaded. Docassemble only imports "
+            "modules whose names start with a letter and contain only letters, "
+            "numbers, and underscores — for example utility.py or "
+            "custom_fields.py."
+        )
+
+
+def check_module_syntax(filename: str, content: str) -> None:
+    """Compile the source, raising :class:`ModuleSyntaxError` if it will not.
+
+    This catches syntax errors only. A module that compiles can still raise on
+    import; nothing short of importing it would find that, and importing
+    untrusted source in the request handler is exactly what we are avoiding.
+    """
+    try:
+        compile(content, filename, "exec")
+    except SyntaxError as exc:
+        detail = exc.msg or "invalid syntax"
+        where = f" on line {exc.lineno}" if exc.lineno else ""
+        raise ModuleSyntaxError(
+            f"{filename} has a Python syntax error{where}: {detail}",
+            filename=filename,
+            line=exc.lineno,
+            offset=exc.offset,
+            text=(exc.text or "").rstrip("\n") or None,
+        ) from exc
+    except ValueError as exc:
+        # Source containing a null byte, and similar, raise ValueError here.
+        raise ModuleSyntaxError(
+            f"{filename} could not be compiled: {exc}",
+            filename=filename,
+        ) from exc
+
+
+def module_package_name(user_id: int, project: str) -> str:
+    """The importable package a project's modules live under."""
+    suffix = "" if project == "default" else str(project)
+    return f"docassemble.playground{int(user_id)}{suffix}"
+
+
+def module_package_directory(
+    package_root: Optional[str], user_id: int, project: str
+) -> Optional[str]:
+    """Where ``copy_playground_modules`` puts this project's modules.
+
+    Mirrors the server's own path construction: ``playground<uid>`` for the
+    default project and ``playground<uid><project>`` for a named one.
+    """
+    if not package_root:
+        return None
+    suffix = "" if project == "default" else str(project)
+    return os.path.join(
+        str(package_root), "docassemble", f"playground{int(user_id)}{suffix}"
+    )
+
+
+def publish_module_source(
+    *,
+    package_root: Optional[str],
+    user_id: int,
+    project: str,
+    filename: str,
+    content: str,
+) -> str:
+    """Copy one module into the importable package directory.
+
+    Returns:
+        ``"live"``
+            The module was not there before, so no worker can be holding an
+            older version of it in ``sys.modules``. It is importable now.
+        ``"restart_required"``
+            An existing module was overwritten. Workers that already imported
+            it keep the old code until the processes restart.
+        ``"unavailable"``
+            The package directory could not be written — a read-only file
+            system, or a server that does not expose its package root. The
+            caller should fall back to requiring a restart.
+    """
+    target_dir = module_package_directory(package_root, user_id, project)
+    if not target_dir:
+        return "unavailable"
+    target = os.path.join(target_dir, filename)
+    try:
+        existed = os.path.exists(target)
+        os.makedirs(target_dir, exist_ok=True)
+        # Written under a temporary name and renamed so that a worker importing
+        # concurrently sees either the whole old file or the whole new one, and
+        # so the directory mtime changes on completion rather than on creation.
+        staging = os.path.join(target_dir, f".weaver-{os.getpid()}-{filename}")
+        with open(staging, "w", encoding="utf-8") as fh:
+            fh.write(content)
+        os.replace(staging, target)
+    except OSError:
+        return "unavailable"
+    # Python caches each directory's listing keyed on its mtime, so a sibling
+    # worker process would normally notice the new file by itself. Coarse mtime
+    # granularity can defeat that within the same second, and invalidating here
+    # at least guarantees it for this process.
+    importlib.invalidate_caches()
+    return "restart_required" if existed else "live"
+
+
+def unpublish_module(
+    *, package_root: Optional[str], user_id: int, project: str, filename: str
+) -> bool:
+    """Remove a module from the importable package directory.
+
+    Deleting the copy stops the *next* import from succeeding, but any worker
+    that already imported it keeps the module object, so the caller still has
+    to mark the project dirty.
+    """
+    target_dir = module_package_directory(package_root, user_id, project)
+    if not target_dir:
+        return False
+    try:
+        os.remove(os.path.join(target_dir, filename))
+    except OSError:
+        return False
+    importlib.invalidate_caches()
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Pending-restart bookkeeping
+# ---------------------------------------------------------------------------
+
+
+def modules_dirty_key(user_id: int, project: str) -> str:
+    return f"{MODULES_DIRTY_KEY_PREFIX}{int(user_id)}:{project}"
+
+
+def restart_status_key(code: str) -> str:
+    return f"{RESTART_STATUS_KEY_PREFIX}{code}"
+
+
+def _decode(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        return value.decode("utf-8", "replace")
+    return str(value)
+
+
+def _redis_set(redis: Any, key: str, value: str, ttl: int) -> None:
+    pipe = redis.pipeline()
+    pipe.set(key, value)
+    pipe.expire(key, ttl)
+    pipe.execute()
+
+
+def mark_modules_dirty(
+    redis: Any,
+    user_id: int,
+    project: str,
+    filename: str,
+    *,
+    server_start_time: float,
+    reason: str = "changed",
+) -> Dict[str, Any]:
+    """Record that this project has module changes awaiting a restart."""
+    key = modules_dirty_key(user_id, project)
+    state = _read_raw_dirty(redis, key) or {}
+    files: List[Dict[str, str]] = [
+        entry
+        for entry in state.get("files", [])
+        if isinstance(entry, dict) and entry.get("filename") != filename
+    ]
+    files.append({"filename": filename, "reason": reason})
+    payload = {
+        "files": sorted(files, key=lambda entry: entry.get("filename", "")),
+        "since": float(state.get("since") or time.time()),
+        "server_start_time": float(server_start_time),
+    }
+    _redis_set(redis, key, json.dumps(payload), MODULES_DIRTY_TTL_SECONDS)
+    return payload
+
+
+def _read_raw_dirty(redis: Any, key: str) -> Optional[Dict[str, Any]]:
+    raw = _decode(redis.get(key))
+    if not raw:
+        return None
+    try:
+        state = json.loads(raw)
+    except ValueError:
+        return None
+    return state if isinstance(state, dict) else None
+
+
+def read_modules_dirty(
+    redis: Any, user_id: int, project: str, *, server_start_time: float
+) -> Optional[Dict[str, Any]]:
+    """Return the pending module changes, or ``None`` if there are none.
+
+    A flag set before the currently running process booted is stale: the server
+    has restarted since — by our hand, by the stock Playground, or by a package
+    install — and the modules are loaded. Those flags clear themselves, so a
+    restart from anywhere counts.
+    """
+    key = modules_dirty_key(user_id, project)
+    state = _read_raw_dirty(redis, key)
+    if not state:
+        return None
+    try:
+        marked_at = float(state.get("server_start_time") or 0)
+    except (TypeError, ValueError):
+        marked_at = 0.0
+    if server_start_time > marked_at:
+        clear_modules_dirty(redis, user_id, project)
+        return None
+    files = [
+        entry
+        for entry in state.get("files", [])
+        if isinstance(entry, dict) and entry.get("filename")
+    ]
+    if not files:
+        return None
+    return {"files": files, "since": state.get("since")}
+
+
+def clear_modules_dirty(redis: Any, user_id: int, project: str) -> None:
+    key = modules_dirty_key(user_id, project)
+    delete = getattr(redis, "delete", None)
+    if callable(delete):
+        try:
+            delete(key)
+            return
+        except Exception:  # pragma: no cover - redis client differences
+            pass
+    _redis_set(redis, key, json.dumps({"files": []}), 60)
+
+
+def normalize_restart_policy(raw: Any) -> str:
+    """Coerce the configured restart policy, defaulting to ``prompt``."""
+    text = str(raw or "").strip().lower().replace("_", " ").replace("-", " ")
+    if text in RESTART_POLICIES:
+        return text
+    if text in {"ask", "confirm"}:
+        return "prompt"
+    if text in {"always", "automatic", "immediately"}:
+        return "auto"
+    if text in {"off", "false", "no", "manual", "none"}:
+        return "never"
+    return DEFAULT_RESTART_POLICY

--- a/docassemble/ALWeaver/test_editor_module_restart.py
+++ b/docassemble/ALWeaver/test_editor_module_restart.py
@@ -1,0 +1,591 @@
+# do not pre-load
+
+"""Saving Playground Python modules, and the deferred restart that loads them."""
+
+import json
+import os
+import tempfile
+import types
+import unittest
+from unittest.mock import patch
+
+from .editor_modules import (
+    ModuleSyntaxError,
+    check_module_syntax,
+    clear_modules_dirty,
+    mark_modules_dirty,
+    module_package_directory,
+    normalize_restart_policy,
+    publish_module_source,
+    read_modules_dirty,
+    unpublish_module,
+    validate_module_filename,
+)
+from .test_editor_api import api_editor
+
+
+class FakeRedis:
+    """Enough Redis for the dirty flag and the restart-status record."""
+
+    def __init__(self):
+        self.values = {}
+
+    def get(self, key):
+        return self.values.get(key)
+
+    def delete(self, key):
+        self.values.pop(key, None)
+
+    def pipeline(self):
+        store = self.values
+
+        class _Pipe:
+            def __init__(self):
+                self.pending = []
+
+            def set(self, key, value):
+                self.pending.append((key, value))
+                return self
+
+            def expire(self, key, seconds):
+                return self
+
+            def execute(self):
+                for key, value in self.pending:
+                    store[key] = value
+                self.pending = []
+
+        return _Pipe()
+
+
+class TestModuleFilenames(unittest.TestCase):
+    def test_names_docassemble_would_never_import_are_refused(self):
+        # copy_playground_modules only copies files matching ^[A-Za-z].*\.py$,
+        # so these would be saved and then silently never loaded.
+        for bad in ("_helpers.py", "2col.py", ".hidden.py", "util", "util.txt"):
+            with self.subTest(filename=bad):
+                with self.assertRaises(ValueError):
+                    validate_module_filename(bad)
+
+    def test_ordinary_module_names_are_accepted(self):
+        for good in ("util.py", "custom_fields.py", "Housing2.py"):
+            with self.subTest(filename=good):
+                validate_module_filename(good)
+
+
+class TestModuleSyntaxCheck(unittest.TestCase):
+    def test_a_syntax_error_reports_where_it_is(self):
+        with self.assertRaises(ModuleSyntaxError) as caught:
+            check_module_syntax("util.py", "def broken(:\n    pass\n")
+        self.assertEqual(caught.exception.filename, "util.py")
+        self.assertEqual(caught.exception.line, 1)
+        self.assertIn("util.py", str(caught.exception))
+
+    def test_source_that_compiles_passes(self):
+        check_module_syntax("util.py", "def fine():\n    return 1\n")
+
+    def test_a_module_that_compiles_but_would_fail_on_import_is_not_run(self):
+        # Importing to find this would mean executing the developer's code in
+        # the request handler, which is exactly what the compile check avoids.
+        check_module_syntax("util.py", "raise RuntimeError('boom')\n")
+
+
+class TestPublishingModules(unittest.TestCase):
+    def setUp(self):
+        self.root = tempfile.mkdtemp()
+
+    def _publish(self, filename, content, project="default"):
+        return publish_module_source(
+            package_root=self.root,
+            user_id=7,
+            project=project,
+            filename=filename,
+            content=content,
+        )
+
+    def test_a_new_module_goes_live_without_a_restart(self):
+        # Nothing can be holding it in sys.modules, so copying it across is
+        # enough.
+        self.assertEqual(self._publish("util.py", "X = 1\n"), "live")
+        installed = os.path.join(
+            module_package_directory(self.root, 7, "default"), "util.py"
+        )
+        with open(installed, encoding="utf-8") as handle:
+            self.assertEqual(handle.read(), "X = 1\n")
+
+    def test_overwriting_an_installed_module_needs_a_restart(self):
+        self._publish("util.py", "X = 1\n")
+        self.assertEqual(self._publish("util.py", "X = 2\n"), "restart_required")
+
+    def test_named_projects_get_their_own_package_directory(self):
+        self._publish("util.py", "X = 1\n", project="Housing")
+        self.assertTrue(
+            module_package_directory(self.root, 7, "Housing").endswith(
+                os.path.join("docassemble", "playground7Housing")
+            )
+        )
+
+    def test_a_server_without_a_writable_package_root_reports_unavailable(self):
+        self.assertEqual(
+            publish_module_source(
+                package_root=None,
+                user_id=7,
+                project="default",
+                filename="util.py",
+                content="X = 1\n",
+            ),
+            "unavailable",
+        )
+
+    def test_no_partially_written_module_is_ever_visible(self):
+        self._publish("util.py", "X = 1\n")
+        target_dir = module_package_directory(self.root, 7, "default")
+        # Only the finished file, never the staging name, is left behind.
+        self.assertEqual(sorted(os.listdir(target_dir)), ["util.py"])
+
+    def test_unpublishing_reports_whether_the_module_was_installed(self):
+        self._publish("util.py", "X = 1\n")
+        self.assertTrue(
+            unpublish_module(
+                package_root=self.root, user_id=7, project="default", filename="util.py"
+            )
+        )
+        self.assertFalse(
+            unpublish_module(
+                package_root=self.root, user_id=7, project="default", filename="util.py"
+            )
+        )
+
+
+class TestPendingRestartState(unittest.TestCase):
+    def setUp(self):
+        self.redis = FakeRedis()
+
+    def test_marked_changes_are_read_back_once_per_file(self):
+        mark_modules_dirty(self.redis, 7, "default", "util.py", server_start_time=100.0)
+        mark_modules_dirty(self.redis, 7, "default", "util.py", server_start_time=100.0)
+        mark_modules_dirty(
+            self.redis, 7, "default", "other.py", server_start_time=100.0
+        )
+        state = read_modules_dirty(self.redis, 7, "default", server_start_time=100.0)
+        self.assertEqual(
+            [entry["filename"] for entry in state["files"]], ["other.py", "util.py"]
+        )
+
+    def test_a_restart_from_anywhere_clears_the_flag(self):
+        # The stock Playground, a package install, or our own restart all move
+        # START_TIME forward, and any of them loads the module.
+        mark_modules_dirty(self.redis, 7, "default", "util.py", server_start_time=100.0)
+        self.assertIsNone(
+            read_modules_dirty(self.redis, 7, "default", server_start_time=200.0)
+        )
+
+    def test_projects_do_not_share_a_flag(self):
+        mark_modules_dirty(self.redis, 7, "Housing", "util.py", server_start_time=100.0)
+        self.assertIsNone(
+            read_modules_dirty(self.redis, 7, "default", server_start_time=100.0)
+        )
+
+    def test_clearing_removes_the_flag(self):
+        mark_modules_dirty(self.redis, 7, "default", "util.py", server_start_time=100.0)
+        clear_modules_dirty(self.redis, 7, "default")
+        self.assertIsNone(
+            read_modules_dirty(self.redis, 7, "default", server_start_time=100.0)
+        )
+
+    def test_unreadable_state_is_treated_as_nothing_pending(self):
+        self.redis.values["da:weaver:modules_dirty:7:default"] = b"not json"
+        self.assertIsNone(
+            read_modules_dirty(self.redis, 7, "default", server_start_time=100.0)
+        )
+
+
+class TestRestartPolicy(unittest.TestCase):
+    def test_the_default_is_to_ask_first(self):
+        for raw in (None, "", "nonsense"):
+            with self.subTest(raw=raw):
+                self.assertEqual(normalize_restart_policy(raw), "prompt")
+
+    def test_the_configured_spellings_are_accepted(self):
+        self.assertEqual(normalize_restart_policy("auto"), "auto")
+        self.assertEqual(normalize_restart_policy("Never"), "never")
+        self.assertEqual(normalize_restart_policy("always"), "auto")
+        self.assertEqual(normalize_restart_policy("off"), "never")
+
+
+class TestModuleSaveApi(unittest.TestCase):
+    def setUp(self):
+        self.redis = FakeRedis()
+        self.storage = tempfile.mkdtemp()
+        self.package_root = tempfile.mkdtemp()
+        self.area = types.SimpleNamespace(finalize=lambda: None)
+
+    def _save(self, payload):
+        with (
+            patch.object(api_editor, "_editor_auth_check", return_value=True),
+            patch.object(api_editor, "_current_user_id", return_value=7),
+            patch.object(api_editor, "r", self.redis),
+            patch.object(
+                api_editor,
+                "_editor_storage_directory",
+                return_value=(self.area, self.storage),
+            ),
+            patch.object(
+                api_editor, "full_package_directory", return_value=self.package_root
+            ),
+            patch.object(api_editor, "server_start_time", return_value=100.0),
+        ):
+            with api_editor.app.test_request_context(
+                "/al/editor/api/section-file", method="POST", json=payload
+            ):
+                return api_editor.editor_api_save_section_file()
+
+    def test_a_new_module_is_saved_and_reported_live(self):
+        response = self._save(
+            {
+                "project": "default",
+                "section": "modules",
+                "filename": "util.py",
+                "content": "X = 1\n",
+            }
+        )
+        data = response.get_json()["data"]
+        self.assertEqual(data["module"]["status"], "live")
+        self.assertFalse(data["module"]["restart_required"])
+        self.assertFalse(data["restart_state"]["pending"])
+
+    def test_changing_an_installed_module_marks_the_project_for_restart(self):
+        payload = {
+            "project": "default",
+            "section": "modules",
+            "filename": "util.py",
+            "content": "X = 1\n",
+        }
+        self._save(payload)
+        payload["content"] = "X = 2\n"
+        data = self._save(payload).get_json()["data"]
+        self.assertTrue(data["module"]["restart_required"])
+        self.assertTrue(data["restart_state"]["pending"])
+        self.assertEqual(
+            [entry["filename"] for entry in data["restart_state"]["files"]], ["util.py"]
+        )
+
+    def test_a_module_that_does_not_compile_is_refused_and_not_written(self):
+        response = self._save(
+            {
+                "project": "default",
+                "section": "modules",
+                "filename": "util.py",
+                "content": "def broken(:\n",
+            }
+        )
+        self.assertEqual(response.status_code, 400)
+        error = response.get_json()["error"]
+        self.assertEqual(error["type"], "module_syntax_error")
+        self.assertEqual(error["line"], 1)
+        self.assertFalse(os.path.exists(os.path.join(self.storage, "util.py")))
+
+    def test_forcing_keeps_unfinished_work_without_installing_it(self):
+        response = self._save(
+            {
+                "project": "default",
+                "section": "modules",
+                "filename": "util.py",
+                "content": "def broken(:\n",
+                "force": True,
+            }
+        )
+        data = response.get_json()["data"]
+        self.assertEqual(data["module"]["status"], "not_published")
+        self.assertTrue(os.path.exists(os.path.join(self.storage, "util.py")))
+        self.assertFalse(
+            os.path.exists(
+                os.path.join(self.package_root, "docassemble", "playground7", "util.py")
+            )
+        )
+
+    def test_a_module_name_docassemble_would_skip_is_refused(self):
+        response = self._save(
+            {
+                "project": "default",
+                "section": "modules",
+                "filename": "_helpers.py",
+                "content": "X = 1\n",
+            }
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("but never loaded", response.get_json()["error"]["message"])
+
+    def test_other_sections_are_untouched_by_any_of_this(self):
+        response = self._save(
+            {
+                "project": "default",
+                "section": "templates",
+                "filename": "_notes.txt",
+                "content": "hello\n",
+            }
+        )
+        data = response.get_json()["data"]
+        self.assertNotIn("module", data)
+        self.assertNotIn("restart_state", data)
+
+
+class TestBulkModuleWrites(unittest.TestCase):
+    """Paths that replace module files without going through a save."""
+
+    def setUp(self):
+        self.redis = FakeRedis()
+        self.storage = tempfile.mkdtemp()
+        self.package_root = tempfile.mkdtemp()
+        self.area = types.SimpleNamespace(finalize=lambda: None)
+
+    def _write(self, filename, content):
+        with open(os.path.join(self.storage, filename), "w", encoding="utf-8") as fh:
+            fh.write(content)
+
+    def _installed(self, filename):
+        return os.path.join(self.package_root, "docassemble", "playground7", filename)
+
+    def _patched(self):
+        return (
+            patch.object(api_editor, "r", self.redis),
+            patch.object(
+                api_editor,
+                "_editor_storage_directory",
+                return_value=(self.area, self.storage),
+            ),
+            patch.object(
+                api_editor, "full_package_directory", return_value=self.package_root
+            ),
+            patch.object(api_editor, "server_start_time", return_value=100.0),
+        )
+
+    def _reconcile(self):
+        redis_patch, storage_patch, root_patch, time_patch = self._patched()
+        with redis_patch, storage_patch, root_patch, time_patch:
+            api_editor._reconcile_project_modules(7, "default")
+
+    def test_a_pulled_module_is_installed_without_a_restart(self):
+        self._write("util.py", "X = 1\n")
+        self._reconcile()
+        self.assertTrue(os.path.exists(self._installed("util.py")))
+        self.assertIsNone(
+            read_modules_dirty(self.redis, 7, "default", server_start_time=100.0)
+        )
+
+    def test_a_pull_that_changes_an_installed_module_needs_a_restart(self):
+        self._write("util.py", "X = 1\n")
+        self._reconcile()
+        self._write("util.py", "X = 2\n")
+        self._reconcile()
+        state = read_modules_dirty(self.redis, 7, "default", server_start_time=100.0)
+        self.assertEqual([entry["filename"] for entry in state["files"]], ["util.py"])
+
+    def test_a_module_the_pull_removed_is_uninstalled_and_flagged(self):
+        self._write("util.py", "X = 1\n")
+        self._reconcile()
+        os.remove(os.path.join(self.storage, "util.py"))
+        self._reconcile()
+        self.assertFalse(os.path.exists(self._installed("util.py")))
+        state = read_modules_dirty(self.redis, 7, "default", server_start_time=100.0)
+        self.assertEqual(state["files"][0]["reason"], "deleted")
+
+    def test_a_pulled_module_that_does_not_compile_is_not_installed(self):
+        self._write("util.py", "def broken(:\n")
+        self._reconcile()
+        self.assertFalse(os.path.exists(self._installed("util.py")))
+        self.assertIsNotNone(
+            read_modules_dirty(self.redis, 7, "default", server_start_time=100.0)
+        )
+
+    def test_a_name_docassemble_would_skip_is_left_alone_entirely(self):
+        self._write("_helpers.py", "X = 1\n")
+        self._reconcile()
+        self.assertFalse(os.path.exists(self._installed("_helpers.py")))
+        # Nothing to restart for: Docassemble would never have loaded it.
+        self.assertIsNone(
+            read_modules_dirty(self.redis, 7, "default", server_start_time=100.0)
+        )
+
+    def test_reconciling_never_fails_the_operation_it_follows(self):
+        with (
+            patch.object(api_editor, "r", self.redis),
+            patch.object(
+                api_editor,
+                "_editor_storage_directory",
+                side_effect=SystemExit(1),
+            ),
+        ):
+            api_editor._reconcile_project_modules(7, "default")
+
+    def test_project_wide_replace_installs_the_module_it_rewrote(self):
+        self._write("util.py", "GREETING = 'hi'\n")
+        self._reconcile()
+        redis_patch, storage_patch, root_patch, time_patch = self._patched()
+        with redis_patch, storage_patch, root_patch, time_patch:
+            api_editor._write_project_text_file(
+                7, "default", "modules", "util.py", "GREETING = 'hello'\n"
+            )
+        with open(self._installed("util.py"), encoding="utf-8") as fh:
+            self.assertEqual(fh.read(), "GREETING = 'hello'\n")
+        self.assertIsNotNone(
+            read_modules_dirty(self.redis, 7, "default", server_start_time=100.0)
+        )
+
+
+class TestRestartApi(unittest.TestCase):
+    def setUp(self):
+        self.redis = FakeRedis()
+
+    def _context(self, path, **kwargs):
+        return api_editor.app.test_request_context(path, **kwargs)
+
+    def test_restart_state_reports_the_policy_and_what_is_pending(self):
+        mark_modules_dirty(self.redis, 7, "default", "util.py", server_start_time=100.0)
+        with (
+            patch.object(api_editor, "_editor_auth_check", return_value=True),
+            patch.object(api_editor, "_current_user_id", return_value=7),
+            patch.object(api_editor, "r", self.redis),
+            patch.object(api_editor, "server_start_time", return_value=100.0),
+            patch.object(api_editor, "_restarting_is_allowed", return_value=True),
+            patch.object(api_editor, "_filesystem_is_read_only", return_value=False),
+            patch.object(api_editor, "_module_restart_policy", return_value="prompt"),
+        ):
+            with self._context("/al/editor/api/server/restart-state?project=default"):
+                data = api_editor.editor_api_restart_state().get_json()["data"]
+        self.assertTrue(data["pending"])
+        self.assertEqual(data["policy"], "prompt")
+        self.assertTrue(data["restart_allowed"])
+        self.assertEqual(data["disruption_seconds"], [10, 30])
+
+    def test_a_read_only_server_explains_itself_instead_of_offering_a_restart(self):
+        with (
+            patch.object(api_editor, "_editor_auth_check", return_value=True),
+            patch.object(api_editor, "_current_user_id", return_value=7),
+            patch.object(api_editor, "r", self.redis),
+            patch.object(api_editor, "server_start_time", return_value=100.0),
+            patch.object(api_editor, "_filesystem_is_read_only", return_value=True),
+        ):
+            with self._context("/al/editor/api/server/restart-state?project=default"):
+                data = api_editor.editor_api_restart_state().get_json()["data"]
+        self.assertFalse(data["restart_allowed"])
+        self.assertIn("read-only", data["restart_blocked_reason"])
+
+    def test_restarting_writes_the_polling_record_before_taking_the_server_down(self):
+        order = []
+
+        def fake_restart():
+            order.append(
+                "restart:" + str(sorted(k for k in self.redis.values if "restart" in k))
+            )
+
+        mark_modules_dirty(self.redis, 7, "default", "util.py", server_start_time=100.0)
+        with (
+            patch.object(api_editor, "_editor_auth_check", return_value=True),
+            patch.object(api_editor, "_current_user_id", return_value=7),
+            patch.object(api_editor, "r", self.redis),
+            patch.object(api_editor, "server_start_time", return_value=100.0),
+            patch.object(api_editor, "_restarting_is_allowed", return_value=True),
+            patch.object(api_editor, "_filesystem_is_read_only", return_value=False),
+            patch.object(api_editor, "restart_docassemble", side_effect=fake_restart),
+        ):
+            with self._context(
+                "/al/editor/api/server/restart",
+                method="POST",
+                json={"project": "default"},
+            ):
+                payload = api_editor.editor_api_restart_server().get_json()
+        task_id = payload["data"]["task_id"]
+        # The record has to exist before restart_all takes down this worker,
+        # or the browser has nothing left to poll.
+        self.assertIn("da:restart_status:" + task_id, order[0])
+        self.assertNotIn("da:weaver:modules_dirty:7:default", self.redis.values)
+
+    def test_a_server_that_may_not_restart_refuses_with_the_reason(self):
+        with (
+            patch.object(api_editor, "_editor_auth_check", return_value=True),
+            patch.object(api_editor, "_current_user_id", return_value=7),
+            patch.object(api_editor, "r", self.redis),
+            patch.object(api_editor, "_filesystem_is_read_only", return_value=False),
+            patch.object(api_editor, "_restarting_is_allowed", return_value=False),
+        ):
+            with self._context(
+                "/al/editor/api/server/restart",
+                method="POST",
+                json={"project": "default"},
+            ):
+                response = api_editor.editor_api_restart_server()
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(response.get_json()["error"]["code"], "restart_not_allowed")
+
+    def test_restart_status_completes_only_once_a_newer_process_answers(self):
+        self.redis.values["da:restart_status:abc"] = json.dumps(
+            {"server_start_time": 100.0}
+        )
+
+        def status(start_time, reset_running):
+            with (
+                patch.object(api_editor, "_editor_auth_check", return_value=True),
+                patch.object(api_editor, "r", self.redis),
+                patch.object(api_editor, "server_start_time", return_value=start_time),
+                patch.object(
+                    api_editor, "reset_process_is_running", return_value=reset_running
+                ),
+            ):
+                with self._context("/al/editor/api/server/restart-status?task_id=abc"):
+                    return api_editor.editor_api_restart_status().get_json()["data"][
+                        "status"
+                    ]
+
+        self.assertEqual(status(100.0, False), "working")
+        # A newer process is answering, but supervisor is still resetting the
+        # background workers, so the restart is not finished.
+        self.assertEqual(status(200.0, True), "working")
+        self.assertEqual(status(200.0, False), "completed")
+
+    def test_an_unknown_task_is_reported_rather_than_erroring(self):
+        with (
+            patch.object(api_editor, "_editor_auth_check", return_value=True),
+            patch.object(api_editor, "r", self.redis),
+        ):
+            with self._context("/al/editor/api/server/restart-status?task_id=gone"):
+                data = api_editor.editor_api_restart_status().get_json()["data"]
+        self.assertEqual(data["status"], "unknown")
+
+
+class TestRuntimeSessionFreshness(unittest.TestCase):
+    def test_starting_a_test_session_invalidates_the_cached_parse(self):
+        # "Run the interview" reaches Docassemble with cache=0 and the server
+        # bumps the index itself; the API path has to do it explicitly or the
+        # inspector runs against YAML from before the last save.
+        bumped = []
+        with (
+            patch.object(api_editor, "_editor_auth_check", return_value=True),
+            patch.object(api_editor, "_runtime_inspector_enabled", return_value=True),
+            patch.object(api_editor, "_current_user_id", return_value=7),
+            patch.object(api_editor, "r", FakeRedis()),
+            patch.object(api_editor, "playground_read_yaml", return_value="id: x\n"),
+            patch.object(
+                api_editor, "bump_interview_source_index", side_effect=bumped.append
+            ),
+            patch.object(
+                api_editor,
+                "create_target_session",
+                return_value=types.SimpleNamespace(
+                    yaml_filename="docassemble.playground7:main.yml",
+                    session_id="target-id",
+                    secret=None,
+                ),
+            ),
+        ):
+            with api_editor.app.test_request_context(
+                "/al/editor/api/runtime/sessions",
+                method="POST",
+                json={"project": "default", "filename": "main.yml"},
+            ):
+                api_editor.editor_api_runtime_create_session()
+        self.assertEqual(bumped, ["docassemble.playground7:main.yml"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The problem

When you save a Python module in the Weaver editor today, nothing happens.

Not "it's risky" — literally nothing. Docassemble doesn't load modules from where the Playground saves them. It saves to one folder, and imports from a completely different one, and the only thing that copies between them is a step that runs when the server boots. So a module you edit in the editor sits in the save folder forever, and your interview keeps running whatever was there the last time the server started. A brand-new module just fails to import.

The standard Playground avoids this by restarting the whole server every single time you press Save. That works, but it's heavy: a restart bounces Celery, RabbitMQ and websockets, takes about 10–30 seconds, and interrupts everyone else on the server while it comes back. Editing three modules means three restarts.

This PR fixes the "nothing happens" part, and makes the restart happen less often than the Playground does — without ever pretending a change took effect when it didn't.

## The rule, in one sentence

**A module the server has never loaded can be installed right now. A module the server might already have loaded needs a restart, because Python won't let you un-load something.**

Everything below follows from that.

## What happens when

| You do this | Restart needed? | Why |
|---|---|---|
| Create a brand-new module | **No** | Nothing has loaded it, so there's no old copy stuck in memory. It works the second you save. |
| Edit a module you created a minute ago in this same session | **Yes** | Something may have loaded the first version by now. |
| Edit a module that already existed | **Yes** | Same reason — the old version may be in memory. |
| Rename a module | **Yes** | The old name may still be loaded and answering. |
| Delete a module | **Yes** | Same. |
| Pull from GitHub, and it brings new modules | **No** | They're new to this server, same as creating one. |
| Pull from GitHub, and it changes modules you already had | **Yes** | Same as editing. |
| Import a whole project from GitHub | **Usually no** | It's a new project, so its modules are all new. |
| Save a template, static file, or data source | **No** | Only Python modules have this problem. |
| Someone else restarts the server for any reason | **Clears it** | See below. |

**Best case:** you're writing a new module. You save, you run the interview, it works. No restart ever, which is better than the standard Playground, which would have restarted anyway.

**Worst case:** you're editing an existing module. You save as many times as you like — the banner just sits there saying a restart is pending. One restart when you're ready. The Playground would have restarted on every save.

## When you're actually asked

The restart isn't offered when you save. It's offered when you do something that runs your interview:

- **Run the interview** / **Open interview**
- **Start test session** (runtime inspector)
- **Open in Playground**

That's deliberate. At save time you're still typing and a restart is pure interruption. At run time you're already opening a new tab and expecting to wait. It also means five edits cost one restart instead of five.

The dialog tells you what it costs — about 10–30 seconds of everyone on the server seeing slow pages, background document assembly cancelled, nobody loses saved answers — and gives you three choices: **Restart now**, **Continue without restarting**, or **Cancel**. Declining is a real option; you just get the old module code until you change your mind. There's also a banner across the top with a Restart button, whenever you want to get it over with.

Admins can change this with `weaver: restart on module save`:

- `prompt` (default) — ask, as described above
- `auto` — just restart, no dialog
- `never` — only ever show the banner, never interrupt

If the server *can't* restart itself (restarting disabled, or a read-only filesystem where the restart script refuses), you get the banner and a plain explanation instead of a button that would only fail.

## The pending flag clears itself

The "this project needs a restart" flag remembers which server boot it was set during. If the server has booted since — because of this feature, or the standard Playground, or a package install, or a deploy — the flag is stale and disappears on its own. So a restart from anywhere counts, and you never get nagged to restart for something that's already loaded.

## Two things that are now caught at save time

The Playground lets both of these through silently. This does not:

**Filenames Docassemble will never load.** The copy step only picks up files starting with a letter. `_helpers.py` and `2col.py` get saved and then ignored forever, with no error anywhere. Those names are now refused when you create, save, rename, or upload.

**Source that doesn't compile.** A module with a syntax error currently saves fine and breaks every interview that imports it, with the failure showing up far away from the edit. Now you get the line number at save time. If you're mid-thought and want to save anyway, you can — it's kept, just not installed, so your working interview keeps running the last good version.

## Other paths that write modules

Project-wide find/replace and GitHub pull/import can rewrite module files without any save going through the editor. All three now go through the same install-or-flag logic, including uninstalling modules that a pull deleted. If that bookkeeping fails for any reason, it logs and gets out of the way — it never turns a successful pull into a failed one.

## One unrelated fix

Starting a runtime test session now refreshes the cached copy of your interview first. "Run the interview" already did this; the test-session API didn't, so the inspector could quietly run against your YAML from before your last save.

## Compatibility

Checked against both Docassemble 1.9.x (what we run) and 1.10.7 upstream. The underlying mechanism is identical in both — 1.10 just moved the code into `develop/helpers.py` and `startup.py`. Everything version-specific goes through the existing `docassemble_compat.py` boundary.

## Testing

38 new tests covering filename rules, the compile check, install-vs-restart for every case in the table above, the self-clearing flag, restart policy, and the bulk-write paths. Full suite is 556 passing; mypy and black clean. The browser controller's decision paths were exercised against a stubbed DOM.
