### PR TITLE
Make elif a first-class branch in the interview order builder

### DIFF
--- a/docassemble/ALWeaver/data/static/editor.css
+++ b/docassemble/ALWeaver/data/static/editor.css
@@ -1591,6 +1591,28 @@ html, body {
   background: #e6eaf0;
 }
 
+/* An `elif` row hangs at the same left edge as the `else` label below it, so
+   the branches of one chain line up with each other instead of stepping
+   further right with every link. */
+.editor-order-chain-link > .editor-order-step {
+  margin-left: -14px;
+  padding-left: 6px;
+  background: transparent;
+}
+
+.editor-order-chain-keyword {
+  flex: 0 0 auto;
+  font-family: ui-monospace, "Cascadia Code", "SFMono-Regular", Consolas, monospace;
+  font-size: 11.5px;
+  font-weight: 600;
+  color: #66778f;
+  letter-spacing: 0.02em;
+}
+
+.editor-order-chain-link > .editor-order-children {
+  margin-left: 18px;
+}
+
 .drag-handle {
   flex: 0 0 20px;
   width: 20px;

--- a/docassemble/ALWeaver/data/static/editor.js
+++ b/docassemble/ALWeaver/data/static/editor.js
@@ -2939,6 +2939,23 @@
     return step.children;
   }
 
+  // --- if / elif / else chains -------------------------------------------
+  //
+  // A chain is stored the way Python means it: each `elif` is an `else` branch
+  // holding exactly one condition.  That keeps one shape on the wire and lets
+  // the parser and serializer round-trip a chain of any length.  Authors think
+  // in flat chains though, so these helpers read that nesting back as the list
+  // of links the order builder draws and edits.
+
+  // The logic itself lives in editor_serializers.js so the node suite can
+  // exercise it directly; these are the names the builder reads it through.
+  function getConditionChain(step) { return window.ALWeaverSerializers.getConditionChain(step); }
+  function getChainTail(step) { return window.ALWeaverSerializers.getChainTail(step); }
+  function chainHasFinalElse(step) { return window.ALWeaverSerializers.chainHasFinalElse(step); }
+  function isChainLink(step, parentStep) { return window.ALWeaverSerializers.isChainLink(step, parentStep); }
+  function appendChainElif(step, newLink) { return window.ALWeaverSerializers.appendChainElif(step, newLink); }
+  function removeChainLink(parentStep, link) { return window.ALWeaverSerializers.removeChainLink(parentStep, link); }
+
   function findBlockByInvoke(step) {
     if (!step) return null;
     if (step.blockId) {
@@ -2969,10 +2986,15 @@
     if (!step) return '';
     if (step.kind === 'screen' || step.kind === 'gather') return '';
     if (step.kind === 'condition') {
+      var conditionChain = getConditionChain(step);
+      var conditionTail = conditionChain[conditionChain.length - 1];
       var childCount = Array.isArray(step.children) ? step.children.length : 0;
-      var elseCount = Array.isArray(step.else_children) ? step.else_children.length : 0;
       var parts = [childCount + ' then'];
-      if (step.has_else) parts.push(elseCount + ' else');
+      if (conditionChain.length > 1) parts.push((conditionChain.length - 1) + ' else if');
+      if (conditionTail.has_else) {
+        var elseCount = Array.isArray(conditionTail.else_children) ? conditionTail.else_children.length : 0;
+        parts.push(elseCount + ' else');
+      }
       return parts.join(' · ');
     }
     if (step.kind === 'section') return step.value || '';
@@ -3163,16 +3185,23 @@
       else if (step.kind === 'progress') lines.push(prefix + 'set_progress(' + String(step.value || '0') + ')');
       else if (step.kind === 'gather' || step.kind === 'screen' || step.kind === 'function') lines.push(prefix + String(step.invoke || ''));
       else if (step.kind === 'condition') {
-        lines.push(prefix + 'if ' + String(step.condition || step.summary || 'True') + ':');
-        if (Array.isArray(step.children) && step.children.length) {
-          lines.push(renderOrderCodePreview(step.children, indent + 2));
-        } else {
-          lines.push(new Array(indent + 3).join(' ') + 'pass');
-        }
-        if (step.has_else) {
+        // Walk the chain so the preview shows the `elif` the server will
+        // actually write, rather than a ladder of nested `if`.
+        var chainLinks = getConditionChain(step);
+        chainLinks.forEach(function (link, linkIndex) {
+          var keyword = linkIndex === 0 ? 'if ' : 'elif ';
+          lines.push(prefix + keyword + String(link.condition || link.summary || 'True') + ':');
+          if (Array.isArray(link.children) && link.children.length) {
+            lines.push(renderOrderCodePreview(link.children, indent + 2));
+          } else {
+            lines.push(new Array(indent + 3).join(' ') + 'pass');
+          }
+        });
+        var previewTail = chainLinks[chainLinks.length - 1];
+        if (previewTail.has_else) {
           lines.push(prefix + 'else:');
-          if (Array.isArray(step.else_children) && step.else_children.length) {
-            lines.push(renderOrderCodePreview(step.else_children, indent + 2));
+          if (Array.isArray(previewTail.else_children) && previewTail.else_children.length) {
+            lines.push(renderOrderCodePreview(previewTail.else_children, indent + 2));
           } else {
             lines.push(new Array(indent + 3).join(' ') + 'pass');
           }
@@ -7292,6 +7321,55 @@
     return html;
   }
 
+  /* One `elif` link: the condition row plus the steps it guards.
+
+     Deliberately not a drag target -- an elif is a branch of the chain it
+     belongs to, not a step you can drop somewhere else, and the steps *inside*
+     it stay draggable through the drop list renderOrderBranch emits. */
+  function renderOrderChainLink(step, depth) {
+    var condition = cleanOrderText(step.condition || step.summary || 'condition');
+    var thenCount = Array.isArray(step.children) ? step.children.length : 0;
+    var html = '<div class="editor-order-step-shell editor-order-chain-link" style="--order-depth:' + depth + '">';
+    html += '<div class="editor-order-step editor-order-step-condition" data-step-id="' + esc(step.id) + '" tabindex="0">';
+    html += '<div class="editor-order-step-top">';
+    html += '<div class="editor-order-step-main">';
+    html += '<span class="editor-order-chain-keyword" aria-hidden="true">elif</span>';
+    html += '<span class="editor-order-title editor-order-title-meta" data-editable="true" data-step-id="' + esc(step.id) + '">' + esc(condition) + '</span>';
+    html += '<span class="editor-order-detail">' + thenCount + ' then</span>';
+    html += '</div>';
+    html += '<span class="editor-order-spacer" aria-hidden="true"></span>';
+    html += '<div class="editor-order-step-actions">';
+    html += '<div class="dropdown">';
+    html += '<button type="button" class="editor-kebab-btn" data-bs-toggle="dropdown" data-bs-boundary="viewport" data-bs-display="dynamic" aria-expanded="false" title="Actions"><i class="fa-solid fa-ellipsis-vertical" aria-hidden="true"></i><span class="visually-hidden">Actions for this else if branch</span></button>';
+    html += '<ul class="dropdown-menu dropdown-menu-end">';
+    html += '<li><button class="dropdown-item" type="button" data-step-action="edit" data-step-id="' + esc(step.id) + '"><i class="fa-solid fa-pen-to-square me-2" aria-hidden="true"></i>Edit condition</button></li>';
+    html += renderOrderChainBranchMenuItems(step);
+    html += '<li><hr class="dropdown-divider"></li>';
+    html += '<li><button class="dropdown-item text-danger" type="button" data-step-action="remove" data-step-id="' + esc(step.id) + '"><i class="fa-solid fa-trash-can me-2" aria-hidden="true"></i>Remove this else if</button></li>';
+    html += '</ul></div>';
+    html += '</div>';
+    html += '<span class="editor-order-type editor-order-type-condition">else if</span>';
+    html += '</div>';
+    html += '</div>';
+    if (_inlineEditStepId === step.id) html += renderInlineEditRow(step);
+    html += '<div class="editor-order-children">';
+    html += renderOrderBranch(step, depth + 1, 'then', 'Then');
+    html += '</div>';
+    html += '</div>';
+    return html;
+  }
+
+  /* "Add else if" is always available on a chain; "Add else" only until the
+     chain already ends in one. Both act on the end of the chain, so they mean
+     the same thing whichever link they were opened from. */
+  function renderOrderChainBranchMenuItems(step) {
+    var html = '<li><button class="dropdown-item" type="button" data-step-action="add-elif" data-step-id="' + esc(step.id) + '"><i class="fa-solid fa-code-branch me-2" aria-hidden="true"></i>Add else if branch</button></li>';
+    if (!chainHasFinalElse(step)) {
+      html += '<li><button class="dropdown-item" type="button" data-step-action="add-else" data-step-id="' + esc(step.id) + '"><i class="fa-solid fa-code-branch me-2" aria-hidden="true"></i>Add else branch</button></li>';
+    }
+    return html;
+  }
+
   function renderOrderStepTree(stepList, depth, parentStepId, branch) {
     var html = '';
     depth = depth || 0;
@@ -7301,7 +7379,6 @@
     stepList.forEach(function (step, index) {
       var presentation = getOrderStepPresentation(step);
       var isCollapsed = Boolean(state.orderCollapsed[step.id]);
-      var hasElse = Boolean(step.has_else);
       var typeLabel = getOrderStepTypeLabel(step);
       html += '<div class="editor-order-step-shell" style="--order-depth:' + depth + '">';
       html += '<div class="editor-order-step editor-order-step-' + esc(step.kind) + (step.kind === 'condition' ? ' editor-order-step-condition' : '') + (_lastInsertedOrderStepId === step.id ? ' editor-order-step-new' : '') + '" data-step-id="' + esc(step.id) + '" tabindex="0">';
@@ -7328,8 +7405,8 @@
       if (step.kind === 'condition') {
         html += '<li><button class="dropdown-item" type="button" data-step-action="toggle-collapse" data-step-id="' + esc(step.id) + '"><i class="fa-solid ' + (isCollapsed ? 'fa-chevron-down' : 'fa-chevron-up') + ' me-2" aria-hidden="true"></i>' + (isCollapsed ? 'Expand branches' : 'Collapse branches') + '</button></li>';
       }
-      if (step.kind === 'condition' && !hasElse) {
-        html += '<li><button class="dropdown-item" type="button" data-step-action="add-else" data-step-id="' + esc(step.id) + '"><i class="fa-solid fa-code-branch me-2" aria-hidden="true"></i>Add else branch</button></li>';
+      if (step.kind === 'condition') {
+        html += renderOrderChainBranchMenuItems(step);
       }
       var hasBlockRef = (step.kind === 'screen' || step.kind === 'gather') && !!step.invoke;
       if (hasBlockRef) {
@@ -7355,9 +7432,17 @@
         html += renderInlineEditRow(step);
       }
       if (step.kind === 'condition') {
+        // The whole chain is drawn flat inside this one collapsible region, so
+        // `elif` reads as a sibling of `if` instead of burying each branch a
+        // level deeper than the last.
+        var chain = getConditionChain(step);
+        var chainTail = chain[chain.length - 1];
         html += '<div class="editor-order-children' + (isCollapsed ? ' d-none' : '') + '">';
         html += renderOrderBranch(step, depth + 1, 'then', 'Then');
-        if (hasElse) html += renderOrderBranch(step, depth + 1, 'else', 'Else');
+        for (var linkIndex = 1; linkIndex < chain.length; linkIndex++) {
+          html += renderOrderChainLink(chain[linkIndex], depth);
+        }
+        if (chainTail.has_else) html += renderOrderBranch(chainTail, depth + 1, 'else', 'Else');
         html += '</div>';
       }
       html += '</div>';
@@ -9366,7 +9451,11 @@
       var stepRecord = findStepRecord(state.orderSteps, targetStepId, null);
       if (!stepRecord) return;
       if (action === 'remove') {
-        stepRecord.list.splice(stepRecord.index, 1);
+        // Removing an `elif` has to close the chain up behind it, or the
+        // branch it was holding for the rest of the chain is dropped too.
+        if (!removeChainLink(stepRecord.parent, stepRecord.step)) {
+          stepRecord.list.splice(stepRecord.index, 1);
+        }
         delete state.selectedOrderStepIds[targetStepId];
         syncActiveOrderStepMap();
         markOrderDirty();
@@ -9378,9 +9467,17 @@
       } else if (action === 'toggle-collapse') {
         state.orderCollapsed[targetStepId] = !state.orderCollapsed[targetStepId];
         renderCanvas();
-      } else if (action === 'add-else') {
-        stepRecord.step.has_else = true;
-        if (!Array.isArray(stepRecord.step.else_children)) stepRecord.step.else_children = [];
+      } else if (action === 'add-else' || action === 'add-elif') {
+        // Both attach at the end of the chain, so it does not matter which
+        // link the menu was opened from.
+        if (action === 'add-elif') {
+          var newLink = appendChainElif(stepRecord.step, createOrderStep('condition'));
+          _lastInsertedOrderStepId = newLink.id;
+        } else {
+          var chainTailStep = getChainTail(stepRecord.step);
+          chainTailStep.has_else = true;
+          if (!Array.isArray(chainTailStep.else_children)) chainTailStep.else_children = [];
+        }
         state.orderCollapsed[targetStepId] = false;
         syncActiveOrderStepMap();
         markOrderDirty();

--- a/docassemble/ALWeaver/data/static/editor_serializers.js
+++ b/docassemble/ALWeaver/data/static/editor_serializers.js
@@ -140,8 +140,85 @@
     return appendQuestionAdvancedYaml(yaml, block);
   }
 
+  // -------------------------------------------------------------------------
+  // if / elif / else chains in the interview order
+  //
+  // A chain is stored the way Python means it: each `elif` is an `else` branch
+  // holding exactly one condition.  One shape on the wire keeps the server's
+  // parser and serializer able to round-trip a chain of any length.  Authors
+  // think in flat chains though, so the order builder reads that nesting back
+  // through these helpers and edits it through the two mutations below.
+  // -------------------------------------------------------------------------
+
+  /* The condition an `else` branch consists entirely of, or null. */
+  function getSoleElseCondition(step) {
+    if (!step || !step.has_else) return null;
+    var elseChildren = Array.isArray(step.else_children) ? step.else_children : [];
+    if (elseChildren.length !== 1) return null;
+    var only = elseChildren[0];
+    return only && only.kind === 'condition' ? only : null;
+  }
+
+  /* [if, elif, elif, ...] starting at `step`. */
+  function getConditionChain(step) {
+    var chain = [];
+    var current = step;
+    while (current && current.kind === 'condition' && chain.indexOf(current) === -1) {
+      chain.push(current);
+      current = getSoleElseCondition(current);
+    }
+    return chain;
+  }
+
+  /* The last link, whose `else` branch is the chain's real else body. */
+  function getChainTail(step) {
+    var chain = getConditionChain(step);
+    return chain.length ? chain[chain.length - 1] : step;
+  }
+
+  function chainHasFinalElse(step) {
+    var tail = getChainTail(step);
+    return Boolean(tail && tail.has_else);
+  }
+
+  /* True when `step` is an `elif` -- the whole content of `parentStep`'s else. */
+  function isChainLink(step, parentStep) {
+    return Boolean(parentStep) && getSoleElseCondition(parentStep) === step;
+  }
+
+  /* Add `newLink` as the last `elif` of the chain `step` belongs to.
+
+     A chain already ending in `else` keeps it: the new branch goes in front,
+     which is where an author adding one means it. Returns the link. */
+  function appendChainElif(step, newLink) {
+    var tail = getChainTail(step);
+    if (tail.has_else) {
+      newLink.has_else = true;
+      newLink.else_children = Array.isArray(tail.else_children) ? tail.else_children : [];
+    }
+    tail.has_else = true;
+    tail.else_children = [newLink];
+    return newLink;
+  }
+
+  /* Drop one `elif` and close the chain up behind it, so whatever it was
+     holding for the rest of the chain is not dropped with it. */
+  function removeChainLink(parentStep, link) {
+    if (!isChainLink(link, parentStep)) return false;
+    parentStep.has_else = Boolean(link.has_else);
+    parentStep.else_children = Array.isArray(link.else_children) ? link.else_children : [];
+    return true;
+  }
+
   return {
     escapeYamlStr: escapeYamlStr,
     serializeQuestionToYaml: serializeQuestionToYaml,
+    getSoleElseCondition: getSoleElseCondition,
+    getConditionChain: getConditionChain,
+    getChainTail: getChainTail,
+    chainHasFinalElse: chainHasFinalElse,
+    isChainLink: isChainLink,
+    appendChainElif: appendChainElif,
+    removeChainLink: removeChainLink,
   };
 });

--- a/docassemble/ALWeaver/editor_utils.py
+++ b/docassemble/ALWeaver/editor_utils.py
@@ -1206,6 +1206,7 @@ _RE_SET_PROGRESS = re.compile(r"set_progress\(\s*(\d+)\s*\)")
 _RE_GATHER = re.compile(r"(\S+)\.gather\(\)")
 _RE_FUNCTION_CALL = re.compile(r"(\S+\(.*\))")
 _RE_IF = re.compile(r"if\s+(.+):$")
+_RE_ELIF = re.compile(r"elif\s+(.+):$")
 _RE_ELSE = re.compile(r"else:$")
 
 
@@ -1369,7 +1370,7 @@ def parse_order_code(code: str) -> List[Dict[str, Any]]:
             if (
                 stop_on_else_indent is not None
                 and indent == stop_on_else_indent
-                and _RE_ELSE.match(stripped_line)
+                and (_RE_ELSE.match(stripped_line) or _RE_ELIF.match(stripped_line))
             ):
                 break
 
@@ -1396,18 +1397,12 @@ def parse_order_code(code: str) -> List[Dict[str, Any]]:
                 children, next_index, step_counter = _parse_block(
                     index + 1, child_indent, step_counter, stop_on_else_indent=indent
                 )
-                else_children: List[Dict[str, Any]] = []
-                has_else = False
-                if next_index < len(raw_lines):
-                    next_line = raw_lines[next_index]
-                    if _line_indent(next_line) == indent and _RE_ELSE.match(
-                        next_line.strip()
-                    ):
-                        has_else = True
-                        else_child_indent = _next_child_indent(next_index + 1, indent)
-                        else_children, next_index, step_counter = _parse_block(
-                            next_index + 1, else_child_indent, step_counter
-                        )
+                (
+                    has_else,
+                    else_children,
+                    next_index,
+                    step_counter,
+                ) = _parse_conditional_tail(next_index, indent, step_counter)
                 steps.append(
                     {
                         "id": step_id,
@@ -1428,6 +1423,63 @@ def parse_order_code(code: str) -> List[Dict[str, Any]]:
 
         return steps, index, step_counter
 
+    def _parse_conditional_tail(
+        index: int, indent: int, step_counter: int
+    ) -> Tuple[bool, List[Dict[str, Any]], int, int]:
+        """Parse the ``elif``/``else`` tail of an ``if`` block at ``indent``.
+
+        ``elif`` is represented as an ``else`` branch holding a single nested
+        condition step, which is what it means in Python.  Keeping it in the
+        existing shape means a chain of any length round-trips through
+        :func:`serialize_order_steps` and renders in the order builder without
+        a separate step kind for it.  Before this, an ``elif`` was not
+        recognised at all: it became a raw step and its body became *sibling*
+        steps, so saving the order block silently moved those screens out of
+        the branch and ran them unconditionally.
+        """
+        if index >= len(raw_lines):
+            return False, [], index, step_counter
+
+        line = raw_lines[index]
+        if _line_indent(line) != indent:
+            return False, [], index, step_counter
+        stripped = line.strip()
+
+        elif_match = _RE_ELIF.match(stripped)
+        if elif_match:
+            step_counter += 1
+            step_id = f"step-{step_counter}"
+            child_indent = _next_child_indent(index + 1, indent)
+            children, next_index, step_counter = _parse_block(
+                index + 1, child_indent, step_counter, stop_on_else_indent=indent
+            )
+            (
+                nested_has_else,
+                nested_else_children,
+                next_index,
+                step_counter,
+            ) = _parse_conditional_tail(next_index, indent, step_counter)
+            nested_step = {
+                "id": step_id,
+                "kind": STEP_CONDITION,
+                "label": "Condition",
+                "summary": elif_match.group(1),
+                "condition": elif_match.group(1),
+                "children": children,
+                "has_else": nested_has_else,
+                "else_children": nested_else_children,
+            }
+            return True, [nested_step], next_index, step_counter
+
+        if _RE_ELSE.match(stripped):
+            else_child_indent = _next_child_indent(index + 1, indent)
+            else_children, next_index, step_counter = _parse_block(
+                index + 1, else_child_indent, step_counter
+            )
+            return True, else_children, next_index, step_counter
+
+        return False, [], index, step_counter
+
     parsed_steps, _next_index, _final_counter = _parse_block(0, 0, 0)
     return parsed_steps
 
@@ -1436,6 +1488,41 @@ def serialize_order_steps(steps: Sequence[Dict[str, Any]]) -> str:
     """Convert structured order steps back into Python code for a mandatory
     code block."""
     lines: List[str] = []
+
+    def _append_condition(step: Dict[str, Any], indent: int, keyword: str) -> None:
+        """Write one link of an ``if``/``elif``/``else`` chain.
+
+        An ``else`` branch whose only content is a condition is written back as
+        ``elif`` rather than as a nested ``if``.  That is the same code either
+        way, and it is what :func:`parse_order_code` produces for an ``elif``,
+        so a chain survives a parse/serialize round trip unchanged.
+        """
+        prefix = " " * indent
+        condition = str(step.get("condition") or step.get("summary") or "True")
+        lines.append(f"{prefix}{keyword} {condition}:")
+        children = step.get("children") or []
+        if children:
+            _append_steps(children, indent + 2)
+        else:
+            lines.append(f"{' ' * (indent + 2)}pass")
+
+        if not step.get("has_else"):
+            return
+
+        else_children = step.get("else_children") or []
+        if (
+            len(else_children) == 1
+            and isinstance(else_children[0], dict)
+            and else_children[0].get("kind") == STEP_CONDITION
+        ):
+            _append_condition(else_children[0], indent, "elif")
+            return
+
+        lines.append(f"{prefix}else:")
+        if else_children:
+            _append_steps(else_children, indent + 2)
+        else:
+            lines.append(f"{' ' * (indent + 2)}pass")
 
     def _append_steps(step_list: Sequence[Dict[str, Any]], indent: int) -> None:
         prefix = " " * indent
@@ -1454,20 +1541,7 @@ def serialize_order_steps(steps: Sequence[Dict[str, Any]]) -> str:
             elif kind == STEP_FUNCTION:
                 lines.append(f"{prefix}{step.get('invoke', '')}")
             elif kind == STEP_CONDITION:
-                condition = str(step.get("condition") or step.get("summary") or "True")
-                lines.append(f"{prefix}if {condition}:")
-                children = step.get("children") or []
-                if children:
-                    _append_steps(children, indent + 2)
-                else:
-                    lines.append(f"{' ' * (indent + 2)}pass")
-                if step.get("has_else"):
-                    lines.append(f"{prefix}else:")
-                    else_children = step.get("else_children") or []
-                    if else_children:
-                        _append_steps(else_children, indent + 2)
-                    else:
-                        lines.append(f"{' ' * (indent + 2)}pass")
+                _append_condition(step, indent, "if")
             elif kind == STEP_RAW:
                 code = step.get("code", "")
                 for raw_line in str(code).splitlines() or [""]:

--- a/docassemble/ALWeaver/test_editor_frontend.py
+++ b/docassemble/ALWeaver/test_editor_frontend.py
@@ -317,6 +317,39 @@ class TestEditorFrontend(unittest.TestCase):
         )
         self.assertIn("color: transparent;", css)
         self.assertIn("border-left: 2px solid", css)
+
+    def test_order_builder_can_add_and_draw_an_elif_branch(self):
+        editor = (self.package_dir / "data/static/editor.js").read_text()
+        css = (self.package_dir / "data/static/editor.css").read_text()
+
+        # Adding one is a real menu action, offered from any link of a chain.
+        self.assertIn('data-step-action="add-elif"', editor)
+        self.assertIn("Add else if branch", editor)
+        self.assertIn("function renderOrderChainBranchMenuItems(step)", editor)
+        self.assertIn("if (!chainHasFinalElse(step))", editor)
+
+        # The chain is drawn flat, so `elif` reads as a sibling of `if`
+        # instead of nesting a level deeper with every link.
+        self.assertIn("function renderOrderChainLink(step, depth)", editor)
+        self.assertIn("editor-order-chain-keyword", editor)
+        self.assertIn("linkIndex < chain.length", editor)
+        self.assertIn(".editor-order-chain-link", css)
+
+        # The mutations live in the module the node suite exercises, so the
+        # builder cannot grow its own copy of the chain rules.
+        for helper in (
+            "getConditionChain",
+            "getChainTail",
+            "chainHasFinalElse",
+            "isChainLink",
+            "appendChainElif",
+            "removeChainLink",
+        ):
+            self.assertIn(f"window.ALWeaverSerializers.{helper}(", editor)
+
+        # The code preview has to show the elif the server will actually
+        # write, not the nested if the steps are stored as.
+        self.assertIn("var keyword = linkIndex === 0 ? 'if ' : 'elif ';", editor)
         self.assertIn("height: 32px;", css)
 
     def test_unsaved_changes_modal_cannot_trap_the_page(self):

--- a/docassemble/ALWeaver/test_editor_order_conditions.py
+++ b/docassemble/ALWeaver/test_editor_order_conditions.py
@@ -1,0 +1,203 @@
+# do not pre-load
+
+import unittest
+
+from .editor_utils import STEP_CONDITION, parse_order_code, serialize_order_steps
+
+
+class TestOrderConditionRoundTrip(unittest.TestCase):
+    """The order builder rewrites the whole block on save, so anything it
+    cannot parse is silently lost.  ``elif`` used to be exactly that: it was
+    read as a raw line and its body became sibling steps, so saving moved those
+    screens out of the branch and ran them unconditionally.
+    """
+
+    def assert_round_trips(self, source: str) -> None:
+        self.assertEqual(
+            serialize_order_steps(parse_order_code(source)).strip(),
+            source.strip(),
+        )
+
+    def test_elif_body_stays_inside_its_branch(self):
+        source = "\n".join(
+            [
+                "if user_started_case:",
+                "  petition_screen",
+                "elif user_is_defendant:",
+                "  answer_screen",
+                "else:",
+                "  other_screen",
+                "final_screen",
+            ]
+        )
+
+        self.assert_round_trips(source)
+
+    def test_elif_chain_without_else_round_trips(self):
+        source = "\n".join(
+            [
+                "if a:",
+                "  one",
+                "elif b:",
+                "  two",
+                "elif c:",
+                "  three",
+            ]
+        )
+
+        self.assert_round_trips(source)
+
+    def test_elif_nested_inside_a_condition_round_trips(self):
+        source = "\n".join(
+            [
+                "if a:",
+                "  if b:",
+                "    one",
+                "  elif c:",
+                "    two",
+                "  else:",
+                "    three",
+                "elif d:",
+                "  four",
+                "last",
+            ]
+        )
+
+        self.assert_round_trips(source)
+
+    def test_plain_if_else_is_unchanged(self):
+        source = "\n".join(
+            [
+                "if a:",
+                "  one",
+                "else:",
+                "  two",
+            ]
+        )
+
+        self.assert_round_trips(source)
+
+    def test_elif_parses_as_a_condition_in_the_else_branch(self):
+        # ``elif`` is modeled as an ``else`` holding one nested condition, which
+        # is what it means in Python and is a shape the order builder already
+        # renders, so no separate step kind is needed for it.
+        steps = parse_order_code(
+            "\n".join(
+                [
+                    "if a:",
+                    "  one",
+                    "elif b:",
+                    "  two",
+                ]
+            )
+        )
+
+        self.assertEqual(len(steps), 1)
+        outer = steps[0]
+        self.assertEqual(outer["kind"], STEP_CONDITION)
+        self.assertEqual(outer["condition"], "a")
+        self.assertTrue(outer["has_else"])
+
+        self.assertEqual(len(outer["else_children"]), 1)
+        nested = outer["else_children"][0]
+        self.assertEqual(nested["kind"], STEP_CONDITION)
+        self.assertEqual(nested["condition"], "b")
+        self.assertFalse(nested["has_else"])
+        self.assertEqual([child["invoke"] for child in nested["children"]], ["two"])
+
+    def test_step_ids_stay_unique_across_a_chain(self):
+        steps = parse_order_code(
+            "\n".join(
+                [
+                    "if a:",
+                    "  one",
+                    "elif b:",
+                    "  two",
+                    "else:",
+                    "  three",
+                ]
+            )
+        )
+
+        seen = []
+
+        def collect(step_list):
+            for step in step_list:
+                seen.append(step["id"])
+                collect(step.get("children") or [])
+                collect(step.get("else_children") or [])
+
+        collect(steps)
+
+        self.assertEqual(len(seen), len(set(seen)))
+
+    def test_else_holding_a_condition_is_written_as_elif(self):
+        # A chain the author builds by nesting in the order builder comes back
+        # as idiomatic ``elif`` rather than a growing ladder of nested ``if``.
+        steps = [
+            {
+                "kind": STEP_CONDITION,
+                "condition": "a",
+                "children": [{"kind": "screen", "invoke": "one"}],
+                "has_else": True,
+                "else_children": [
+                    {
+                        "kind": STEP_CONDITION,
+                        "condition": "b",
+                        "children": [{"kind": "screen", "invoke": "two"}],
+                        "has_else": False,
+                        "else_children": [],
+                    }
+                ],
+            }
+        ]
+
+        self.assertEqual(
+            serialize_order_steps(steps),
+            "\n".join(
+                [
+                    "if a:",
+                    "  one",
+                    "elif b:",
+                    "  two",
+                ]
+            ),
+        )
+
+    def test_else_with_a_condition_plus_other_steps_stays_an_else(self):
+        steps = [
+            {
+                "kind": STEP_CONDITION,
+                "condition": "a",
+                "children": [{"kind": "screen", "invoke": "one"}],
+                "has_else": True,
+                "else_children": [
+                    {
+                        "kind": STEP_CONDITION,
+                        "condition": "b",
+                        "children": [{"kind": "screen", "invoke": "two"}],
+                        "has_else": False,
+                        "else_children": [],
+                    },
+                    {"kind": "screen", "invoke": "three"},
+                ],
+            }
+        ]
+
+        self.assertEqual(
+            serialize_order_steps(steps),
+            "\n".join(
+                [
+                    "if a:",
+                    "  one",
+                    "else:",
+                    "  if b:",
+                    "    two",
+                    "  three",
+                ]
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docassemble/ALWeaver/test_editor_serializers.js
+++ b/docassemble/ALWeaver/test_editor_serializers.js
@@ -134,3 +134,119 @@ const modifierYaml = serialize('text', modifierKeys);
 modifierKeys.forEach((key) => {
   assert.ok(modifierYaml.includes('    ' + key + ': modifier_value\n'), key);
 });
+
+// ---------------------------------------------------------------------------
+// if / elif / else chains in the interview order
+// ---------------------------------------------------------------------------
+
+const {
+  getConditionChain,
+  getChainTail,
+  chainHasFinalElse,
+  isChainLink,
+  appendChainElif,
+  removeChainLink,
+} = serializers;
+
+let _stepSeq = 0;
+function cond(condition, children) {
+  _stepSeq += 1;
+  return {
+    id: 'step-' + _stepSeq,
+    kind: 'condition',
+    condition: condition,
+    children: children || [],
+    has_else: false,
+    else_children: [],
+  };
+}
+function screen(name) {
+  _stepSeq += 1;
+  return { id: 'step-' + _stepSeq, kind: 'screen', invoke: name, summary: name };
+}
+function conditions(chain) {
+  return chain.map((link) => link.condition);
+}
+
+// A lone `if` is a chain of one.
+const single = cond('a', [screen('one')]);
+assert.deepStrictEqual(conditions(getConditionChain(single)), ['a']);
+assert.strictEqual(getChainTail(single), single);
+assert.strictEqual(chainHasFinalElse(single), false);
+
+// An `else` that is not a lone condition ends the chain.
+const withElse = cond('a', [screen('one')]);
+withElse.has_else = true;
+withElse.else_children = [screen('two')];
+assert.deepStrictEqual(conditions(getConditionChain(withElse)), ['a']);
+assert.strictEqual(chainHasFinalElse(withElse), true);
+
+// An `else` holding exactly one condition is an `elif`, and chains.
+const chained = cond('a', [screen('one')]);
+const linkB = cond('b', [screen('two')]);
+const linkC = cond('c', [screen('three')]);
+chained.has_else = true;
+chained.else_children = [linkB];
+linkB.has_else = true;
+linkB.else_children = [linkC];
+assert.deepStrictEqual(conditions(getConditionChain(chained)), ['a', 'b', 'c']);
+assert.strictEqual(getChainTail(chained), linkC);
+assert.strictEqual(isChainLink(linkB, chained), true);
+assert.strictEqual(isChainLink(linkC, linkB), true);
+assert.strictEqual(isChainLink(linkC, chained), false);
+assert.strictEqual(isChainLink(chained, null), false);
+// An `else` with a condition *plus* something else is a real else, not a link.
+const notALink = cond('a');
+const inner = cond('b');
+notALink.has_else = true;
+notALink.else_children = [inner, screen('tail')];
+assert.strictEqual(isChainLink(inner, notALink), false);
+assert.deepStrictEqual(conditions(getConditionChain(notALink)), ['a']);
+
+// Adding an elif appends to the end of the chain...
+const growing = cond('a', [screen('one')]);
+appendChainElif(growing, cond('b'));
+assert.deepStrictEqual(conditions(getConditionChain(growing)), ['a', 'b']);
+appendChainElif(growing, cond('c'));
+assert.deepStrictEqual(conditions(getConditionChain(growing)), ['a', 'b', 'c']);
+// ...from any link, not just the head.
+appendChainElif(getConditionChain(growing)[1], cond('d'));
+assert.deepStrictEqual(conditions(getConditionChain(growing)), ['a', 'b', 'c', 'd']);
+
+// A chain that already ends in `else` keeps it; the new branch goes in front.
+const withTrailingElse = cond('a', [screen('one')]);
+withTrailingElse.has_else = true;
+withTrailingElse.else_children = [screen('fallback')];
+appendChainElif(withTrailingElse, cond('b'));
+const grownChain = getConditionChain(withTrailingElse);
+assert.deepStrictEqual(conditions(grownChain), ['a', 'b']);
+assert.strictEqual(chainHasFinalElse(withTrailingElse), true);
+assert.deepStrictEqual(
+  getChainTail(withTrailingElse).else_children.map((s) => s.invoke),
+  ['fallback']
+);
+
+// Removing a link closes the chain up behind it rather than dropping the rest.
+const shrinking = cond('a', [screen('one')]);
+const midLink = appendChainElif(shrinking, cond('b', [screen('two')]));
+appendChainElif(shrinking, cond('c', [screen('three')]));
+assert.strictEqual(removeChainLink(shrinking, midLink), true);
+assert.deepStrictEqual(conditions(getConditionChain(shrinking)), ['a', 'c']);
+
+// Removing the only link leaves a plain `if` with no empty else behind it.
+const lastLink = cond('a', [screen('one')]);
+const onlyLink = appendChainElif(lastLink, cond('b'));
+assert.strictEqual(removeChainLink(lastLink, onlyLink), true);
+assert.strictEqual(lastLink.has_else, false);
+assert.deepStrictEqual(lastLink.else_children, []);
+
+// Removing a link that is not one is refused, so the caller falls back to a
+// normal list removal instead of silently rewriting the wrong branch.
+assert.strictEqual(removeChainLink(notALink, inner), false);
+assert.strictEqual(removeChainLink(null, onlyLink), false);
+
+// A malformed self-referencing branch terminates instead of hanging.
+const looped = cond('a');
+looped.has_else = true;
+looped.else_children = [looped];
+assert.deepStrictEqual(conditions(getConditionChain(looped)), ['a']);


### PR DESCRIPTION
`elif` in the interview order block was in a bad place: writing one by hand got it destroyed, and the order builder gave you no way to write one at all. This makes it a branch you can add, alongside `then` and `else`.

## The bug it started from

`parse_order_code()` recognised `if` and `else` and nothing else. An `elif` line fell through to `_parse_line()` as a raw step, and its indented body became **sibling** steps rather than children — so `serialize_order_steps()` wrote that body back at the top level.

The order builder rewrites the whole code block on save, so opening it and saving was enough to change what the interview does:

```python
# before
if user_started_case:
    petition_screen
elif user_is_defendant:
    answer_screen
else:
    other_screen
```

```python
# after opening the order builder and saving
if user_started_case:
    petition_screen
elif user_is_defendant:
answer_screen
else:
other_screen
```

`answer_screen` and `other_screen` now run unconditionally. No error, no diagnostic. There was no test covering `elif`, and ["Adding conditional logic to the screen order"](https://assemblyline.suffolklitlab.org/docs/authoring/customizing_interview) tells authors to write exactly this.

## How a chain is stored

`elif` is stored the way Python means it: an `else` branch holding exactly one condition. One shape on the wire, so a chain of any length round-trips, and the serializer writes an `else`-holding-one-condition back out as `elif` rather than as a growing ladder of nested `if`.

That means a chain the author builds in the UI and a chain they wrote by hand are the same thing by the time either is saved.

## What the builder does now

- **Add else if branch** on any condition, from any link of the chain. It attaches at the end; a chain that already ends in `else` keeps it, with the new branch going in front — where an author adding one means it.
- **Add else branch** now attaches to the end of the chain too. Before this, a chain whose head already had an `elif` offered no way to add a final `else` at all, because the head's else slot was taken by the `elif`.
- The chain draws **flat** inside one collapsible region — each link labelled `elif` and aligned with the `else` below it — instead of indenting every branch a level deeper than the last.
- **Removing an `elif`** closes the chain up behind it. The generic list removal would have left `else: pass` and taken the rest of the chain with it.
- The order preview shows the `elif` the server will write, not the nested `if` the steps are stored as.

Steps inside an `elif` stay draggable through the normal drop list. The `elif` row itself is not a drag target — it is a branch of its chain, not a step you can drop elsewhere.

## Where the logic lives

The chain rules are in `editor_serializers.js` as pure functions, so the node suite exercises them directly rather than through DOM code, and `editor.js` reads them through thin wrappers instead of growing a second copy.

## Tests

**`test_editor_order_conditions.py`** (8) — parser and serializer: round trips for a chain with and without a trailing `else` and for one nested inside another condition; plain `if`/`else` unchanged; the parsed shape is a condition inside `else_children`; step ids unique across a chain; `else` holding one condition serializes as `elif`, while `else` holding a condition *plus* other steps stays a real `else`.

**`test_editor_serializers.js`** (~30 assertions) — chain reading and the two mutations: a lone `if`; an `else` that ends the chain; a three-link chain; `isChainLink` telling a real `elif` from a condition that merely sits in an else beside other steps; appending from the head and from a middle link; a trailing `else` surviving an append; removing a middle link, removing the only link, refusing to remove something that is not a link; and a self-referencing branch terminating instead of hanging.

**`test_editor_frontend.py`** — the wiring, including that all six chain helpers are read from the module rather than reimplemented.

I also checked the two halves against each other directly: a chain built through `appendChainElif` in node, fed to the Python serializer, produces

```python
if a:
  one
elif b:
  two
elif c:
  three
else:
  fallback
```

and reparses to itself.

Full suite green: 565 passed, 649 subtests. `mypy -p docassemble.ALWeaver` clean, `black` clean.

## Verified on a live server

Deployed with `dainstall` to a local Docassemble and driven through `/al/editor` in a browser as a signed-in developer. Opening the order builder on an interview containing `elif` and clicking **Save order** — nothing edited — corrupts the file on `main` and is a byte-identical no-op on this branch. Adding and naming a fourth branch through the UI places it before the existing `else` and saves correctly.

Full before/after with screenshots is in the comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
