### PR TITLE
Give ALPeopleList a real control for how many people are in the group

### DIFF
--- a/docassemble/ALWeaver/data/static/editor.css
+++ b/docassemble/ALWeaver/data/static/editor.css
@@ -2161,6 +2161,45 @@ html, body {
   font-size: 11px;
 }
 
+.editor-obj-quantity {
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  padding: 10px 12px;
+  margin: 0;
+  min-width: 0;
+}
+
+.editor-obj-quantity > legend {
+  float: none;
+  width: auto;
+  margin-bottom: 6px;
+  padding: 0;
+}
+
+.editor-obj-quantity .form-check {
+  margin-bottom: 4px;
+}
+
+.editor-obj-quantity .form-check:last-child {
+  margin-bottom: 0;
+}
+
+.editor-obj-quantity .form-check-label {
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.editor-obj-quantity .editor-obj-hint {
+  display: block;
+}
+
+.editor-obj-quantity-number {
+  display: grid;
+  gap: 2px;
+  max-width: 180px;
+  margin: 6px 0 2px;
+}
+
 @media (max-width: 991.98px) {
   .editor-obj-topline {
     grid-template-columns: 1fr;

--- a/docassemble/ALWeaver/data/static/editor.js
+++ b/docassemble/ALWeaver/data/static/editor.js
@@ -3936,6 +3936,91 @@
     });
   }
 
+  // Lists of people are the one `.using()` call authors are routinely told to
+  // write by hand -- "Setting the number of people in a group" in the
+  // AssemblyLine authoring docs -- so the three parameters that answer that
+  // question get a real control instead of a text box.  Everything else in the
+  // call is left in the author's own words next to it.
+  var PEOPLE_LIST_CLASSES = ['ALPeopleList'];
+
+  function _isPeopleListClass(className) {
+    return PEOPLE_LIST_CLASSES.indexOf(String(className || '').trim()) !== -1;
+  }
+
+  /* Returns the quantity state for a people list whose parameters this control
+     can safely own, or null -- meaning render the plain text box, because
+     rewriting a parameter list we did not fully understand would lose part of
+     what the author wrote. */
+  function _peopleListQuantity(className, usingArgs) {
+    if (!_isPeopleListClass(className)) return null;
+    if (!window.ALWeaverSerializers || !window.ALWeaverSerializers.readPeopleListQuantity) return null;
+    var quantity = window.ALWeaverSerializers.readPeopleListQuantity(usingArgs);
+    return quantity && quantity.editable ? quantity : null;
+  }
+
+  function _renderPeopleListQuantity(oi, quantity) {
+    var modes = (window.ALWeaverSerializers && window.ALWeaverSerializers.PEOPLE_LIST_QUANTITY_MODES) || [];
+    var groupName = 'editor-obj-quantity-' + oi;
+    var html = '<fieldset class="editor-form-group editor-form-group-compact editor-obj-quantity" data-obj-quantity="1">';
+    html += '<legend class="editor-tiny">How many people?</legend>';
+    modes.forEach(function (modeOption, mi) {
+      var inputId = groupName + '-' + mi;
+      var checked = quantity.mode === modeOption.value ? ' checked' : '';
+      html += '<div class="form-check">';
+      html += '<input class="form-check-input" type="radio" name="' + groupName + '" id="' + inputId + '" value="' + esc(modeOption.value) + '" data-obj-quantity-mode="1"' + checked + '>';
+      html += '<label class="form-check-label" for="' + inputId + '">' + esc(modeOption.label);
+      html += '<span class="editor-obj-hint">' + esc(modeOption.hint) + '</span></label>';
+      if (modeOption.value === 'exactly') {
+        html += '<div class="editor-obj-quantity-number' + (quantity.mode === 'exactly' ? '' : ' d-none') + '">';
+        html += '<label class="editor-tiny" for="' + groupName + '-number">Number of people</label>';
+        html += '<input class="form-control editor-form-control editor-obj-input" id="' + groupName + '-number" type="number" min="0" step="1" value="' + esc(String(quantity.number)) + '" data-obj-quantity-number="1">';
+        html += '</div>';
+      }
+      html += '</div>';
+    });
+    html += '</fieldset>';
+    return html;
+  }
+
+  /* Read the object rows currently on screen back into the block, so a redraw
+     keeps edits that have not been saved yet. */
+  function _syncObjectEditorRowsFromDom() {
+    var block = getSelectedBlock();
+    if (!block || block.type !== 'objects') return;
+    var rows = $$('.editor-obj-row');
+    if (!rows.length) return;
+    block.editor_objects = rows.map(function (row) {
+      var nameEl = row.querySelector('[data-obj-prop="name"]');
+      var modeEl = row.querySelector('[data-obj-prop="mode"]');
+      var classEl = row.querySelector('[data-obj-prop="class"]');
+      var usingArgsEl = row.querySelector('[data-obj-prop="using-args"]');
+      var rawExprEl = row.querySelector('[data-obj-prop="expression"]');
+      var mode = modeEl ? String(modeEl.value || 'raw') : 'raw';
+      var className = classEl ? String(classEl.value || '').trim() : '';
+      var usingArgs = usingArgsEl ? String(usingArgsEl.value || '').trim() : '';
+      var quantityEl = row.querySelector('[data-obj-quantity]');
+      if (quantityEl && window.ALWeaverSerializers && window.ALWeaverSerializers.composePeopleListUsingArgs) {
+        var checkedMode = row.querySelector('[data-obj-quantity-mode]:checked');
+        var numberEl = row.querySelector('[data-obj-quantity-number]');
+        usingArgs = window.ALWeaverSerializers.composePeopleListUsingArgs(
+          checkedMode ? String(checkedMode.value || 'ask') : 'ask',
+          numberEl ? numberEl.value : 1,
+          usingArgs
+        );
+      }
+      var rawExpression = rawExprEl ? String(rawExprEl.value || '').trim() : '';
+      return {
+        name: nameEl ? String(nameEl.value || '').trim() : '',
+        mode: mode,
+        class_name: className,
+        using_args: usingArgs,
+        raw_expression: mode === 'using' ? _composeObjectExpression(className || 'DAObject', usingArgs) : rawExpression,
+        expression: mode === 'using' ? _composeObjectExpression(className || 'DAObject', usingArgs) : rawExpression,
+        is_document_bundle: className === 'ALDocumentBundle',
+      };
+    });
+  }
+
   function _composeObjectExpression(className, usingArgs) {
     var cleanClass = String(className || '').trim();
     var cleanArgs = String(usingArgs || '').trim();
@@ -3986,6 +4071,16 @@
         if (mode === 'using') {
           var className = classEl ? String(classEl.value || '').trim() : '';
           var usingArgs = usingArgsEl ? String(usingArgsEl.value || '').trim() : '';
+          var quantityEl = row.querySelector('[data-obj-quantity]');
+          if (quantityEl && window.ALWeaverSerializers && window.ALWeaverSerializers.composePeopleListUsingArgs) {
+            var checkedMode = row.querySelector('[data-obj-quantity-mode]:checked');
+            var numberEl = row.querySelector('[data-obj-quantity-number]');
+            usingArgs = window.ALWeaverSerializers.composePeopleListUsingArgs(
+              checkedMode ? String(checkedMode.value || 'ask') : 'ask',
+              numberEl ? numberEl.value : 1,
+              usingArgs
+            );
+          }
           expression = _composeObjectExpression(className || 'DAObject', usingArgs);
         } else {
           expression = rawExprEl ? String(rawExprEl.value || '').trim() : '';
@@ -6588,9 +6683,14 @@
           }
           html += '</div>';
           if (mode === 'using') {
+            var quantity = _peopleListQuantity(className, usingArgs);
+            if (quantity) {
+              html += _renderPeopleListQuantity(oi, quantity);
+              usingArgs = quantity.otherArgs;
+            }
             html += '<div class="editor-form-group editor-form-group-compact">';
-            html += '<label class="editor-tiny" for="editor-obj-using-' + oi + '">.using() parameters</label>';
-            html += '<textarea class="form-control editor-form-control editor-obj-input font-monospace editor-obj-textarea" id="editor-obj-using-' + oi + '" data-obj-prop="using-args" rows="4" placeholder="elements=[...],&#10;filename=&quot;bundle&quot;,&#10;title=&quot;Document set&quot;">' + esc(usingArgs) + '</textarea>';
+            html += '<label class="editor-tiny" for="editor-obj-using-' + oi + '">' + (quantity ? 'Other .using() parameters' : '.using() parameters') + '</label>';
+            html += '<textarea class="form-control editor-form-control editor-obj-input font-monospace editor-obj-textarea" id="editor-obj-using-' + oi + '" data-obj-prop="using-args" rows="' + (quantity ? 2 : 4) + '" placeholder="elements=[...],&#10;filename=&quot;bundle&quot;,&#10;title=&quot;Document set&quot;">' + esc(usingArgs) + '</textarea>';
             if (obj.is_document_bundle) {
               html += '<div class="editor-obj-hint">Common <code>ALDocumentBundle</code> params: <code>elements=[...]</code>, <code>filename=...</code>, <code>title=...</code>, <code>enabled=True</code>.</div>';
             }
@@ -9709,6 +9809,21 @@
     }
     if (target.matches('.editor-field-required-switch') || target.id === 'adv-mandatory-switch' || target.id === 'review-skip-undefined') {
       markInterviewDirty();
+      return;
+    }
+    if (target.matches('[data-obj-quantity-mode]')) {
+      var quantityRow = target.closest('.editor-obj-row');
+      var numberWrap = quantityRow && quantityRow.querySelector('.editor-obj-quantity-number');
+      if (numberWrap) numberWrap.classList.toggle('d-none', target.value !== 'exactly');
+      markInterviewDirty();
+      return;
+    }
+    // Typing a class name in or out of ALPeopleList decides whether the
+    // quantity control applies, so commit the row and redraw it.
+    if (target.matches('[data-obj-prop="class"]')) {
+      _syncObjectEditorRowsFromDom();
+      markInterviewDirty();
+      renderCanvas();
       return;
     }
     if (target.id === 'section-upload-input') {

--- a/docassemble/ALWeaver/data/static/editor.js
+++ b/docassemble/ALWeaver/data/static/editor.js
@@ -4027,9 +4027,16 @@
     if (!cleanClass) return '';
     if (!cleanArgs) return cleanClass;
     if (cleanArgs.indexOf('\n') === -1) return cleanClass + '.using(' + cleanArgs + ')';
-    var indentedArgs = cleanArgs.split('\n').map(function (line) {
-      return line ? '  ' + line : '';
-    }).join('\n');
+    // A multi-argument call is shown one argument per line with the commas
+    // stripped, and that is the form that comes back here on save. Put the
+    // commas back, or what gets written is not valid Python.
+    var argList = window.ALWeaverSerializers.splitUsingArgs(cleanArgs);
+    if (argList === null || !argList.length) {
+      argList = cleanArgs.split('\n').map(function (line) { return line.trim(); })
+        .filter(function (line) { return line !== ''; });
+    }
+    if (!argList.length) return cleanClass;
+    var indentedArgs = argList.map(function (arg) { return '  ' + arg; }).join(',\n');
     return cleanClass + '.using(\n' + indentedArgs + '\n)';
   }
 
@@ -6690,7 +6697,13 @@
             }
             html += '<div class="editor-form-group editor-form-group-compact">';
             html += '<label class="editor-tiny" for="editor-obj-using-' + oi + '">' + (quantity ? 'Other .using() parameters' : '.using() parameters') + '</label>';
-            html += '<textarea class="form-control editor-form-control editor-obj-input font-monospace editor-obj-textarea" id="editor-obj-using-' + oi + '" data-obj-prop="using-args" rows="' + (quantity ? 2 : 4) + '" placeholder="elements=[...],&#10;filename=&quot;bundle&quot;,&#10;title=&quot;Document set&quot;">' + esc(usingArgs) + '</textarea>';
+            // The quantity control owns the parameters a people list is
+            // usually configured with, so suggesting bundle parameters next to
+            // it would point at the wrong thing.
+            var usingPlaceholder = quantity
+              ? 'complete_attribute=&quot;name&quot;'
+              : 'elements=[...],&#10;filename=&quot;bundle&quot;,&#10;title=&quot;Document set&quot;';
+            html += '<textarea class="form-control editor-form-control editor-obj-input font-monospace editor-obj-textarea" id="editor-obj-using-' + oi + '" data-obj-prop="using-args" rows="' + (quantity ? 2 : 4) + '" placeholder="' + usingPlaceholder + '">' + esc(usingArgs) + '</textarea>';
             if (obj.is_document_bundle) {
               html += '<div class="editor-obj-hint">Common <code>ALDocumentBundle</code> params: <code>elements=[...]</code>, <code>filename=...</code>, <code>title=...</code>, <code>enabled=True</code>.</div>';
             }

--- a/docassemble/ALWeaver/data/static/editor_serializers.js
+++ b/docassemble/ALWeaver/data/static/editor_serializers.js
@@ -178,7 +178,15 @@
     },
   ];
 
-  /* Split a `.using()` argument list on top-level commas.
+  /* Split a `.using()` argument list into its arguments.
+
+     Top-level commas separate arguments, and so do newlines: the editor
+     normalizes any call with more than one argument onto separate lines
+     before the browser ever sees it (`_format_object_using_args`), so
+     `ask_number=True, target_number=1` arrives here as two lines with no
+     comma between them. Splitting on commas alone made every multi-argument
+     call look like one malformed argument.
+
      Returns null when brackets or quotes are unbalanced, because a partial
      split would silently drop an argument. */
   function splitUsingArgs(argText) {
@@ -210,7 +218,7 @@
         depth--;
         if (depth < 0) return null;
       }
-      if (ch === ',' && depth === 0) {
+      if ((ch === ',' || ch === '\n') && depth === 0) {
         parts.push(current);
         current = '';
         continue;

--- a/docassemble/ALWeaver/data/static/editor_serializers.js
+++ b/docassemble/ALWeaver/data/static/editor_serializers.js
@@ -140,8 +140,205 @@
     return appendQuestionAdvancedYaml(yaml, block);
   }
 
+  // -------------------------------------------------------------------------
+  // ALPeopleList quantity
+  //
+  // "Setting the number of people in a group" in the AssemblyLine authoring
+  // docs is one `.using()` call with a handful of recognised shapes.  Reading
+  // those shapes back out of source is the part that has to be exact: the
+  // graphical control may only take over a parameter list it fully
+  // understands, because anything it takes over it also rewrites.  Anything
+  // else -- an expression instead of a literal, a repeated key, a positional
+  // argument, unbalanced brackets -- is reported as not editable, and the
+  // caller leaves the author's own text alone.
+  // -------------------------------------------------------------------------
+
+  var PEOPLE_LIST_QUANTITY_KEYS = ['there_are_any', 'ask_number', 'target_number'];
+
+  var PEOPLE_LIST_QUANTITY_MODES = [
+    {
+      value: 'ask',
+      label: 'Ask whether there are any',
+      hint: 'The default. Asks if there are any, then collects them one at a time.',
+    },
+    {
+      value: 'at_least_one',
+      label: 'At least one',
+      hint: 'Skips the "are there any?" question and starts with one.',
+    },
+    {
+      value: 'ask_count',
+      label: 'Ask how many',
+      hint: 'Asks for a number first, then collects that many.',
+    },
+    {
+      value: 'exactly',
+      label: 'Exactly this many',
+      hint: 'Never asks. Use this when the form has room for a fixed number.',
+    },
+  ];
+
+  /* Split a `.using()` argument list on top-level commas.
+     Returns null when brackets or quotes are unbalanced, because a partial
+     split would silently drop an argument. */
+  function splitUsingArgs(argText) {
+    var text = String(argText === undefined || argText === null ? '' : argText).trim();
+    if (!text) return [];
+    var parts = [];
+    var current = '';
+    var depth = 0;
+    var quote = null;
+    for (var i = 0; i < text.length; i++) {
+      var ch = text.charAt(i);
+      if (quote) {
+        current += ch;
+        if (ch === '\\' && i + 1 < text.length) {
+          current += text.charAt(i + 1);
+          i++;
+        } else if (ch === quote) {
+          quote = null;
+        }
+        continue;
+      }
+      if (ch === '"' || ch === "'") {
+        quote = ch;
+        current += ch;
+        continue;
+      }
+      if (ch === '(' || ch === '[' || ch === '{') depth++;
+      if (ch === ')' || ch === ']' || ch === '}') {
+        depth--;
+        if (depth < 0) return null;
+      }
+      if (ch === ',' && depth === 0) {
+        parts.push(current);
+        current = '';
+        continue;
+      }
+      current += ch;
+    }
+    if (depth !== 0 || quote) return null;
+    parts.push(current);
+    return parts
+      .map(function (part) { return part.trim(); })
+      .filter(function (part) { return part !== ''; });
+  }
+
+  /* Pull the quantity parameters out of a `.using()` argument list.
+
+     Returns `{ editable, mode, number, otherArgs }`.  When `editable` is
+     false the argument list holds something this control cannot own, and the
+     caller must fall back to editing the text directly. */
+  function readPeopleListQuantity(argText) {
+    var fallback = {
+      editable: false,
+      mode: 'ask',
+      number: 1,
+      otherArgs: String(argText === undefined || argText === null ? '' : argText).trim(),
+    };
+
+    var parts = splitUsingArgs(argText);
+    if (parts === null) return fallback;
+
+    var quantity = {};
+    var others = [];
+    var seen = {};
+    for (var i = 0; i < parts.length; i++) {
+      var part = parts[i];
+      var eq = _topLevelAssignmentIndex(part);
+      if (eq === -1) {
+        // A positional argument or `**kwargs`. Either could carry a quantity
+        // parameter this control would then contradict, so say nothing.
+        return fallback;
+      }
+      var key = part.slice(0, eq).trim();
+      var value = part.slice(eq + 1).trim();
+      if (PEOPLE_LIST_QUANTITY_KEYS.indexOf(key) === -1) {
+        others.push(part);
+        continue;
+      }
+      if (seen[key]) return fallback;
+      seen[key] = true;
+      quantity[key] = value;
+    }
+
+    var hasAny = Object.prototype.hasOwnProperty.call(quantity, 'there_are_any');
+    var hasAsk = Object.prototype.hasOwnProperty.call(quantity, 'ask_number');
+    var hasTarget = Object.prototype.hasOwnProperty.call(quantity, 'target_number');
+    var otherArgs = others.join(', ');
+
+    if (!hasAny && !hasAsk && !hasTarget) {
+      return { editable: true, mode: 'ask', number: 1, otherArgs: otherArgs };
+    }
+    if (hasAny && !hasAsk && !hasTarget && quantity.there_are_any === 'True') {
+      return { editable: true, mode: 'at_least_one', number: 1, otherArgs: otherArgs };
+    }
+    if (hasAsk && !hasAny && quantity.ask_number === 'True') {
+      if (!hasTarget) {
+        return { editable: true, mode: 'ask_count', number: 1, otherArgs: otherArgs };
+      }
+      if (/^\d+$/.test(quantity.target_number)) {
+        return {
+          editable: true,
+          mode: 'exactly',
+          number: parseInt(quantity.target_number, 10),
+          otherArgs: otherArgs,
+        };
+      }
+    }
+    return fallback;
+  }
+
+  /* Build the `.using()` argument list for a chosen quantity, keeping any
+     parameters the control does not own in the order the author wrote them. */
+  function composePeopleListUsingArgs(mode, number, otherArgs) {
+    var quantityArgs = [];
+    if (mode === 'at_least_one') {
+      quantityArgs.push('there_are_any=True');
+    } else if (mode === 'ask_count') {
+      quantityArgs.push('ask_number=True');
+    } else if (mode === 'exactly') {
+      var count = parseInt(number, 10);
+      if (isNaN(count) || count < 0) count = 1;
+      quantityArgs.push('ask_number=True');
+      quantityArgs.push('target_number=' + count);
+    }
+    var rest = splitUsingArgs(otherArgs);
+    if (rest === null) {
+      var raw = String(otherArgs === undefined || otherArgs === null ? '' : otherArgs).trim();
+      rest = raw ? [raw] : [];
+    }
+    return quantityArgs.concat(rest).join(', ');
+  }
+
+  function _topLevelAssignmentIndex(part) {
+    var depth = 0;
+    var quote = null;
+    for (var i = 0; i < part.length; i++) {
+      var ch = part.charAt(i);
+      if (quote) {
+        if (ch === '\\') { i++; continue; }
+        if (ch === quote) quote = null;
+        continue;
+      }
+      if (ch === '"' || ch === "'") { quote = ch; continue; }
+      if (ch === '(' || ch === '[' || ch === '{') depth++;
+      if (ch === ')' || ch === ']' || ch === '}') depth--;
+      if (ch !== '=' || depth !== 0) continue;
+      // Skip ==, <=, >=, != so a comparison is never read as a keyword.
+      if (part.charAt(i + 1) === '=') { i++; continue; }
+      if ('=!<>'.indexOf(part.charAt(i - 1)) !== -1) continue;
+      return i;
+    }
+    return -1;
+  }
+
   return {
     escapeYamlStr: escapeYamlStr,
     serializeQuestionToYaml: serializeQuestionToYaml,
+    splitUsingArgs: splitUsingArgs,
+    readPeopleListQuantity: readPeopleListQuantity,
+    composePeopleListUsingArgs: composePeopleListUsingArgs,
+    PEOPLE_LIST_QUANTITY_MODES: PEOPLE_LIST_QUANTITY_MODES,
   };
 });

--- a/docassemble/ALWeaver/editor_utils.py
+++ b/docassemble/ALWeaver/editor_utils.py
@@ -225,7 +225,10 @@ def _split_top_level_commas(text: str) -> List[str]:
             depth += 1
         elif char in ")]}":
             depth = max(0, depth - 1)
-        elif char == "," and depth == 0:
+        elif char in ",\n" and depth == 0:
+            # Newlines separate arguments as well as commas: a multi-argument
+            # call is displayed one argument per line with the commas removed,
+            # and that display form comes back through here on the way out.
             segment = "".join(current[:-1]).strip()
             if segment:
                 parts.append(segment)
@@ -278,9 +281,12 @@ def _compose_object_using_expression(class_name: str, using_args: str) -> str:
         return cleaned_class_name
     if "\n" not in cleaned_args:
         return f"{cleaned_class_name}.using({cleaned_args})"
-    indented_args = "\n".join(
-        f"  {line}" if line else "" for line in cleaned_args.splitlines()
-    )
+    # The display form drops the commas between arguments. Put them back, or
+    # the composed expression is not valid Python.
+    arguments = _split_top_level_commas(cleaned_args)
+    if not arguments:
+        return cleaned_class_name
+    indented_args = ",\n".join(f"  {argument}" for argument in arguments)
     return f"{cleaned_class_name}.using(\n{indented_args}\n)"
 
 

--- a/docassemble/ALWeaver/test_editor_frontend.py
+++ b/docassemble/ALWeaver/test_editor_frontend.py
@@ -118,6 +118,28 @@ class TestEditorFrontend(unittest.TestCase):
         self.assertIn("apiPost('/api/github/pull'", editor)
         self.assertIn("Local changes will be preserved", editor)
 
+    def test_people_list_quantity_has_a_control_instead_of_a_text_box(self):
+        editor = (self.package_dir / "data/static/editor.js").read_text()
+        css = (self.package_dir / "data/static/editor.css").read_text()
+
+        # The control only claims ALPeopleList, and only when the parameter
+        # list is one it fully understands.
+        self.assertIn("var PEOPLE_LIST_CLASSES = ['ALPeopleList'];", editor)
+        self.assertIn("readPeopleListQuantity(usingArgs)", editor)
+        self.assertIn("return quantity && quantity.editable ? quantity : null;", editor)
+        self.assertIn("How many people?", editor)
+        self.assertIn("Other .using() parameters", editor)
+
+        # Both the save path and the redraw path recompose through the same
+        # helper, so the two can't drift apart.
+        self.assertEqual(editor.count("composePeopleListUsingArgs("), 2)
+        self.assertIn("function _syncObjectEditorRowsFromDom()", editor)
+        self.assertIn("target.matches('[data-obj-quantity-mode]')", editor)
+        self.assertIn("target.matches('[data-obj-prop=\"class\"]')", editor)
+
+        self.assertIn(".editor-obj-quantity", css)
+        self.assertIn(".editor-obj-quantity-number", css)
+
     def test_new_project_accepts_an_unrestricted_github_url(self):
         editor = (self.package_dir / "data/static/editor.js").read_text()
 

--- a/docassemble/ALWeaver/test_editor_object_primitives.py
+++ b/docassemble/ALWeaver/test_editor_object_primitives.py
@@ -55,3 +55,66 @@ class TestALIndividualPrimitiveGroups(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestObjectUsingExpressionRoundTrip(unittest.TestCase):
+    """A multi-argument ``.using()`` call is displayed one argument per line
+    with the commas stripped.  Composing that display form back into an
+    expression has to put them back, or the editor writes a call that is not
+    valid Python and the object silently fails to build.
+    """
+
+    def test_multiline_arguments_keep_their_commas(self):
+        from .editor_utils import _compose_object_using_expression
+
+        composed = _compose_object_using_expression(
+            "ALDocumentBundle",
+            'elements=[]\nfilename="court_bundle"\ntitle="All forms"',
+        )
+
+        self.assertEqual(
+            composed,
+            "ALDocumentBundle.using(\n"
+            "  elements=[],\n"
+            '  filename="court_bundle",\n'
+            '  title="All forms"\n'
+            ")",
+        )
+
+    def test_single_argument_stays_inline(self):
+        from .editor_utils import _compose_object_using_expression
+
+        self.assertEqual(
+            _compose_object_using_expression("ALPeopleList", "there_are_any=True"),
+            "ALPeopleList.using(there_are_any=True)",
+        )
+
+    def test_a_full_read_compose_round_trip_preserves_the_call(self):
+        from .editor_utils import (
+            _compose_object_using_expression,
+            _format_object_using_args,
+            _split_object_using_expression,
+        )
+
+        original = (
+            'ALDocumentBundle.using(elements=[a, b], filename="bundle", title="All")'
+        )
+        class_name, args_text = _split_object_using_expression(original)
+        displayed = _format_object_using_args(args_text, raw_expression=original)
+        composed = _compose_object_using_expression(class_name, displayed)
+
+        # Reading the composed form again must yield the same arguments, which
+        # is only true if the commas survived.
+        _class_again, args_again = _split_object_using_expression(composed)
+        self.assertEqual(
+            _format_object_using_args(args_again, raw_expression=composed),
+            displayed,
+        )
+
+    def test_a_comma_inside_a_bracket_is_not_an_argument_separator(self):
+        from .editor_utils import _split_top_level_commas
+
+        self.assertEqual(
+            _split_top_level_commas('elements=[a, b]\nfilename="x"'),
+            ["elements=[a, b]", 'filename="x"'],
+        )

--- a/docassemble/ALWeaver/test_editor_serializers.js
+++ b/docassemble/ALWeaver/test_editor_serializers.js
@@ -146,7 +146,32 @@ const {
   PEOPLE_LIST_QUANTITY_MODES,
 } = serializers;
 
-// Splitting only ever happens on top-level commas.
+// The editor normalizes any multi-argument `.using()` call onto separate lines
+// before the browser sees it, so newlines separate arguments just like commas.
+// Testing only the comma form hid this: the docs' own "exactly one" example
+// reaches this code as two lines and got no control at all.
+assert.deepStrictEqual(
+  splitUsingArgs('ask_number=True\ntarget_number=1'),
+  ['ask_number=True', 'target_number=1']
+);
+const normalizedExactly = readPeopleListQuantity('ask_number=True\ntarget_number=1');
+assert.strictEqual(normalizedExactly.editable, true);
+assert.strictEqual(normalizedExactly.mode, 'exactly');
+assert.strictEqual(normalizedExactly.number, 1);
+
+const normalizedWithOthers = readPeopleListQuantity(
+  "ask_number=True\ntarget_number=2\ncomplete_attribute='name'"
+);
+assert.strictEqual(normalizedWithOthers.editable, true);
+assert.strictEqual(normalizedWithOthers.mode, 'exactly');
+assert.strictEqual(normalizedWithOthers.number, 2);
+assert.strictEqual(normalizedWithOthers.otherArgs, "complete_attribute='name'");
+
+// A newline inside brackets or quotes is not a separator.
+assert.deepStrictEqual(splitUsingArgs('elements=[\n  a,\n  b\n]'), ['elements=[\n  a,\n  b\n]']);
+assert.deepStrictEqual(splitUsingArgs('title="two\nlines"'), ['title="two\nlines"']);
+
+// Splitting on top-level commas.
 assert.deepStrictEqual(splitUsingArgs(''), []);
 assert.deepStrictEqual(splitUsingArgs('a=1, b=2'), ['a=1', 'b=2']);
 assert.deepStrictEqual(splitUsingArgs('a=[1, 2], b=f(3, 4)'), ['a=[1, 2]', 'b=f(3, 4)']);

--- a/docassemble/ALWeaver/test_editor_serializers.js
+++ b/docassemble/ALWeaver/test_editor_serializers.js
@@ -134,3 +134,108 @@ const modifierYaml = serialize('text', modifierKeys);
 modifierKeys.forEach((key) => {
   assert.ok(modifierYaml.includes('    ' + key + ': modifier_value\n'), key);
 });
+
+// ---------------------------------------------------------------------------
+// ALPeopleList quantity — "Setting the number of people in a group"
+// ---------------------------------------------------------------------------
+
+const {
+  splitUsingArgs,
+  readPeopleListQuantity,
+  composePeopleListUsingArgs,
+  PEOPLE_LIST_QUANTITY_MODES,
+} = serializers;
+
+// Splitting only ever happens on top-level commas.
+assert.deepStrictEqual(splitUsingArgs(''), []);
+assert.deepStrictEqual(splitUsingArgs('a=1, b=2'), ['a=1', 'b=2']);
+assert.deepStrictEqual(splitUsingArgs('a=[1, 2], b=f(3, 4)'), ['a=[1, 2]', 'b=f(3, 4)']);
+assert.deepStrictEqual(splitUsingArgs('a="x, y", b=2'), ['a="x, y"', 'b=2']);
+// Unbalanced input is refused rather than half-parsed.
+assert.strictEqual(splitUsingArgs('a=[1, 2'), null);
+assert.strictEqual(splitUsingArgs("a='unterminated"), null);
+
+// The three shapes the AssemblyLine docs describe.
+const bare = readPeopleListQuantity('');
+assert.strictEqual(bare.editable, true);
+assert.strictEqual(bare.mode, 'ask');
+
+const atLeastOne = readPeopleListQuantity('there_are_any=True');
+assert.strictEqual(atLeastOne.editable, true);
+assert.strictEqual(atLeastOne.mode, 'at_least_one');
+
+const exactlyOne = readPeopleListQuantity('ask_number=True, target_number=1');
+assert.strictEqual(exactlyOne.editable, true);
+assert.strictEqual(exactlyOne.mode, 'exactly');
+assert.strictEqual(exactlyOne.number, 1);
+
+const askCount = readPeopleListQuantity('ask_number=True');
+assert.strictEqual(askCount.editable, true);
+assert.strictEqual(askCount.mode, 'ask_count');
+
+// Parameters the control does not own survive untouched, in source order.
+const withOthers = readPeopleListQuantity('there_are_any=True, complete_attribute="name"');
+assert.strictEqual(withOthers.editable, true);
+assert.strictEqual(withOthers.mode, 'at_least_one');
+assert.strictEqual(withOthers.otherArgs, 'complete_attribute="name"');
+
+// Anything the control cannot fully account for is left to the author.
+[
+  'target_number=how_many',            // an expression, not a literal
+  'ask_number=True, target_number=n+1',
+  'there_are_any=False',               // a real setting, but not one of the modes
+  'there_are_any=True, ask_number=True',
+  'there_are_any=True, there_are_any=True',
+  'target_number=2',                   // target without ask_number
+  'there_are_any=maybe_any',
+  '**overrides',
+  'ask_number=[1',                     // unbalanced
+].forEach((args) => {
+  assert.strictEqual(readPeopleListQuantity(args).editable, false, args);
+  // A refusal must hand the original text back for the plain editor.
+  assert.strictEqual(readPeopleListQuantity(args).otherArgs, args, args);
+});
+
+// Composing is the exact inverse for every mode the control offers.
+assert.strictEqual(composePeopleListUsingArgs('ask', 1, ''), '');
+assert.strictEqual(composePeopleListUsingArgs('at_least_one', 1, ''), 'there_are_any=True');
+assert.strictEqual(composePeopleListUsingArgs('ask_count', 1, ''), 'ask_number=True');
+assert.strictEqual(
+  composePeopleListUsingArgs('exactly', 1, ''),
+  'ask_number=True, target_number=1'
+);
+assert.strictEqual(
+  composePeopleListUsingArgs('exactly', 3, 'complete_attribute="name"'),
+  'ask_number=True, target_number=3, complete_attribute="name"'
+);
+// A blank or nonsense count falls back to one rather than writing target_number=NaN.
+assert.strictEqual(
+  composePeopleListUsingArgs('exactly', '', ''),
+  'ask_number=True, target_number=1'
+);
+
+// Every offered mode round-trips through read -> compose -> read.
+PEOPLE_LIST_QUANTITY_MODES.forEach((mode) => {
+  const args = composePeopleListUsingArgs(mode.value, 2, 'complete_attribute="name"');
+  const parsed = readPeopleListQuantity(args);
+  assert.strictEqual(parsed.editable, true, mode.value);
+  assert.strictEqual(parsed.mode, mode.value, mode.value);
+  assert.strictEqual(parsed.otherArgs, 'complete_attribute="name"', mode.value);
+  if (mode.value === 'exactly') assert.strictEqual(parsed.number, 2);
+});
+
+// Reading a list and composing it again without touching the control is a no-op.
+[
+  '',
+  'there_are_any=True',
+  'ask_number=True',
+  'ask_number=True, target_number=1',
+  'ask_number=True, target_number=4, complete_attribute="name"',
+].forEach((args) => {
+  const parsed = readPeopleListQuantity(args);
+  assert.strictEqual(
+    composePeopleListUsingArgs(parsed.mode, parsed.number, parsed.otherArgs),
+    args,
+    args
+  );
+});


### PR DESCRIPTION
Implements the "number of people in a group" item from the `/al/editor` parity review — the highest benefit-to-cost fix on the authoring-docs list. It has no tracking issue of its own; the seven blocking gaps from that review are #1016–#1022.

## The problem

["Setting the number of people in a group"](https://assemblyline.suffolklitlab.org/docs/authoring/customizing_interview) is a whole section of the authoring docs, and the objects editor answered it with a free-text `.using()` box:

```
.using() parameters
┌─────────────────────────────────────┐
│ there_are_any=True                  │
└─────────────────────────────────────┘
```

To use it you had to already know that `there_are_any=True` means "at least one", that `ask_number=True, target_number=1` means "exactly one", and that a bare `ALPeopleList` asks whether there are any at all. The editor recognised `ALDocumentBundle` well enough to print a hint about its parameters, and offered nothing for `ALPeopleList` — the case authors actually hit.

Weaver already models these three states on the Python side (`_guess_people_quantities()` infers them from PDF field indices), so the vocabulary was understood everywhere except where an author could see it.

## What this does

On an `ALPeopleList` row, the parameter box is replaced by a four-way choice, with the remaining parameters kept in a text box beside it:

| Choice | Writes |
|---|---|
| Ask whether there are any | *(no parameters)* |
| At least one | `there_are_any=True` |
| Ask how many | `ask_number=True` |
| Exactly this many | `ask_number=True, target_number=N` |

The first three come straight from the docs' own example; the fourth is the same shape with the number exposed.

## Refusing rather than guessing

The control may only take over a parameter list it **fully** understands, because anything it takes over it also rewrites. Each of these is reported as not editable, and the author's own text is left exactly as written:

- a value that isn't a literal — `target_number=how_many`, `there_are_any=maybe_any`
- a combination that isn't one of the four modes — `there_are_any=False`, `there_are_any=True, ask_number=True`, `target_number=2` with no `ask_number`
- a repeated key
- a positional argument or `**kwargs`, either of which could carry a quantity parameter the control would then contradict
- unbalanced brackets or quotes, where a partial split would silently drop an argument

Parameters the control doesn't own — `complete_attribute="name"`, say — survive in the author's own order.

## Implementation notes

- Parsing and composition live in `editor_serializers.js` as pure functions, so the node suite exercises them directly instead of through DOM code.
- The save path and the redraw path recompose through the *same* helper, so a redraw can't write back something different from what a save would. There's a test asserting there are exactly two call sites.
- Editing the class name in or out of `ALPeopleList` commits the row and redraws it, so the control appears and disappears when it should without losing in-progress edits.
- Only `ALPeopleList` is claimed, via a named list that's easy to extend.

## Tests

- ~40 new assertions in `test_editor_serializers.js`: top-level splitting, each of the four modes, every refusal case above, round-trip through read → compose → read for all four modes, and read → compose being a no-op on untouched input.
- `test_people_list_quantity_has_a_control_instead_of_a_text_box` in `test_editor_frontend.py` for the wiring.

Full suite green: 557 passed, 649 subtests. `mypy -p docassemble.ALWeaver` clean, `black` clean.

## Verified on a live server

Deployed with `dainstall` and driven through `/al/editor` in a browser against an interview declaring seven objects covering every shape the control handles. That run found two bugs, both fixed in 0e6b78e:

1. **Mine.** The control never appeared for `ask_number=True, target_number=1` — the docs' own "exactly one" example. The editor normalizes multi-argument `.using()` calls onto separate lines before the browser sees them, so the arguments arrive with no comma between them. My tests fed the function comma-separated strings, so they tested its contract rather than the contract of the data it actually receives.
2. **Pre-existing.** Composing a multi-argument call back into an expression never restored the commas, so editing any one object and saving rewrote *every* multi-argument `.using()` call in the block into invalid Python and the interview stopped loading. Fixed in both the browser and the server composer, with regression tests. Say the word if you would rather this were a separate PR.

Full before/after with screenshots is in the comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
