### PR TITLE
Enhance AssemblyLine settings panel, LIST topic picker, and project creation metadata

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -39,9 +39,14 @@ Other files:
 - `configuration_capabilities.yml`: currently describes the list of optional
   packages someone can install in a generated package with the
   Weaver--envisioned to allow more flexible configuration in the future
-- `output_patterns.yml`: this file contains small Mako templates that are used
-  to build the YAML file that the Weaver produces. It is set up as a series of
-  small templates right now rather a single large template.
+The Mako templates that build the YAML the Weaver produces live in
+`docassemble/ALWeaver/data/templates`: `output.mako` is the body,
+`output_defs.mako` holds shared helpers, and `question_library.mako` holds the
+AssemblyLine person questions copied into a generated interview.
+`_render_interview_yaml()` (`interview_generator.py`) resolves and concatenates
+them. (An older `data/sources/output_patterns.yml` no longer exists;
+`assembly_line.yml` still names it in a `DAInterview.using(template_path=...)`
+argument that is not read.)
 
 This directory also contains test files for unit testing with ALKiln (see below for more information.)
 

--- a/docassemble/AGENTS.md
+++ b/docassemble/AGENTS.md
@@ -27,3 +27,120 @@ Weaver and the branchname, using CamelCase as no non-letter
 characters are allowed.
 
 Then run the test via server.com/start/playground[my user ID]/assembly_line
+
+## Running the checks locally
+
+Run pytest from a directory that is **not** the repo root:
+
+    cd /tmp && /path/to/repo/.venv/bin/python -m pytest /path/to/repo/docassemble/ALWeaver -q
+
+Running a *subset* of the tests from the repo root can fail every selected test
+at fixture setup with
+
+    ImportError: Blocked import of defusedxml from current working directory
+
+nltk's import guard refuses imports from the working directory, and the repo
+root contains `docassemble/`. The full suite happens to import in an order that
+avoids it, so this bites when you narrow to one file to debug something —
+exactly when a wall of errors is most misleading. It is not a real failure and
+has nothing to do with your change; move out of the root and re-run before
+investigating.
+
+CI runs unit tests, mypy and black (`black_linter.yml`). Run `black` and `mypy`
+on anything you touched before you call the work done.
+
+`data/static/editor.js` is a single ~10k-line file that builds its markup by
+string concatenation, so a missing quote is a runtime break, not a parse error
+in review. Run `node --check docassemble/ALWeaver/data/static/editor.js` after
+every edit to it.
+
+
+## Editing generated and author-written YAML
+
+The rule the editor is built around: **never re-serialize a document to change
+part of it.** Patch the exact source range and leave every other byte alone.
+Authors' comments, quote styles, key order and blank lines are theirs.
+
+Two traps in that, both of which have already caused bugs:
+
+- PyYAML ends a **block sequence** node where the *next token* begins, so the
+  node text runs past the last item and over any comment or blank line before
+  the following key. Use `node.value[-1].end_mark` for the real end. Plain and
+  block scalars do report accurate ends.
+- `ast` column offsets are **UTF-8 byte offsets**, not character offsets. Do
+  source edits driven by `ast` on `code.encode("utf-8")`.
+
+Re-read and verify a patch before keeping it, and refuse rather than guess when
+the source is not a shape you recognise. `update_settings()` and
+`validate_candidate_source()` both work this way, and the round-trip guard in
+`_update_metadata()` is what caught the multi-item-list corruption rather than
+shipping it.
+
+Write only what actually changed. Rewriting an unchanged value re-quotes
+literals the author typed by hand and produces a diff full of churn that hides
+the real edit.
+
+Distinguish a **literal** from a **computed** value before writing anything
+back. `al_form_type = form_type_for(case)` reaches the panel as its source text;
+rendering it through `repr()` turns working code into the string
+`'form_type_for(case)'`. Values the interview computes are read-only in the UI
+and skipped on save, and the UI says which block to edit by hand instead.
+
+One name, one home. If a setting is already assigned in an author-owned block,
+update it there rather than adding a second assignment in Weaver's block — two
+assignments of one name leave document order to decide the winner.
+
+
+## Derive facts, do not restate them
+
+Anything the UI says about the code should be computed from the code. The
+AssemblyLine settings panel names the YAML document each section writes to, and
+that list comes from the fields' own `scope` rather than a parallel table, so it
+cannot drift when a field moves between metadata and code. Prefer one more
+derivation over one more list to keep in sync.
+
+Comments explain *why*, not *what*. The interesting comments in this codebase
+record the constraint that forced the shape of the code — what PyYAML reports,
+what docassemble does on Enter, what a round-trip guard is protecting against.
+Match that; skip the ones that restate the line below them.
+
+`architecture.md` is the design document for the editor and is worth reading
+before any editor work. It is also worth correcting when you find it stale.
+
+
+## Editor front end
+
+Vanilla JS and Bootstrap, no jQuery. ALToolbox controls such as
+`al_tree_select` are docassemble `CustomDataType`s bound to jQuery and to
+docassemble's form machinery, so they cannot be dropped into the editor SPA;
+mirror the pattern (plain `<details>`/`<summary>` groups around plain
+checkboxes) instead of importing the file.
+
+`esc()` escapes quotes as well as angle brackets, because nearly every call site
+puts its output inside a double-quoted HTML attribute. Keep it that way.
+
+Guidance that the author needs *while typing* belongs under the control, not in
+a `placeholder`, which disappears exactly when it is wanted. Keep placeholders
+for genuine example values (`MA`, `15em`, `https://example.com/help`).
+
+There is no DOM test harness. `test_editor_frontend.py` asserts against the
+text of `editor.js` and `editor.html`, which is a cheap regression net for
+wiring, ids and copy — add to it when you add a control.
+
+
+## Generated interview conventions
+
+Filenames follow the AssemblyLine YAML coding style: a descriptive name derived
+from the document when the package holds one interview, `main.yml` for a
+runnable file in a package with several. Never `interview.yml`.
+
+`map_raw_to_final_display()` and the tables in `generator_constants.py` are the
+only thing that turns template field labels into AssemblyLine variables. It is
+always on; no toggle disables it, and the LLM assist path only rewrites labels
+and datatypes. Label UI accordingly so authors do not read a question-wording
+option as a naming option.
+
+Style-check findings come from ALDashboard's linter, which grades its own rules
+red/yellow/green. They are advisory: they never run inside
+`validate_candidate_source()` and never block a save, so do not present them at
+the same severity as a file that will not load.

--- a/docassemble/ALWeaver/api_editor.py
+++ b/docassemble/ALWeaver/api_editor.py
@@ -24,6 +24,7 @@ Provides:
     POST /al/editor/api/draft-order — generate a draft order from blocks
     POST /al/editor/api/draft-review-screen — generate draft review YAML
     GET  /al/editor/api/preview-url — get the interview preview URL
+    GET  /al/editor/api/list-topics — LIST taxonomy codes for the topic picker
     GET  /al/editor/api/weaver/validate — validate a saved YAML file
     POST /al/editor/api/validate-source — validate a submitted source buffer
     POST /al/editor/api/project/search — search every text file in a project
@@ -198,6 +199,8 @@ from .editor_agent_models import (
     store_progress,
 )
 from .editor_agent_validation import (
+    SEVERITY_ERROR,
+    SEVERITY_WARNING,
     annotate_lint_findings,
     block_line_span,
     block_lookup_map,
@@ -589,6 +592,28 @@ def _normalize_new_filename(raw: Optional[str]) -> str:
     return value
 
 
+# AssemblyLine's YAML coding style: a runnable file is `main.yml`, and a package
+# with a single interview may instead carry a descriptive name derived from the
+# document (`eviction.yml`).  https://assemblyline.suffolklitlab.org/docs/coding_style/yaml
+DEFAULT_NEW_INTERVIEW_FILENAME = "main.yml"
+
+
+def _normalize_new_interview_filename(raw: Optional[str]) -> Optional[str]:
+    """An author-supplied interview filename, or None to use the derived name."""
+    value = str(raw or "").strip()
+    if not value:
+        return None
+    return _normalize_new_filename(value)
+
+
+def _normalize_generated_filename(raw: Optional[str]) -> str:
+    """The filename Weaver derived for a generated interview, or the AL default."""
+    try:
+        return _normalize_new_filename(raw)
+    except ValueError:
+        return DEFAULT_NEW_INTERVIEW_FILENAME
+
+
 def _normalize_renamed_storage_filename(
     raw: Optional[str], existing_filename: str
 ) -> str:
@@ -708,6 +733,28 @@ def _run_interview_linter(raw_yaml: str, include_llm: bool = True) -> Dict[str, 
     from docassemble.ALDashboard.interview_linter import lint_interview_content
 
     return lint_interview_content(raw_yaml, include_llm=include_llm)
+
+
+def _demote_style_findings(findings: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Cap style findings at ``warning``.
+
+    The style checker is house style, not validity: it never runs inside
+    `validate_candidate_source()` and it never stops a save. ALDashboard grades
+    its own rules red/yellow/green, and red arrives here as `error` -- the same
+    level a YAML file that will not load produces. An interview that runs fine
+    but has a thin `metadata` block should not be reported the same way.
+    """
+    demoted: List[Dict[str, Any]] = []
+    for finding in findings:
+        item = dict(finding)
+        if _lint_level_from_severity(item.get("level") or item.get("severity")) == (
+            SEVERITY_ERROR
+        ):
+            item["level"] = SEVERITY_WARNING
+            item["severity"] = SEVERITY_WARNING
+            item["style_original_level"] = SEVERITY_ERROR
+        demoted.append(item)
+    return demoted
 
 
 def _is_text_editable(filename: str, mimetype: str) -> bool:
@@ -3088,8 +3135,10 @@ def editor_api_style_check() -> Response:
         )
         if not isinstance(findings, list):
             findings = []
-        annotated_findings = _annotate_lint_findings(
-            findings, model["blocks"], source_name="style-check"
+        annotated_findings = _demote_style_findings(
+            _annotate_lint_findings(
+                findings, model["blocks"], source_name="style-check"
+            )
         )
         summary = _lint_summary_for_findings(annotated_findings)
 
@@ -3907,6 +3956,106 @@ def editor_api_save_metadata() -> Response:
         )
 
 
+def _resolve_server_defaults() -> Dict[str, Dict[str, Any]]:
+    """What each server-wide AssemblyLine setting resolves to right now.
+
+    Several of these settings exist server-wide as well as per interview, so
+    typing a value into the panel silently overrides the whole server for this
+    one interview. The panel says so, which means it needs the value being
+    overridden.
+    """
+    from .assemblyline_settings import ASSEMBLY_LINE_FALLBACKS, SERVER_DEFAULTS
+
+    resolved: Dict[str, Dict[str, Any]] = {}
+    for key, config_key in SERVER_DEFAULTS.items():
+        entry: Dict[str, Any] = {
+            "config_key": config_key,
+            "value": "",
+            "source": "assemblyline",
+        }
+        if config_key:
+            config_value = _daconfig().get(config_key)
+            if config_value not in (None, ""):
+                entry["value"] = str(config_value)
+                entry["source"] = "config"
+        if not entry["value"]:
+            entry["value"] = ASSEMBLY_LINE_FALLBACKS.get(key, "")
+        resolved[key] = entry
+    return resolved
+
+
+LIST_TAXONOMY_FILE = "data/sources/list-taxonomy.csv"
+LIST_TAXONOMY_URL = "https://taxonomy.legal"
+
+
+def _list_topic_groups() -> List[Dict[str, Any]]:
+    """The LIST taxonomy, grouped for a picker.
+
+    `get_LIST_codes()` is the same reader the question-driven Weaver's topics
+    screen uses, so the editor and the classic flow offer the same codes in the
+    same relevance order.
+    """
+    from .list_taxonomy import get_LIST_codes
+
+    csv_path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), LIST_TAXONOMY_FILE
+    )
+    groups: List[Dict[str, Any]] = []
+    index: Dict[str, Dict[str, Any]] = {}
+    for entry in get_LIST_codes(csv_path) or []:
+        if not isinstance(entry, dict):
+            continue
+        code = str(entry.get("value") or "").strip()
+        label = str(entry.get("label") or "").strip()
+        group_label = str(entry.get("group") or "Other").strip() or "Other"
+        if not code or not label:
+            continue
+        group = index.get(group_label)
+        if group is None:
+            group = {"label": group_label, "topics": []}
+            index[group_label] = group
+            groups.append(group)
+        # A group's own heading code (XX-00-00-00-00) is a valid answer too, and
+        # reads first because it is the broadest one in the group.
+        is_heading = code.endswith("-00-00-00-00")
+        topic = {"code": code, "label": label, "heading": is_heading}
+        if is_heading:
+            group["topics"].insert(0, topic)
+            group["code"] = code
+        else:
+            group["topics"].append(topic)
+    return groups
+
+
+@app.route(f"{EDITOR_BASE_PATH}/api/list-topics", methods=["GET"])
+def editor_api_list_topics() -> Response:
+    """Return the LIST taxonomy so the editor can offer a topic picker."""
+    request_id = str(uuid.uuid4())
+    if not _editor_auth_check():
+        return _auth_fail(request_id)
+    try:
+        return jsonify(
+            {
+                "success": True,
+                "request_id": request_id,
+                "data": {
+                    "groups": _list_topic_groups(),
+                    "docs_url": LIST_TAXONOMY_URL,
+                },
+            }
+        )
+    except Exception as exc:
+        log(f"ALWeaver editor: LIST topics error: {exc!r}", "error")
+        return jsonify_with_status(
+            {
+                "success": False,
+                "request_id": request_id,
+                "error": {"type": "server_error", "message": str(exc)},
+            },
+            500,
+        )
+
+
 @app.route(f"{EDITOR_BASE_PATH}/api/assemblyline-settings", methods=["GET"])
 def editor_api_get_assemblyline_settings() -> Response:
     """Return structured metadata and exact-name AssemblyLine variables."""
@@ -3924,6 +4073,7 @@ def editor_api_get_assemblyline_settings() -> Response:
                 "project": project,
                 "filename": filename,
                 "revision": source_revision(content),
+                "server_defaults": _resolve_server_defaults(),
             }
         )
         return jsonify({"success": True, "request_id": request_id, "data": data})
@@ -6867,6 +7017,7 @@ def _complete_new_project_upload_job(
     uploaded_files: List[Dict[str, Any]],
     generation_options: Dict[str, Any],
     debug_requested: bool,
+    interview_filename: Optional[str] = None,
 ) -> Dict[str, Any]:
     stage = "start"
     temp_dir = tempfile.mkdtemp(prefix="editor-upload-")
@@ -6933,7 +7084,12 @@ def _complete_new_project_upload_job(
             message="Writing generated interview YAML.",
             progress=70,
         )
-        playground_write_yaml(uid, project_name, "interview.yml", yaml_text)
+        # Weaver already derived a descriptive name from the document; the
+        # author may have overridden it on the creation screen.
+        yaml_filename = interview_filename or _normalize_generated_filename(
+            first_result.get("yaml_filename")
+        )
+        playground_write_yaml(uid, project_name, yaml_filename, yaml_text)
 
         stage = "copy_templates"
         _update_new_project_job_state(
@@ -6974,7 +7130,7 @@ def _complete_new_project_upload_job(
 
         result = {
             "project": project_name,
-            "filename": "interview.yml",
+            "filename": yaml_filename,
             "generated_from": first_result.get("input_filename"),
             "uploaded_count": len(temp_paths),
             "generated_template_count": len(generated_paths),
@@ -7028,6 +7184,7 @@ def _start_new_project_upload_job(
     uploaded_files: List[Dict[str, Any]],
     generation_options: Dict[str, Any],
     debug_requested: bool,
+    interview_filename: Optional[str] = None,
 ) -> Dict[str, Any]:
     job_id = str(uuid.uuid4())
     queued_at = time.time()
@@ -7061,6 +7218,7 @@ def _start_new_project_upload_job(
                 "uploaded_files": uploaded_files,
                 "generation_options": generation_options,
                 "debug_requested": debug_requested,
+                "interview_filename": interview_filename,
             },
         )
     except Exception as exc:
@@ -7537,8 +7695,11 @@ def _new_project_from_template(uid: int, request_id: str) -> Response:
             "continue button field: intro_screen\n"
         )
 
-    # Write starter YAML
-    playground_write_yaml(uid, project_name, "interview.yml", starter_yaml)
+    # Write starter YAML. There is no document to name it after, so a blank
+    # project gets AssemblyLine's functional name for a runnable file.
+    playground_write_yaml(
+        uid, project_name, DEFAULT_NEW_INTERVIEW_FILENAME, starter_yaml
+    )
 
     return jsonify(
         {
@@ -7546,7 +7707,7 @@ def _new_project_from_template(uid: int, request_id: str) -> Response:
             "request_id": request_id,
             "data": {
                 "project": project_name,
-                "filename": "interview.yml",
+                "filename": DEFAULT_NEW_INTERVIEW_FILENAME,
                 "template_id": template_id,
             },
         }
@@ -7620,6 +7781,24 @@ def _new_project_from_uploads(
     normalize_field_names = parse_bool(
         request.form.get("normalize_field_names"), default=False
     )
+    # Publishing metadata. The generator can invent a title from the filename and
+    # `_ensure_required_metadata_values()` backfills the rest, but the values an
+    # author actually knows -- jurisdiction, topics, landing page -- can only come
+    # from the author, and a project created without them starts life failing the
+    # shared metadata style rule.
+    interview_title = request.form.get("interview_title", "").strip()
+    interview_short_title = request.form.get("interview_short_title", "").strip()
+    interview_description = request.form.get("interview_description", "").strip()
+    jurisdiction = request.form.get("jurisdiction", "").strip()
+    landing_page_url = request.form.get("landing_page_url", "").strip()
+    list_topics = [
+        topic.strip()
+        for topic in request.form.get("list_topics", "").split(",")
+        if topic.strip()
+    ]
+    interview_filename = _normalize_new_interview_filename(
+        request.form.get("interview_filename", "")
+    )
 
     base_name = normalize_project_name(raw_name)
     existing = get_list_of_projects(uid)
@@ -7670,6 +7849,21 @@ def _new_project_from_uploads(
             "enable_navigation": enable_navigation,
             "next_steps_enabled": include_next_steps,
         }
+        if interview_title:
+            interview_overrides["title"] = interview_title
+        if interview_short_title:
+            interview_overrides["short_title"] = interview_short_title
+        if interview_description:
+            interview_overrides["description"] = interview_description
+        if landing_page_url:
+            interview_overrides["landing_page_url"] = landing_page_url
+        if list_topics:
+            # output.mako builds `LIST_topics` from the category selections, so
+            # freeform topics travel as `other_categories`.
+            interview_overrides["has_other_categories"] = True
+            interview_overrides["other_categories"] = ", ".join(list_topics)
+        if jurisdiction:
+            interview_overrides["jurisdiction"] = jurisdiction
         if form_type != "auto":
             interview_overrides["form_type"] = form_type
             interview_overrides["court_related"] = form_type != "letter"
@@ -7677,7 +7871,8 @@ def _new_project_from_uploads(
             interview_overrides["typical_role"] = typical_role
         if default_state:
             interview_overrides["state"] = default_state
-            interview_overrides["jurisdiction"] = f"NAM-US-US+{default_state}"
+            if not jurisdiction:
+                interview_overrides["jurisdiction"] = f"NAM-US-US+{default_state}"
 
         generation_options: Dict[str, Any] = {
             "create_package_zip": False,
@@ -7711,6 +7906,7 @@ def _new_project_from_uploads(
             uploaded_files=uploaded_payloads,
             generation_options=generation_options,
             debug_requested=debug_requested,
+            interview_filename=interview_filename,
         )
 
         return jsonify_with_status(

--- a/docassemble/ALWeaver/api_weaver_worker.py
+++ b/docassemble/ALWeaver/api_weaver_worker.py
@@ -116,6 +116,7 @@ def weaver_editor_new_project_task(
     uploaded_files: list[Dict[str, Any]],
     generation_options: Dict[str, Any],
     debug_requested: bool,
+    interview_filename: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Create an editor project inside Docassemble's configured Celery worker."""
     with bg_context():
@@ -129,4 +130,5 @@ def weaver_editor_new_project_task(
             uploaded_files=uploaded_files,
             generation_options=generation_options,
             debug_requested=debug_requested,
+            interview_filename=interview_filename,
         )

--- a/docassemble/ALWeaver/assemblyline_settings.py
+++ b/docassemble/ALWeaver/assemblyline_settings.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import ast
 import copy
 import re
-from typing import Any, Dict, List, Mapping, Optional, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Set, Tuple
 
 import yaml
 
@@ -21,6 +21,196 @@ DOCS_URL = (
     "https://assemblyline.suffolklitlab.org/docs/components/AssemblyLine/"
     "magic_variables/"
 )
+
+
+# Where each value shows up and what else it affects.  The question-driven Weaver
+# explained this as you filled each screen in; the graphical panel shows every
+# setting at once, so the explanation has to travel with the control.
+FIELD_HELP: Dict[str, str] = {
+    # Form identity and publishing
+    "title": (
+        "The form's name. Shown on the interview's first screen, in the browser "
+        "tab, and in listings such as CourtFormsOnline."
+    ),
+    "short title": (
+        "A shorter name, up to about 25 characters, used where the full title "
+        "does not fit."
+    ),
+    "description": (
+        "Helps people find your form. It is used for metadata and listings and is "
+        "not displayed inside the interview."
+    ),
+    "can_I_use_this_form": (
+        "Explain when someone can and cannot use this form -- conditions such as "
+        "age, county, or the status of their case."
+    ),
+    "before_you_start": (
+        "What the user needs to gather or know before they begin. Shown on the "
+        "introduction screen. Markdown lists and bullets work here."
+    ),
+    "when_you_are_finished": (
+        "What the user should do after they finish. Used for metadata and to "
+        "guide the next-steps document."
+    ),
+    "landing_page_url": (
+        "A public page about this form. Used by publishing and indexing tools; "
+        "not shown to the user inside the interview."
+    ),
+    "authors": "Credited as the authors of the interview in published metadata.",
+    "LIST_topics": (
+        "LIST/NSMI taxonomy codes, such as HO-00-00-00-00. Referral sites use "
+        "these to categorise the form."
+    ),
+    "original_form": "URLs for the official published version of the paper form.",
+    "jurisdiction": (
+        "A jurisdiction code such as NAM-US-US+MA. Used by publishing tools to "
+        "place the form geographically."
+    ),
+    "allowed_courts": (
+        "Restricts the courts this form can be filed in. Leave empty to allow "
+        "every court the server knows about."
+    ),
+    "typical_role": (
+        "Whether the person filling this out normally starts the case or responds "
+        "to one. AssemblyLine uses it to word party questions."
+    ),
+    "efiling_enabled": "Optional publishing metadata. Leave off if unknown.",
+    "integrated_efiling": "Optional publishing metadata. Leave off if unknown.",
+    "integrated_email_filing": "Optional publishing metadata. Leave off if unknown.",
+    "requires_notarization": (
+        "Optional publishing metadata: the finished document has to be notarized."
+    ),
+    "unlisted": (
+        "Keeps the interview out of public listings. It stays reachable by direct "
+        "link."
+    ),
+    "estimated_completion_minutes": (
+        "How long most people take, in minutes. Shown to the user before they start."
+    ),
+    "estimated_completion_delta": (
+        "The plus-or-minus range on that estimate, in minutes."
+    ),
+    # Organization and locale
+    "AL_ORGANIZATION_TITLE": (
+        "The organization named in the terms of use, reminder messages, and the "
+        "interview footer."
+    ),
+    "AL_ORGANIZATION_HOMEPAGE": (
+        "Linked from the download screen and the terms of use as the "
+        "organization's home page."
+    ),
+    "AL_DEFAULT_COUNTRY": (
+        "Sets which country's address format and state list address questions use."
+    ),
+    "AL_DEFAULT_STATE": (
+        "Preselects the state or province in address questions. Leave empty to "
+        "make the user choose."
+    ),
+    "AL_DEFAULT_LANGUAGE": (
+        "The language generated documents are written in. Separate from the "
+        "interview's own language switching."
+    ),
+    "AL_DEFAULT_OVERFLOW_MESSAGE": (
+        "Printed in a PDF field when the answer is too long for the space, "
+        "pointing the reader at the addendum."
+    ),
+    # Interview behavior
+    "al_form_type": (
+        "Drives party wording, the next-steps document, and whether AssemblyLine "
+        "asks court-related questions."
+    ),
+    "user_ask_role": (
+        "Whether the user is treated as the party who started the case. Set it to "
+        "unknown to have AssemblyLine ask."
+    ),
+    "al_person_answering": (
+        "Whether the person at the keyboard is the litigant or someone helping "
+        "them. Changes first- and third-person wording throughout."
+    ),
+    "al_form_requires_digital_signature": (
+        "Adds the signature flow before the download screen. Turn it off for "
+        "forms that are signed on paper."
+    ),
+    "al_typed_signature_prefix": (
+        "Printed before a typed signature, for example /s/ Jane Doe."
+    ),
+    "al_typed_signature_font": (
+        "The font a typed signature is rendered in. Leave empty for the "
+        "AssemblyLine default."
+    ),
+    "speak_text": (
+        "Shows the read-aloud control in the navigation bar. Needs a "
+        "text-to-speech service configured on the server."
+    ),
+    # Languages
+    "enable_al_language": (
+        "Shows AssemblyLine's language switcher. Only useful once you have "
+        "translations for the interview."
+    ),
+    "al_user_default_language": "The language the interview opens in.",
+    "al_interview_languages": (
+        "The languages offered in the switcher, as two-letter codes."
+    ),
+    # Repository and feedback
+    "github_repo_name": (
+        "The repository this package lives in. Used by the in-interview feedback "
+        "form to file issues in the right place."
+    ),
+    "github_user": "The GitHub owner or organization for that repository.",
+    # Next steps
+    "al_next_steps_enabled": (
+        "Includes the next-steps document in the download bundle. Turning it off "
+        "keeps the file so you can turn it back on later."
+    ),
+    "al_next_steps_document_title": (
+        "What the next-steps document calls the thing the user just made, for "
+        'example "form" or "motion".'
+    ),
+    "al_next_steps_document_purpose": (
+        "What the next-steps document calls what the user is asking for, for "
+        'example "request" or "appeal".'
+    ),
+    "al_next_steps_help_organization": (
+        "The organization the next-steps document tells the user to contact."
+    ),
+    "al_next_steps_help_url": "Where the next-steps document sends the user for help.",
+    "al_next_steps_generate_qr_code": (
+        "Prints a QR code in the next-steps document linking back to the interview."
+    ),
+    "al_next_steps_what_happens_next": (
+        "The next-steps section describing what happens after the form is filed."
+    ),
+    "al_next_steps_what_can_decision_maker_do": (
+        "The next-steps section describing the decisions a judge or clerk can make."
+    ),
+    "al_next_steps_what_happens_if_i_win": (
+        "The next-steps section describing what follows if the request is granted."
+    ),
+}
+
+
+# Settings AssemblyLine also resolves server-wide.  Writing one here overrides the
+# server for this interview only, which the panel has to say out loud.
+# The value is the Docassemble configuration key, or None when the fallback is an
+# AssemblyLine literal rather than something in the server configuration.
+SERVER_DEFAULTS: Dict[str, Optional[str]] = {
+    "AL_ORGANIZATION_TITLE": "appname",
+    "AL_ORGANIZATION_HOMEPAGE": "app homepage",
+    "AL_DEFAULT_COUNTRY": None,
+    "AL_DEFAULT_STATE": None,
+    "AL_DEFAULT_LANGUAGE": None,
+    "AL_DEFAULT_OVERFLOW_MESSAGE": None,
+}
+
+# What AssemblyLine falls back to when neither the interview nor the server sets
+# the value (al_settings.yml).
+ASSEMBLY_LINE_FALLBACKS: Dict[str, str] = {
+    "AL_ORGANIZATION_TITLE": "docassemble",
+    "AL_ORGANIZATION_HOMEPAGE": "https://courtformsonline.org",
+    "AL_DEFAULT_COUNTRY": "US",
+    "AL_DEFAULT_LANGUAGE": "en",
+    "AL_DEFAULT_OVERFLOW_MESSAGE": "...",
+}
 
 
 def _field(
@@ -32,6 +222,12 @@ def _field(
 ) -> Dict[str, Any]:
     result = {"key": key, "label": label, "kind": kind, "default": default}
     result.update(kwargs)
+    result.setdefault("help", FIELD_HELP.get(key, ""))
+    if key in SERVER_DEFAULTS:
+        result.setdefault("server_default_key", SERVER_DEFAULTS[key])
+        result.setdefault("has_server_default", True)
+        if key in ASSEMBLY_LINE_FALLBACKS:
+            result.setdefault("assembly_line_fallback", ASSEMBLY_LINE_FALLBACKS[key])
     return result
 
 
@@ -274,6 +470,65 @@ METADATA_FIELDS = {
 }
 
 
+METADATA_DOCUMENT_ID = "metadata"
+
+# What each kind of setting is, in one place, so the panel can explain itself
+# rather than assuming the author already knows the difference.
+PANEL_EXPLAINER = (
+    "AssemblyLine reads two different kinds of setting, and both normally live "
+    "in YAML you edit by hand. Publishing metadata -- title, description, "
+    "jurisdiction, topics -- sits in the interview's metadata block and tells "
+    "listing sites such as CourtFormsOnline what this form is. Predefined "
+    "variables -- names like al_form_type or AL_DEFAULT_STATE -- have a special "
+    "meaning to AssemblyLine and change how your interview looks and behaves. "
+    "This page gathers both in one place, shows each one's exact name, and "
+    "writes them back to the blocks named on each section."
+)
+
+_DOCUMENT_DESCRIPTIONS = {
+    METADATA_DOCUMENT_ID: (
+        "the interview's metadata block, read by AssemblyLine and by publishing "
+        "sites"
+    ),
+    MANAGED_BLOCK_ID: (
+        "a code block Weaver owns and rewrites in full; your own code blocks are "
+        "never touched"
+    ),
+}
+
+
+def _section_documents(section: Mapping[str, Any]) -> List[Dict[str, str]]:
+    """Name the YAML documents a section's values are written to.
+
+    Derived from the fields' own scopes rather than written out by hand, so it
+    cannot drift when a field moves between metadata and code.
+    """
+    documents: List[Dict[str, str]] = []
+    scopes = {field.get("scope") for field in section.get("fields", [])}
+    if scopes & {"metadata", "both"}:
+        documents.append(
+            {
+                "id": METADATA_DOCUMENT_ID,
+                "kind": "metadata",
+                "description": _DOCUMENT_DESCRIPTIONS[METADATA_DOCUMENT_ID],
+            }
+        )
+    if scopes & {None, "both"}:
+        documents.append(
+            {
+                "id": MANAGED_BLOCK_ID,
+                "kind": "code",
+                "description": _DOCUMENT_DESCRIPTIONS[MANAGED_BLOCK_ID],
+            }
+        )
+    return documents
+
+
+for _section in SETTINGS_SCHEMA:
+    _section["documents"] = _section_documents(_section)
+del _section
+
+
 _SEPARATOR_RE = re.compile(r"(?m)^---[ \t]*(?:\r?\n|$)")
 
 
@@ -287,12 +542,19 @@ def _documents(source: str) -> List[Tuple[int, int, str]]:
     return result
 
 
-def _literal_assignments(code: str) -> Dict[str, Any]:
+def _code_assignments(code: str) -> Dict[str, Tuple[Any, bool]]:
+    """Every supported setting this code assigns, and whether it is a literal.
+
+    A setting the author computes -- ``al_form_type = form_type_for(case)`` --
+    is reported as its source text with ``False``. The panel can display that,
+    but it must never write it back: rendering it as a value would turn working
+    code into a string.
+    """
     try:
         tree = ast.parse(code)
     except SyntaxError:
         return {}
-    result: Dict[str, Any] = {}
+    result: Dict[str, Tuple[Any, bool]] = {}
     for node in tree.body:
         if not isinstance(node, (ast.Assign, ast.AnnAssign)):
             continue
@@ -302,12 +564,186 @@ def _literal_assignments(code: str) -> Dict[str, Any]:
             continue
         try:
             value = ast.literal_eval(value_node)
+            is_literal = True
         except (ValueError, TypeError):
             value = ast.get_source_segment(code, value_node) or ""
+            is_literal = False
         for target in targets:
             if isinstance(target, ast.Name) and target.id in CODE_FIELDS:
-                result[target.id] = value
+                result[target.id] = (value, is_literal)
     return result
+
+
+def _literal_assignments(code: str) -> Dict[str, Any]:
+    return {key: value for key, (value, _literal) in _code_assignments(code).items()}
+
+
+def _rewrite_code_assignment(code: str, key: str, rendered: str) -> Optional[str]:
+    """Replace the right-hand side of ``key = ...`` in a block of Python.
+
+    Only the value expression is touched, so comments, ordering, and every other
+    statement in the block survive. Returns None when the name is not assigned
+    here, so the caller can fall back to Weaver's own block.
+    """
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return None
+
+    # ast column offsets are UTF-8 byte offsets, so the edit is done on bytes.
+    data = code.encode("utf-8")
+    line_starts = [0]
+    for line in code.splitlines(keepends=True):
+        line_starts.append(line_starts[-1] + len(line.encode("utf-8")))
+
+    for node in reversed(tree.body):
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        value_node = node.value
+        if value_node is None:
+            continue
+        if not any(
+            isinstance(target, ast.Name) and target.id == key for target in targets
+        ):
+            continue
+        if value_node.end_lineno is None or value_node.end_col_offset is None:
+            return None
+        start = line_starts[value_node.lineno - 1] + value_node.col_offset
+        end = line_starts[value_node.end_lineno - 1] + value_node.end_col_offset
+        updated = data[:start] + rendered.encode("utf-8") + data[end:]
+        return updated.decode("utf-8")
+    return None
+
+
+def _code_scalar_span(body: str) -> Optional[Tuple[int, int]]:
+    """The exact source range of a block's ``code:`` scalar, header included."""
+    try:
+        root = yaml.compose(body)
+    except yaml.YAMLError:
+        return None
+    if not isinstance(root, yaml.MappingNode):
+        return None
+    for key_node, value_node in root.value:
+        if (
+            isinstance(key_node, yaml.ScalarNode)
+            and key_node.value == "code"
+            and isinstance(value_node, yaml.ScalarNode)
+        ):
+            return value_node.start_mark.index, value_node.end_mark.index
+    return None
+
+
+def _render_code_scalar(original: str, code: str, newline: str) -> Optional[str]:
+    """Re-render a ``code:`` block scalar around new code text.
+
+    The header -- and any chomping indicator on it -- is copied from what was
+    there, and every content line is re-indented to the depth the block already
+    used, so the only thing that changes is the code itself.
+    """
+    header, separator, remainder = original.partition("\n")
+    header = header.strip()
+    if not separator or not header.startswith("|"):
+        # Not a literal block scalar; rewriting it is not safe to guess at.
+        return None
+    indent = ""
+    for line in remainder.splitlines():
+        if line.strip():
+            indent = line[: len(line) - len(line.lstrip())]
+            break
+    if not indent:
+        return None
+    rendered_lines = [
+        indent + line if line.strip() else "" for line in code.split("\n")
+    ]
+    while rendered_lines and not rendered_lines[-1]:
+        rendered_lines.pop()
+    trailing = newline if original.endswith(("\n", "\r")) else ""
+    return header + newline + newline.join(rendered_lines) + trailing
+
+
+def rewrite_external_code_assignments(
+    source: str, values: Mapping[str, Any], changed: Set[str]
+) -> Tuple[str, Set[str]]:
+    """Update changed settings in whichever author-owned block already assigns them.
+
+    Two rules, and the second matters as much as the first:
+
+    * A setting the author already assigns in their own block is updated
+      *there*. Writing Weaver's copy as well would leave two blocks assigning
+      one name and the winner decided by document order, so every key this
+      finds is left out of the managed block whether or not it changed.
+    * Only values the author actually changed on the panel are rewritten.
+      Rewriting the rest would re-quote literals the author wrote by hand, and
+      would flatten a computed value -- ``al_form_type = form_type_for(case)``
+      reaches the panel as its source text, and writing that back through
+      ``repr()`` would turn working code into a string.
+
+    Returns the updated source and every key now owned by an author's block.
+    """
+    handled: Set[str] = set()
+    updated_source = source
+    # Later documents are rewritten first so earlier spans stay valid.
+    for start, end, body in reversed(_documents(updated_source)):
+        try:
+            parsed = yaml.safe_load(body)
+        except yaml.YAMLError:
+            continue
+        if not isinstance(parsed, dict) or parsed.get("id") == MANAGED_BLOCK_ID:
+            continue
+        code = parsed.get("code")
+        if not isinstance(code, str):
+            continue
+        assigned = set(_literal_assignments(code)) & set(values)
+        if not assigned:
+            continue
+
+        to_rewrite = assigned & changed
+        if not to_rewrite:
+            # Nothing to write, but the author still owns these names.
+            handled |= assigned
+            continue
+
+        span = _code_scalar_span(body)
+        if span is None:
+            continue
+
+        newline = "\r\n" if "\r\n" in body else "\n"
+        rewritten = code
+        rewritten_keys: Set[str] = set()
+        for key in sorted(to_rewrite):
+            replacement = _rewrite_code_assignment(
+                rewritten, key, _render_code_value(key, values[key])
+            )
+            if replacement is not None:
+                rewritten = replacement
+                rewritten_keys.add(key)
+        if not rewritten_keys:
+            handled |= assigned
+            continue
+
+        scalar_start, scalar_end = span
+        new_scalar = _render_code_scalar(
+            body[scalar_start:scalar_end], rewritten, newline
+        )
+        if new_scalar is None:
+            continue
+        new_body = body[:scalar_start] + new_scalar + body[scalar_end:]
+
+        # Refuse a patch that does not read back as the values just written.
+        try:
+            reparsed = yaml.safe_load(new_body)
+        except yaml.YAMLError:
+            continue
+        if not isinstance(reparsed, dict) or not isinstance(reparsed.get("code"), str):
+            continue
+        read_back = _literal_assignments(reparsed["code"])
+        if any(read_back.get(key) != values[key] for key in rewritten_keys):
+            continue
+
+        updated_source = updated_source[:start] + new_body + updated_source[end:]
+        handled |= assigned
+    return updated_source, handled
 
 
 def _metadata(source: str) -> Tuple[Dict[str, Any], Optional[Tuple[int, int, str]]]:
@@ -333,6 +769,10 @@ def read_settings(source: str) -> Dict[str, Any]:
             values[key] = metadata[key]
 
     sources: Dict[str, str] = {}
+    # Settings the interview works out at runtime rather than storing a value
+    # for. The panel shows these read-only: it has no value it could safely
+    # write, and the author's expression is the real answer.
+    computed: Dict[str, str] = {}
     for _start, _end, body in _documents(source):
         try:
             parsed = yaml.safe_load(body)
@@ -340,17 +780,25 @@ def read_settings(source: str) -> Dict[str, Any]:
             continue
         if not isinstance(parsed, dict) or not isinstance(parsed.get("code"), str):
             continue
-        assignments = _literal_assignments(parsed["code"])
+        assignments = _code_assignments(parsed["code"])
         block_id = str(parsed.get("id") or "code block")
-        for key, value in assignments.items():
+        for key, (value, is_literal) in assignments.items():
             values[key] = value
             sources[key] = block_id
+            if is_literal:
+                computed.pop(key, None)
+            else:
+                computed[key] = block_id
 
     return {
         "schema": copy.deepcopy(SETTINGS_SCHEMA),
         "values": values,
         "sources": sources,
+        "computed": computed,
         "docs_url": DOCS_URL,
+        "explainer": PANEL_EXPLAINER,
+        "managed_block_id": MANAGED_BLOCK_ID,
+        "metadata_document_id": METADATA_DOCUMENT_ID,
     }
 
 
@@ -382,7 +830,25 @@ def _coerce_value(field: Mapping[str, Any], value: Any) -> Any:
     return value
 
 
-def _managed_block(values: Mapping[str, Any]) -> str:
+def _render_code_value(key: str, value: Any) -> str:
+    """One setting as the Python source that assigns it."""
+    if CODE_FIELDS[key].get("kind") == "python":
+        rendered = str(value or "None")
+        try:
+            ast.parse(rendered, mode="eval")
+        except SyntaxError as exc:
+            raise ValueError(
+                f"{CODE_FIELDS[key]['label']} is not valid Python"
+            ) from exc
+        return rendered
+    return repr(value)
+
+
+def _managed_block(
+    values: Mapping[str, Any],
+    elsewhere: Optional[Set[str]] = None,
+    computed: Optional[Mapping[str, str]] = None,
+) -> str:
     lines = [
         f"id: {MANAGED_BLOCK_ID}",
         "initial: True",
@@ -392,18 +858,12 @@ def _managed_block(values: Mapping[str, Any]) -> str:
     for key in CODE_FIELDS:
         if key not in values:
             continue
-        value = values[key]
-        if CODE_FIELDS[key].get("kind") == "python":
-            rendered = str(value or "None")
-            try:
-                ast.parse(rendered, mode="eval")
-            except SyntaxError as exc:
-                raise ValueError(
-                    f"{CODE_FIELDS[key]['label']} is not valid Python"
-                ) from exc
-        else:
-            rendered = repr(value)
-        lines.append(f"  {key} = {rendered}")
+        lines.append(f"  {key} = {_render_code_value(key, values[key])}")
+    for key in sorted(elsewhere or ()):
+        # Say where a setting went instead of leaving a silent gap here.
+        lines.append(f"  # {key} is set in one of your own code blocks, not here.")
+    for key in sorted(computed or ()):
+        lines.append(f"  # {key} is computed by your own code, and is left alone.")
     return "\n".join(lines) + "\n"
 
 
@@ -574,6 +1034,16 @@ def _update_metadata(source: str, updates: Mapping[str, Any]) -> str:
         key_node, value_node = existing[key]
         value_start = value_node.start_mark.index
         value_end = value_node.end_mark.index
+        if (
+            isinstance(value_node, yaml.SequenceNode)
+            and not value_node.flow_style
+            and value_node.value
+        ):
+            # A block sequence's node ends where the *next* token begins, so it
+            # swallows any comment or blank line sitting between this value and
+            # the key below it. The last item's own end is where the value
+            # really stops. Scalars and block scalars already end accurately.
+            value_end = value_node.value[-1].end_mark.index
         fragment = body[value_start:value_end]
         replacement = _metadata_value_fragment(
             value,
@@ -582,12 +1052,15 @@ def _update_metadata(source: str, updates: Mapping[str, Any]) -> str:
             key_indent=key_node.start_mark.column,
             newline=newline,
         )
-        if fragment.endswith("\r\n") and not replacement.endswith(("\r", "\n")):
-            replacement += "\r\n"
-        elif fragment.endswith("\n") and not replacement.endswith(("\r", "\n")):
-            replacement += "\n"
-        elif fragment.endswith("\r") and not replacement.endswith(("\r", "\n")):
-            replacement += "\r"
+        # PyYAML ends a block value's node after the newline *and* the
+        # indentation of whatever comes next, so that run is layout rather than
+        # value. `_metadata_value_fragment` only ever returns content, so the
+        # run has to be carried over: without it a multi-line value -- a list
+        # with more than one item, or a literal block -- swallows the key that
+        # follows it onto its own last line.
+        trailing_layout = fragment[len(fragment.rstrip(" \t\r\n")) :]
+        if trailing_layout and not replacement.endswith(trailing_layout):
+            replacement += trailing_layout
         operations.append((value_start, value_end, replacement))
 
     if missing:
@@ -648,16 +1121,37 @@ def update_settings(source: str, submitted: Mapping[str, Any]) -> str:
     if unknown:
         raise ValueError("Unsupported settings: " + ", ".join(sorted(unknown)))
 
-    current = read_settings(source)["values"]
+    settings = read_settings(source)
+    current = settings["values"]
+    computed: Dict[str, str] = settings["computed"]
     metadata_updates: Dict[str, Any] = {}
-    code_values = {key: current[key] for key in CODE_FIELDS}
+    code_values = {key: current[key] for key in CODE_FIELDS if key not in computed}
+    changed_code: Set[str] = set()
     for key, raw_value in submitted.items():
+        if key in computed:
+            # The interview computes this one. There is no value the panel could
+            # write that would not replace the author's expression, and the
+            # control is read-only for exactly that reason, so anything that
+            # arrives for it is ignored rather than validated.
+            continue
         field = METADATA_FIELDS.get(key) or CODE_FIELDS[key]
         value = _coerce_value(field, raw_value)
         if key in METADATA_FIELDS and value != current.get(key):
             metadata_updates[key] = value
         if key in CODE_FIELDS:
             code_values[key] = value
+            if value != current.get(key):
+                changed_code.add(key)
 
     updated = _update_metadata(source, metadata_updates) if metadata_updates else source
-    return _replace_or_insert_managed(updated, _managed_block(code_values))
+    # A setting the author already assigns in their own block is updated there.
+    # Adding Weaver's copy on top would leave two blocks assigning one name.
+    updated, elsewhere = rewrite_external_code_assignments(
+        updated, code_values, changed_code
+    )
+    managed_values = {
+        key: value for key, value in code_values.items() if key not in elsewhere
+    }
+    return _replace_or_insert_managed(
+        updated, _managed_block(managed_values, elsewhere, computed)
+    )

--- a/docassemble/ALWeaver/data/static/editor.css
+++ b/docassemble/ALWeaver/data/static/editor.css
@@ -648,6 +648,7 @@ html, body {
 .editor-outline-type {
   font-size: 9px;
   letter-spacing: 0.04em;
+  white-space: nowrap;
   color: var(--editor-muted);
   background: #f1f3f7;
   padding: 1px 5px;
@@ -2283,6 +2284,7 @@ html, body {
 .editor-outline-type-obj { background: #d1fae5; color: #065f46; }
 .editor-outline-type-meta { background: #ede9fe; color: #5b21b6; }
 .editor-outline-type-inc { background: #fce7f3; color: #9d174d; }
+.editor-outline-type-comment { background: #fff7ed; color: #9a3412; }
 .editor-outline-type-oth { background: #f1f3f7; color: var(--editor-muted); }
 
 /* ===== Drag handle (order builder) ===== */
@@ -3511,4 +3513,96 @@ html, body {
 .editor-screen-preview-select {
   width: auto;
   min-width: 9rem;
+}
+
+/* ===== AssemblyLine settings panel ===== */
+
+.editor-al-setting-help {
+  color: var(--editor-muted);
+}
+
+.editor-al-setting-server-default {
+  color: var(--editor-muted);
+}
+
+.editor-al-setting-server-default.is-overriding {
+  color: #92400e;
+}
+
+.editor-al-setting-key {
+  opacity: 0.75;
+}
+
+.editor-field-mod-hint {
+  color: var(--editor-muted);
+  margin-top: 2px;
+}
+
+/* ===== LIST topic picker =====
+   Mirrors ALToolbox's al_tree_select: plain <details> groups, plain checkboxes. */
+
+.editor-topic-group {
+  border: 1px solid var(--editor-border, #e3e6ee);
+  border-radius: 6px;
+  margin-bottom: 6px;
+}
+
+.editor-topic-summary {
+  cursor: pointer;
+  padding: 8px 10px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  list-style: revert;
+}
+
+.editor-topic-summary-label {
+  flex: 1 1 auto;
+}
+
+.editor-topic-count {
+  flex: 0 0 auto;
+}
+
+.editor-topic-children {
+  padding: 0 12px 10px 28px;
+}
+
+.editor-topic-item {
+  margin-bottom: 2px;
+}
+
+/* ===== Create-project accordion ===== */
+
+.editor-new-project-accordion .accordion-button {
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.editor-new-project-accordion .accordion-body {
+  padding-top: 12px;
+}
+
+.editor-al-settings-documents {
+  margin-bottom: 12px;
+  color: var(--editor-muted);
+  font-size: 11px;
+}
+
+.editor-al-settings-document {
+  font-size: 11px;
+}
+
+.editor-al-settings-explainer {
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.editor-al-setting-external {
+  color: #1e40af;
+}
+
+.editor-al-setting-computed {
+  color: var(--editor-muted);
 }

--- a/docassemble/ALWeaver/data/static/editor.js
+++ b/docassemble/ALWeaver/data/static/editor.js
@@ -354,6 +354,148 @@
     return bootstrap.Modal.getOrCreateInstance(modalEl);
   }
 
+  // -------------------------------------------------------------------------
+  // LIST topic picker
+  //
+  // Typing taxonomy codes by hand means knowing them by heart, so the code
+  // fields get a picker instead. It is built the way ALToolbox's
+  // `al_tree_select` is -- ordinary <details>/<summary> groups around ordinary
+  // checkboxes -- so keyboard, screen reader and find-in-page all work with no
+  // ARIA tree bookkeeping. The taxonomy itself comes from the same
+  // `get_LIST_codes()` reader the question-driven Weaver uses.
+  // -------------------------------------------------------------------------
+  var listTopics = {
+    groups: null,
+    loading: null,
+    targetId: null,
+    separator: ', ',
+  };
+
+  function loadListTopics() {
+    if (listTopics.groups) return Promise.resolve(listTopics.groups);
+    if (listTopics.loading) return listTopics.loading;
+    listTopics.loading = apiGet('/api/list-topics').then(function (res) {
+      listTopics.loading = null;
+      if (!res.success || !res.data) throw new Error('Unable to load the LIST taxonomy.');
+      listTopics.groups = res.data.groups || [];
+      return listTopics.groups;
+    }).catch(function (error) {
+      listTopics.loading = null;
+      throw error;
+    });
+    return listTopics.loading;
+  }
+
+  function _readTopicCodes(input) {
+    if (!input) return [];
+    return String(input.value || '')
+      .split(/[\n,]/)
+      .map(function (part) { return part.trim(); })
+      .filter(Boolean);
+  }
+
+  function renderListTopicsTree(selected) {
+    var tree = document.getElementById('list-topics-tree');
+    if (!tree) return;
+    var chosen = {};
+    (selected || []).forEach(function (code) { chosen[code] = true; });
+    var html = '';
+    (listTopics.groups || []).forEach(function (group, groupIndex) {
+      var groupId = 'list-topic-group-' + groupIndex;
+      html += '<details class="editor-topic-group" data-topic-group open>';
+      html += '<summary class="editor-topic-summary"><span class="editor-topic-summary-label">' + esc(group.label) + '</span>';
+      html += '<span class="badge text-bg-primary editor-topic-count" data-topic-count hidden></span></summary>';
+      html += '<div class="editor-topic-children">';
+      (group.topics || []).forEach(function (topic, topicIndex) {
+        var inputId = groupId + '-' + topicIndex;
+        var searchText = (topic.label + ' ' + topic.code).toLowerCase();
+        html += '<div class="form-check editor-topic-item" data-topic-item data-search="' + esc(searchText) + '">';
+        html += '<input class="form-check-input" type="checkbox" id="' + esc(inputId) + '" data-topic-code="' + esc(topic.code) + '"' + (chosen[topic.code] ? ' checked' : '') + '>';
+        html += '<label class="form-check-label' + (topic.heading ? ' fw-semibold' : '') + '" for="' + esc(inputId) + '">' + esc(topic.label);
+        html += ' <span class="text-muted font-monospace editor-tiny">' + esc(topic.code) + '</span></label>';
+        html += '</div>';
+      });
+      html += '</div></details>';
+    });
+    tree.innerHTML = html;
+    updateListTopicsCounts();
+  }
+
+  function updateListTopicsCounts() {
+    var tree = document.getElementById('list-topics-tree');
+    if (!tree) return;
+    var total = 0;
+    tree.querySelectorAll('[data-topic-group]').forEach(function (group) {
+      var checked = group.querySelectorAll('input[data-topic-code]:checked').length;
+      total += checked;
+      var badge = group.querySelector('[data-topic-count]');
+      if (badge) {
+        badge.textContent = checked ? String(checked) : '';
+        badge.hidden = checked === 0;
+      }
+    });
+    var count = document.getElementById('list-topics-selected-count');
+    if (count) count.textContent = total === 1 ? '1 topic selected' : total + ' topics selected';
+  }
+
+  function applyListTopicsFilter() {
+    var field = document.getElementById('list-topics-filter');
+    var tree = document.getElementById('list-topics-tree');
+    if (!tree) return;
+    var query = String((field && field.value) || '').trim().toLowerCase();
+    var anyVisible = false;
+    tree.querySelectorAll('[data-topic-group]').forEach(function (group) {
+      var visibleItems = 0;
+      group.querySelectorAll('[data-topic-item]').forEach(function (item) {
+        var visible = !query || String(item.getAttribute('data-search') || '').indexOf(query) !== -1;
+        item.classList.toggle('d-none', !visible);
+        if (visible) visibleItems += 1;
+      });
+      group.classList.toggle('d-none', visibleItems === 0);
+      if (visibleItems) {
+        anyVisible = true;
+        // A filter that leaves matches inside a closed group hides them, so
+        // open the group while a filter is running.
+        if (query) group.open = true;
+      }
+    });
+    var empty = document.getElementById('list-topics-empty');
+    if (empty) empty.classList.toggle('d-none', anyVisible);
+  }
+
+  function openListTopicsPicker(targetId, separator) {
+    var input = document.getElementById(targetId);
+    if (!input) return;
+    listTopics.targetId = targetId;
+    listTopics.separator = separator || ', ';
+    var tree = document.getElementById('list-topics-tree');
+    if (tree) tree.innerHTML = '<div class="text-center py-4"><div class="spinner-border" role="status"></div></div>';
+    var filter = document.getElementById('list-topics-filter');
+    if (filter) filter.value = '';
+    var modal = getOrCreateBootstrapModal('list-topics-modal');
+    if (modal) modal.show();
+    loadListTopics().then(function () {
+      renderListTopicsTree(_readTopicCodes(input));
+      applyListTopicsFilter();
+    }).catch(function (error) {
+      if (tree) tree.innerHTML = '<div class="alert alert-danger">' + esc(error.message || 'Unable to load the LIST taxonomy.') + '</div>';
+    });
+  }
+
+  function applyListTopicsSelection() {
+    var input = document.getElementById(listTopics.targetId);
+    var tree = document.getElementById('list-topics-tree');
+    if (!input || !tree) return;
+    var codes = [];
+    tree.querySelectorAll('input[data-topic-code]:checked').forEach(function (box) {
+      codes.push(box.getAttribute('data-topic-code'));
+    });
+    input.value = codes.join(listTopics.separator);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+    closeBootstrapModal('list-topics-modal');
+  }
+
   function closeBootstrapModal(elementId) {
     var modalEl = document.getElementById(elementId);
     if (!modalEl || typeof bootstrap === 'undefined' || !bootstrap.Modal) return;
@@ -386,6 +528,14 @@
         'id: objects_' + stamp + '\n' +
         'objects:\n' +
         '  - user: Individual\n'
+      );
+    }
+    if (kind === 'comment') {
+      // No id: a comment block is prose about the interview, and docassemble
+      // has nothing to reach it by.
+      return (
+        'comment: |\n' +
+        '  Explain what the blocks below do, and why.\n'
       );
     }
     if (kind === 'attachment') {
@@ -1905,9 +2055,13 @@
   // Escaping
   // -------------------------------------------------------------------------
   function esc(text) {
+    // Serializing a text node escapes &, < and > but leaves quotes alone, and
+    // almost every call here lands inside a double-quoted HTML attribute --
+    // block YAML in a title=, a help string in data-bs-content=. A quote in the
+    // value would end the attribute early, so escape those too.
     var el = document.createElement('span');
-    el.textContent = text || '';
-    return el.innerHTML;
+    el.textContent = text === null || text === undefined ? '' : text;
+    return el.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
   }
 
   function cloneData(value) {
@@ -2361,7 +2515,8 @@
       html += '<label class="editor-tiny mt-2" for="insert-image-width">Width (optional)</label>';
       html += '<input class="form-control form-control-sm mt-1" id="insert-image-width" placeholder="100% or 250px">';
       html += '<label class="editor-tiny mt-2" for="insert-image-alt">Alt text (optional)</label>';
-      html += '<input class="form-control form-control-sm mt-1" id="insert-image-alt" placeholder="Describe the image">';
+      html += '<input class="form-control form-control-sm mt-1" id="insert-image-alt">';
+      html += '<div class="editor-tiny mt-1">Describe the image for someone who cannot see it. Leave blank only if the image is decorative.</div>';
     } else if (action === 'table') {
       html += '<label class="editor-tiny" for="insert-table-cols">Columns</label>';
       html += '<input class="form-control form-control-sm mt-1" id="insert-table-cols" type="number" min="2" max="8" value="2">';
@@ -2373,14 +2528,16 @@
       html += '<label class="editor-tiny mt-2" for="insert-file-width">Width (optional)</label>';
       html += '<input class="form-control form-control-sm mt-1" id="insert-file-width" placeholder="100% or 250px">';
       html += '<label class="editor-tiny mt-2" for="insert-file-alt">Alt text (optional)</label>';
-      html += '<input class="form-control form-control-sm mt-1" id="insert-file-alt" placeholder="Accessible description">';
+      html += '<input class="form-control form-control-sm mt-1" id="insert-file-alt">';
+      html += '<div class="editor-tiny mt-1">Describe the file for someone using a screen reader.</div>';
     } else if (action === 'qr') {
       html += '<label class="editor-tiny" for="insert-qr-text">QR text or URL</label>';
       html += '<input class="form-control form-control-sm mt-1" id="insert-qr-text" value="https://">';
       html += '<label class="editor-tiny mt-2" for="insert-qr-width">Width (optional)</label>';
       html += '<input class="form-control form-control-sm mt-1" id="insert-qr-width" placeholder="200px">';
       html += '<label class="editor-tiny mt-2" for="insert-qr-alt">Alt text (optional)</label>';
-      html += '<input class="form-control form-control-sm mt-1" id="insert-qr-alt" placeholder="QR code description">';
+      html += '<input class="form-control form-control-sm mt-1" id="insert-qr-alt">';
+      html += '<div class="editor-tiny mt-1">Say where the QR code leads, for people who cannot scan it.</div>';
     } else if (action === 'youtube') {
       html += '<label class="editor-tiny" for="insert-youtube-id">YouTube video ID</label>';
       html += '<input class="form-control form-control-sm mt-1" id="insert-youtube-id" placeholder="RpgYyuLt7Dx">';
@@ -4864,6 +5021,16 @@
     return null;
   }
 
+  function blockQuickView(block, limit) {
+    // Hovering an outline row previews the block, so a row whose title is thin
+    // (a comment, an unnamed code block) is still recognisable at a glance.
+    var body = String((block && block.yaml) || '').replace(/\r\n/g, '\n').trim();
+    if (!body) return String((block && block.title) || '');
+    var max = limit || 400;
+    if (body.length > max) body = body.slice(0, max - 1).replace(/\s+\S*$/, '') + '\u2026';
+    return body;
+  }
+
   function typeClass(type) {
     if (type === 'question') return 'editor-outline-type-q';
     if (type === 'review') return 'editor-outline-type-review';
@@ -4872,6 +5039,7 @@
     if (type === 'metadata') return 'editor-outline-type-meta';
     if (type === 'includes') return 'editor-outline-type-inc';
     if (type === 'commented') return 'editor-outline-type-disabled';
+    if (type === 'comment') return 'editor-outline-type-comment';
     return 'editor-outline-type-oth';
   }
 
@@ -4884,6 +5052,7 @@
     if (type === 'metadata') return 'Meta';
     if (type === 'includes') return 'Inc';
     if (type === 'default_screen_parts') return 'Def';
+    if (type === 'comment') return 'Comment';
     return type.charAt(0).toUpperCase() + type.slice(1, 3);
   }
 
@@ -4975,7 +5144,7 @@
       var tc = typeClass(displayType);
       var lintFindings = getBlockLintFindings(block.id);
       var lintClass = lintFindings.length ? (' ' + getBlockLintFeedbackClass(lintFindings)) : '';
-      html += '<div class="editor-outline-item' + (active ? ' active' : '') + (block.type === 'commented' ? ' editor-outline-item-commented' : '') + lintClass + '" data-block-id="' + esc(block.id) + '">';
+      html += '<div class="editor-outline-item' + (active ? ' active' : '') + (block.type === 'commented' ? ' editor-outline-item-commented' : '') + lintClass + '" data-block-id="' + esc(block.id) + '" title="' + esc(blockQuickView(block)) + '">';
       html += '<div class="editor-outline-item-row">';
       if (active) html += '<div class="editor-outline-active-bar"></div>';
       if (isOutlineDragEnabled()) {
@@ -5369,7 +5538,7 @@
   var _validationInFlight = false;
 
   function getValidationDrawerTitle() {
-    return state.validationMode === 'style' ? 'Style check' : 'Errors & Warnings';
+    return state.validationMode === 'style' ? 'Style suggestions' : 'Errors & Warnings';
   }
 
   function runCurrentValidationCheck() {
@@ -5540,15 +5709,19 @@
     if (title) title.textContent = getValidationDrawerTitle();
     var count = state.validationErrors.length;
     var summary = _validationSummary(state.validationErrors);
-    var hasProblems = (summary.error + summary.warning) > 0;
+    var isStyleMode = state.validationMode === 'style';
+    // The style check reports house style, not validity. Nothing it finds stops
+    // a save, so it must not dress the topbar up the way a broken file does.
+    var hasProblems = !isStyleMode && (summary.error + summary.warning) > 0;
     var levelClass = summary.error > 0 ? 'validation-error' : (summary.warning > 0 ? 'validation-warning' : 'validation-info');
+    if (isStyleMode) levelClass = 'validation-info';
 
     Array.prototype.forEach.call(document.querySelectorAll('[data-validation-badge]'), function (badge) {
       badge.textContent = count > 0 ? String(count) : '';
       badge.classList.toggle('d-none', count === 0);
-      badge.classList.toggle('validation-error', summary.error > 0);
-      badge.classList.toggle('validation-warning', summary.error === 0 && summary.warning > 0);
-      badge.classList.toggle('validation-info', summary.error === 0 && summary.warning === 0 && summary.info > 0);
+      badge.classList.toggle('validation-error', !isStyleMode && summary.error > 0);
+      badge.classList.toggle('validation-warning', !isStyleMode && summary.error === 0 && summary.warning > 0);
+      badge.classList.toggle('validation-info', isStyleMode || (summary.error === 0 && summary.warning === 0 && summary.info > 0));
     });
 
     Array.prototype.forEach.call(document.querySelectorAll('.js-check-errors-btn'), function (btn) {
@@ -5558,7 +5731,7 @@
 
     // Show/hide the alert icon — only visible when there are actual errors
     Array.prototype.forEach.call(document.querySelectorAll('.js-check-errors-icon'), function (icon) {
-      icon.classList.toggle('d-none', count === 0);
+      icon.classList.toggle('d-none', isStyleMode || count === 0);
     });
 
     drawer.classList.toggle('editor-validation-has-issues', hasProblems);
@@ -5573,8 +5746,8 @@
       return;
     }
     drawer.classList.add('open');
-    var scopeText = state.validationMode === 'style'
-      ? 'This style check covers the saved source.'
+    var scopeText = isStyleMode
+      ? 'Suggestions from the shared house-style checker, against the saved source. None of these stop the interview from running or from being saved.'
       : (state.validationSourceScope === 'unsaved_source'
         ? 'This validation covers the unsaved source currently in the editor.'
         : 'This validation covers the saved source.');
@@ -5583,7 +5756,8 @@
       scopeHtml += '<div class="alert alert-warning py-1 px-2 small mb-2">The saved file changed after this editor buffer was loaded. These results still cover the local buffer; reload or merge before saving.</div>';
     }
     if (count === 0) {
-      body.innerHTML = scopeHtml + '<div class="text-muted small p-2">No errors or warnings found.</div>';
+      body.innerHTML = scopeHtml + '<div class="text-muted small p-2">'
+        + (isStyleMode ? 'No style suggestions.' : 'No errors or warnings found.') + '</div>';
       return;
     }
     var sortedErrors = (state.validationErrors || []).slice().sort(function (a, b) {
@@ -5594,9 +5768,9 @@
       return Number((a && a.line_number) || 0) - Number((b && b.line_number) || 0);
     });
     var html = scopeHtml + '<div class="editor-validation-summary small text-muted mb-2">'
-      + summary.error + ' errors, '
-      + summary.warning + ' warnings, '
-      + summary.info + ' infos'
+      + (isStyleMode
+        ? (summary.warning + ' suggestions, ' + summary.info + ' notes')
+        : (summary.error + ' errors, ' + summary.warning + ' warnings, ' + summary.info + ' infos'))
       + '</div>';
     html += '<ul class="editor-validation-list">';
     sortedErrors.forEach(function (err) {
@@ -5640,11 +5814,108 @@
       });
   }
 
+  function _settingServerDefaultHtml(field, value) {
+    // Several of these also exist server-wide. Setting one here quietly overrides
+    // the whole server for this interview, so say what is being overridden.
+    if (!field || !field.has_server_default) return '';
+    var settings = state.assemblyLineSettings || {};
+    var entry = (settings.server_defaults || {})[field.key];
+    if (!entry) return '';
+    var serverValue = String(entry.value || '');
+    var origin = entry.source === 'config'
+      ? ('the server configuration' + (entry.config_key ? ' (' + entry.config_key + ')' : ''))
+      : 'AssemblyLine';
+    var current = (value === null || value === undefined) ? '' : String(value);
+    var overriding = current !== '' && current !== serverValue;
+    var html = '<div class="form-text editor-al-setting-server-default' + (overriding ? ' is-overriding' : '') + '">';
+    if (overriding) {
+      html += '<i class="fa-solid fa-circle-arrow-up me-1" aria-hidden="true"></i>Overrides ' + esc(origin) + ' for this interview only';
+    } else {
+      html += 'Comes from ' + esc(origin) + ' unless you set it here';
+    }
+    if (serverValue) html += ': <code>' + esc(serverValue) + '</code>';
+    html += '</div>';
+    return html;
+  }
+
+  function _settingsExplainerHtml(data) {
+    var explainer = (data && data.explainer) || '';
+    var html = '<p>' + esc(explainer) + '</p>';
+    html += '<p class="mb-0">Each section names the YAML block it writes to, and each control shows the exact metadata key or variable name, so you can always go and read or edit the YAML directly.</p>';
+    return html;
+  }
+
+  function _settingsSectionDocumentsHtml(section) {
+    // Say where a section's values land. Nothing here is magic -- it is all
+    // ordinary YAML -- and an author who knows which block to open can go and
+    // read it, or edit it by hand instead.
+    var documents = (section && section.documents) || [];
+    if (!documents.length) return '';
+    var html = '<div class="editor-al-settings-documents">';
+    html += '<span class="editor-tiny">Saved to</span> ';
+    documents.forEach(function (document_, index) {
+      if (index) html += ' <span class="editor-tiny">and</span> ';
+      html += '<code class="editor-al-settings-document" title="' + esc(document_.description) + '">' + esc(document_.id) + '</code>';
+      html += '<span class="editor-tiny"> ' + (document_.kind === 'metadata' ? 'block' : 'code block') + '</span>';
+    });
+    html += '</div>';
+    return html;
+  }
+
+  function _settingComputedBlock(field) {
+    // The interview works this one out at runtime, so there is no stored value
+    // for the panel to edit.
+    var settings = state.assemblyLineSettings || {};
+    return (settings.computed || {})[field.key] || '';
+  }
+
+  function _settingComputedHtml(field) {
+    var blockId = _settingComputedBlock(field);
+    if (!blockId) return '';
+    var html = '<div class="form-text editor-al-setting-computed">';
+    html += '<i class="fa-solid fa-lock me-1" aria-hidden="true"></i>';
+    html += 'Your interview works this out while it runs, so there is no stored value for this panel to edit. ';
+    html += 'The expression above lives in the <code>' + esc(blockId) + '</code> block: open that block in the outline, or use YAML source, and edit it there. ';
+    html += 'Saving here leaves it exactly as it is.';
+    html += '</div>';
+    return html;
+  }
+
+  function _settingSourceHtml(field) {
+    // This value lives in a block the author wrote, so say so: saving edits it
+    // there rather than adding a second assignment of the same name.
+    var settings = state.assemblyLineSettings || {};
+    var managedId = settings.managed_block_id || 'alweaver assemblyline settings';
+    var source = (settings.sources || {})[field.key];
+    if (!source || source === managedId) return '';
+    return '<div class="form-text editor-al-setting-external">'
+      + '<i class="fa-solid fa-code-branch me-1" aria-hidden="true"></i>'
+      + 'Kept in your own <code>' + esc(source) + '</code>. Changing it here edits that block; Weaver does not add a second copy.'
+      + '</div>';
+  }
+
   function _settingsInput(field, value) {
     var key = esc(field.key);
     var kind = field.kind || 'text';
     var common = ' data-al-setting="' + key + '" id="al-setting-' + key.replace(/[^a-zA-Z0-9_-]/g, '-') + '"';
-    var variableHint = '<div class="form-text editor-al-setting-key"><code>' + key + '</code></div>';
+    var helpText = field && field.help ? '<div class="form-text editor-al-setting-help">' + esc(field.help) + '</div>' : '';
+    var computedBlock = _settingComputedBlock(field);
+    var variableHint = helpText
+      + (computedBlock
+        ? _settingComputedHtml(field)
+        : _settingServerDefaultHtml(field, value) + _settingSourceHtml(field))
+      + '<div class="form-text editor-al-setting-key"><code>' + key + '</code></div>';
+    if (computedBlock) {
+      // Whatever the field's normal control is, a computed setting holds an
+      // expression rather than a value. A checkbox or a dropdown would have to
+      // pick some position to sit in and would misreport the interview, so the
+      // expression is shown as read-only text instead.
+      var computedId = 'al-setting-' + key.replace(/[^a-zA-Z0-9_-]/g, '-');
+      return '<label class="editor-tiny" for="' + computedId + '">' + esc(field.label) + '</label>'
+        + '<input class="form-control form-control-sm mt-1 font-monospace"' + common + ' value="'
+        + esc(value === null || value === undefined ? '' : value) + '" readonly disabled aria-disabled="true">'
+        + variableHint;
+    }
     if (kind === 'boolean') {
       return '<div class="form-check form-switch"><input class="form-check-input" type="checkbox"' + common + (value ? ' checked' : '') + '><label class="form-check-label" for="al-setting-' + key.replace(/[^a-zA-Z0-9_-]/g, '-') + '">' + esc(field.label) + '</label>' + variableHint + '</div>';
     }
@@ -5654,8 +5925,16 @@
       return select + '</select>' + variableHint;
     }
     var rendered = kind === 'list' ? (Array.isArray(value) ? value.join('\n') : '') : String(value === null || value === undefined ? '' : value);
+    if (field.key === 'LIST_topics') {
+      var topicsId = 'al-setting-' + key.replace(/[^a-zA-Z0-9_-]/g, '-');
+      return '<label class="editor-tiny" for="' + topicsId + '">' + esc(field.label) + '</label>'
+        + '<textarea class="form-control form-control-sm mt-1" rows="3"' + common + '>' + esc(rendered) + '</textarea>'
+        + '<div class="mt-1"><button class="btn btn-sm btn-outline-secondary" type="button" data-open-list-topics="' + topicsId + '" data-topic-separator="newline"><i class="fa-solid fa-list-check me-1" aria-hidden="true"></i>Choose topics</button></div>'
+        + '<div class="form-text">One code per line.</div>'
+        + variableHint;
+    }
     if (kind === 'area' || kind === 'list' || kind === 'python') {
-      return '<label class="editor-tiny" for="al-setting-' + key + '">' + esc(field.label) + '</label><textarea class="form-control form-control-sm mt-1' + (kind === 'python' ? ' font-monospace' : '') + '" rows="' + (kind === 'area' ? '4' : '3') + '"' + common + '>' + esc(rendered) + '</textarea>' + variableHint + (kind === 'list' ? '<div class="form-text">One value per line.</div>' : '');
+      return '<label class="editor-tiny" for="al-setting-' + key + '">' + esc(field.label) + '</label><textarea class="form-control form-control-sm mt-1' + (kind === 'python' ? ' font-monospace' : '') + '" rows="' + (kind === 'area' ? '4' : '3') + '"' + common + '>' + esc(rendered) + '</textarea>' + (kind === 'list' ? '<div class="form-text">One value per line.</div>' : '') + variableHint;
     }
     return '<label class="editor-tiny" for="al-setting-' + key + '">' + esc(field.label) + '</label><input class="form-control form-control-sm mt-1" type="' + (kind === 'integer' ? 'number' : (kind === 'url' ? 'url' : 'text')) + '"' + common + ' value="' + esc(rendered) + '">' + variableHint;
   }
@@ -5686,12 +5965,15 @@
     }
     var data = state.assemblyLineSettings;
     var html = '<div class="editor-new-project-shell"><div class="editor-card"><div class="editor-card-body d-flex justify-content-between align-items-start gap-3 flex-wrap">';
-    html += '<div><h2 style="font-weight:700;font-size:18px;margin:0 0 6px">AssemblyLine settings</h2><p class="text-muted small mb-0">Edit publishing metadata and predefined AssemblyLine variables without finding their YAML or code blocks.</p></div>';
+    html += '<div><h2 style="font-weight:700;font-size:18px;margin:0 0 6px">AssemblyLine settings ';
+    html += '<button type="button" class="btn btn-sm btn-link p-0 align-baseline editor-al-settings-explainer" data-al-settings-explainer data-bs-toggle="popover" data-bs-trigger="focus" data-bs-placement="bottom" data-bs-html="true" data-bs-title="What is this page?" data-bs-content="' + esc(_settingsExplainerHtml(data)) + '">What is this?</button>';
+    html += '</h2><p class="text-muted small mb-0">Edit publishing metadata and predefined AssemblyLine variables without finding their YAML or code blocks.</p></div>';
     html += '<div class="d-flex gap-2"><button class="btn btn-sm btn-outline-secondary" id="close-assemblyline-settings">Back</button><button class="btn btn-sm btn-primary" id="save-assemblyline-settings"' + (state.assemblyLineSettingsDirty ? '' : ' disabled') + '>Save settings</button></div></div></div>';
     html += '<div class="editor-card"><div class="editor-card-body"><label class="editor-tiny" for="assemblyline-settings-filter">Filter settings</label><div class="input-group input-group-sm mt-1"><span class="input-group-text"><i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i></span><input class="form-control" id="assemblyline-settings-filter" type="search" value="' + esc(state.assemblyLineSettingsFilter) + '" placeholder="Search by label or magic variable name" autocomplete="off"></div></div></div>';
     (data.schema || []).forEach(function (section) {
       var sectionSearch = [section.id, section.label].concat(section.notes || []).join(' ').toLowerCase();
       html += '<div class="editor-card" data-al-settings-section data-search="' + esc(sectionSearch) + '"><div class="editor-card-header">' + esc(section.label) + '</div><div class="editor-card-body">';
+      html += _settingsSectionDocumentsHtml(section);
       if (section.readonly) {
         html += '<div data-al-settings-item data-search="' + esc(sectionSearch) + '"><p class="small text-muted">These values are structural, derived, dynamic, or server-wide and are not rewritten as metadata.</p><ul class="small mb-0">';
         (section.notes || []).forEach(function (note) { html += '<li class="mb-1">' + esc(note) + '</li>'; });
@@ -5699,7 +5981,7 @@
       } else {
         html += '<div class="row g-3">';
         (section.fields || []).forEach(function (field) {
-          var fieldSearch = [field.key, field.label, section.id, section.label].join(' ').toLowerCase();
+          var fieldSearch = [field.key, field.label, field.help || '', section.id, section.label].join(' ').toLowerCase();
           html += '<div class="' + (field.pair ? 'col-12 col-md-6' : 'col-12') + '" data-al-settings-item data-search="' + esc(fieldSearch) + '">' + _settingsInput(field, data.values[field.key]) + '</div>';
         });
         html += '</div>';
@@ -5713,12 +5995,26 @@
     html += '<p class="small text-muted">See the <a href="' + esc(data.docs_url) + '" target="_blank" rel="noopener">AssemblyLine special-variable documentation</a>.</p></div>';
     canvasContent.innerHTML = html;
     applyAssemblyLineSettingsFilter();
+    _initSettingsPopovers();
+  }
+
+  function _initSettingsPopovers() {
+    if (typeof bootstrap === 'undefined' || !bootstrap.Popover) return;
+    document.querySelectorAll('[data-al-settings-explainer]').forEach(function (trigger) {
+      var existing = bootstrap.Popover.getInstance(trigger);
+      if (existing) existing.dispose();
+      bootstrap.Popover.getOrCreateInstance(trigger);
+    });
   }
 
   function collectAssemblyLineSettings() {
     var values = {};
+    var computed = (state.assemblyLineSettings || {}).computed || {};
     document.querySelectorAll('[data-al-setting]').forEach(function (input) {
       var key = input.getAttribute('data-al-setting');
+      // A computed setting is displayed but never submitted: its control holds
+      // the author's expression as text, which is not a value.
+      if (computed[key]) return;
       var field = null;
       (state.assemblyLineSettings.schema || []).some(function (section) { return (section.fields || []).some(function (candidate) { if (candidate.key === key) { field = candidate; return true; } return false; }); });
       if (!field) return;
@@ -5879,7 +6175,7 @@
     html += '<p class="text-muted small mb-3">Enter any public GitHub docassemble repository, or a private repository available through your connected account. Weaver will create the project and pull its files in one step.</p>';
     html += '<div class="row g-2 align-items-end">';
     html += '<div class="col-12 col-lg-7"><label class="editor-tiny" for="project-github-import-url">GitHub repository URL</label><input class="form-control form-control-sm mt-1" id="project-github-import-url" type="url" placeholder="https://github.com/owner/docassemble-package"></div>';
-    html += '<div class="col-12 col-lg-3"><label class="editor-tiny" for="project-github-import-name">Project name (optional)</label><input class="form-control form-control-sm mt-1" id="project-github-import-name" placeholder="Derived from repository"></div>';
+    html += '<div class="col-12 col-lg-3"><label class="editor-tiny" for="project-github-import-name">Project name (optional)</label><input class="form-control form-control-sm mt-1" id="project-github-import-name"><div class="text-muted small mt-1">Leave blank to name the project after the repository.</div></div>';
     html += '<div class="col-12 col-lg-2 d-grid"><button type="button" class="btn btn-sm btn-outline-primary" id="project-github-import-submit">Create and pull</button></div>';
     html += '</div><div class="alert py-2 mt-3 mb-0 d-none" id="project-github-import-status" role="status" aria-live="polite"></div>';
     html += '</div></div>';
@@ -6967,10 +7263,13 @@
     var availableTabs = isStandalone ? ['logic'] : ['basic', 'logic', 'help', 'validation', 'appearance', 'metadata', 'more'];
     if (availableTabs.indexOf(activeTab) === -1) activeTab = availableTabs[0];
 
-    function row(labelFor, labelText, controlHtml, rowClass) {
+    function row(labelFor, labelText, controlHtml, rowClass, hintText) {
       var out = '<div class="' + (rowClass || 'editor-field-mod-row') + '">';
       if (labelText) out += '<label class="editor-tiny" for="' + esc(labelFor) + '">' + esc(labelText) + '</label>';
       out += controlHtml;
+      // A hint that says what the value has to look like stays on screen: a
+      // placeholder is gone exactly when the author starts typing.
+      if (hintText) out += '<div class="editor-tiny editor-field-mod-hint">' + esc(hintText) + '</div>';
       out += '</div>';
       return out;
     }
@@ -7021,7 +7320,7 @@
         '<div><label class="editor-tiny" for="fmod-aota-' + fi + '">all of the above</label><input class="form-control editor-form-control" id="fmod-aota-' + fi + '" data-fmod="all of the above" data-field-idx="' + fi + '" value="' + esc(String(fmods['all of the above'] !== undefined ? fmods['all of the above'] : '')) + '"></div>'
       );
       out += row('fmod-shuffle-' + fi, 'shuffle', '<select class="form-select editor-form-control" id="fmod-shuffle-' + fi + '" data-fmod="shuffle" data-field-idx="' + fi + '"><option value="">(default)</option><option value="True"' + (fmods.shuffle ? ' selected' : '') + '>Yes</option></select>');
-      out += row('fmod-disableothers-' + fi, 'disable others', '<input class="form-control editor-form-control font-monospace" id="fmod-disableothers-' + fi + '" data-fmod="disable others" data-field-idx="' + fi + '" value="' + esc(typeof fmods['disable others'] === 'boolean' ? String(fmods['disable others']) : String(fmods['disable others'] || '')) + '" placeholder="True or list of variables">');
+      out += row('fmod-disableothers-' + fi, 'disable others', '<input class="form-control editor-form-control font-monospace" id="fmod-disableothers-' + fi + '" data-fmod="disable others" data-field-idx="' + fi + '" value="' + esc(typeof fmods['disable others'] === 'boolean' ? String(fmods['disable others']) : String(fmods['disable others'] || '')) + '">', null, 'True, or a list of variable names.');
       return out;
     }
 
@@ -7063,7 +7362,7 @@
       }
       out += row('fmod-validate-' + fi, 'validate', '<input class="form-control editor-form-control font-monospace" id="fmod-validate-' + fi + '" data-fmod="validate" data-field-idx="' + fi + '" value="' + esc(String(fmods.validate || '')) + '" placeholder="function_name or lambda">');
       out += row('fmod-validation-code-' + fi, 'validation code', '<textarea class="form-control editor-form-control font-monospace" id="fmod-validation-code-' + fi + '" data-fmod="validation code" data-field-idx="' + fi + '" rows="2" placeholder="Python to validate">' + esc(String(fmods['validation code'] || '')) + '</textarea>');
-      out += row('fmod-validation-messages-' + fi, 'validation messages', '<textarea class="form-control editor-form-control font-monospace" id="fmod-validation-messages-' + fi + '" data-fmod="validation messages" data-field-idx="' + fi + '" rows="2" placeholder="YAML dict of rule: message">' + esc(typeof fmods['validation messages'] === 'object' ? JSON.stringify(fmods['validation messages'], null, 2) : String(fmods['validation messages'] || '')) + '</textarea>');
+      out += row('fmod-validation-messages-' + fi, 'validation messages', '<textarea class="form-control editor-form-control font-monospace" id="fmod-validation-messages-' + fi + '" data-fmod="validation messages" data-field-idx="' + fi + '" rows="2">' + esc(typeof fmods['validation messages'] === 'object' ? JSON.stringify(fmods['validation messages'], null, 2) : String(fmods['validation messages'] || '')) + '</textarea>', null, 'A YAML mapping of rule name to the message shown when it fails.');
       if (['file', 'files'].indexOf(dtype) !== -1 || fmods.accept !== undefined) {
         out += row('fmod-accept-' + fi, 'accept', '<input class="form-control editor-form-control" id="fmod-accept-' + fi + '" data-fmod="accept" data-field-idx="' + fi + '" value="' + esc(String(fmods.accept || '')) + '">');
       }
@@ -7078,7 +7377,7 @@
       out += row('fmod-floating-label-' + fi, 'floating label', '<select class="form-select editor-form-control" id="fmod-floating-label-' + fi + '" data-fmod="floating label" data-field-idx="' + fi + '"><option value="">(default)</option><option value="True"' + (fmods['floating label'] ? ' selected' : '') + '>Yes</option></select>');
       out += row('fmod-grid-' + fi, 'grid', '<input class="form-control editor-form-control font-monospace" id="fmod-grid-' + fi + '" data-fmod="grid" data-field-idx="' + fi + '" value="' + esc(typeof fmods.grid === 'object' ? JSON.stringify(fmods.grid) : String(fmods.grid || '')) + '" placeholder="1-12">');
       out += row('fmod-item-grid-' + fi, 'item grid', '<input class="form-control editor-form-control font-monospace" id="fmod-item-grid-' + fi + '" data-fmod="item grid" data-field-idx="' + fi + '" value="' + esc(typeof fmods['item grid'] === 'object' ? JSON.stringify(fmods['item grid']) : String(fmods['item grid'] || '')) + '" placeholder="1-12">');
-      out += row('fmod-rows-' + fi, 'rows', '<input class="form-control editor-form-control font-monospace" id="fmod-rows-' + fi + '" data-fmod="rows" data-field-idx="' + fi + '" value="' + esc(String(fmods.rows || '')) + '" placeholder="textarea rows">');
+      out += row('fmod-rows-' + fi, 'rows', '<input class="form-control editor-form-control font-monospace" id="fmod-rows-' + fi + '" data-fmod="rows" data-field-idx="' + fi + '" value="' + esc(String(fmods.rows || '')) + '">', null, 'How many rows tall the textarea is.');
       out += row('fmod-inline-width-' + fi, 'inline width', '<input class="form-control editor-form-control font-monospace" id="fmod-inline-width-' + fi + '" data-fmod="inline width" data-field-idx="' + fi + '" value="' + esc(String(fmods['inline width'] || '')) + '" placeholder="15em">');
       return out;
     }
@@ -7091,13 +7390,13 @@
 
     function renderMoreTab() {
       var out = '';
-      out += row('fmod-address-auto-' + fi, 'address autocomplete', '<textarea class="form-control editor-form-control font-monospace" id="fmod-address-auto-' + fi + '" data-fmod="address autocomplete" data-field-idx="' + fi + '" rows="3" placeholder="True or YAML">' + esc(String(fmods['address autocomplete'] || '')) + '</textarea>');
+      out += row('fmod-address-auto-' + fi, 'address autocomplete', '<textarea class="form-control editor-form-control font-monospace" id="fmod-address-auto-' + fi + '" data-fmod="address autocomplete" data-field-idx="' + fi + '" rows="3">' + esc(String(fmods['address autocomplete'] || '')) + '</textarea>', null, 'True, or YAML options for the autocompleter.');
       out += row('fmod-maximum-image-size-' + fi, 'maximum image size', '<input class="form-control editor-form-control font-monospace" id="fmod-maximum-image-size-' + fi + '" data-fmod="maximum image size" data-field-idx="' + fi + '" value="' + esc(String(fmods['maximum image size'] || '')) + '">');
       out += row('fmod-image-upload-type-' + fi, 'image upload type', '<input class="form-control editor-form-control" id="fmod-image-upload-type-' + fi + '" data-fmod="image upload type" data-field-idx="' + fi + '" value="' + esc(String(fmods['image upload type'] || '')) + '" placeholder="jpeg">');
       out += row('fmod-persistent-' + fi, 'persistent', '<select class="form-select editor-form-control" id="fmod-persistent-' + fi + '" data-fmod="persistent" data-field-idx="' + fi + '"><option value="">(default)</option><option value="True"' + (fmods.persistent ? ' selected' : '') + '>Yes</option><option value="False"' + (fmods.persistent === false || fmods.persistent === 'False' ? ' selected' : '') + '>No</option></select>');
       out += row('fmod-private-' + fi, 'private', '<select class="form-select editor-form-control" id="fmod-private-' + fi + '" data-fmod="private" data-field-idx="' + fi + '"><option value="">(default)</option><option value="True"' + (fmods.private ? ' selected' : '') + '>Yes</option><option value="False"' + (fmods.private === false || fmods.private === 'False' ? ' selected' : '') + '>No</option></select>');
-      out += row('fmod-allow-users-' + fi, 'allow users', '<input class="form-control editor-form-control font-monospace" id="fmod-allow-users-' + fi + '" data-fmod="allow users" data-field-idx="' + fi + '" value="' + esc(String(fmods['allow users'] || '')) + '" placeholder="emails or user ids">');
-      out += row('fmod-allow-privileges-' + fi, 'allow privileges', '<input class="form-control editor-form-control font-monospace" id="fmod-allow-privileges-' + fi + '" data-fmod="allow privileges" data-field-idx="' + fi + '" value="' + esc(String(fmods['allow privileges'] || '')) + '" placeholder="developer, user">');
+      out += row('fmod-allow-users-' + fi, 'allow users', '<input class="form-control editor-form-control font-monospace" id="fmod-allow-users-' + fi + '" data-fmod="allow users" data-field-idx="' + fi + '" value="' + esc(String(fmods['allow users'] || '')) + '">', null, 'Email addresses or user IDs, separated by commas.');
+      out += row('fmod-allow-privileges-' + fi, 'allow privileges', '<input class="form-control editor-form-control font-monospace" id="fmod-allow-privileges-' + fi + '" data-fmod="allow privileges" data-field-idx="' + fi + '" value="' + esc(String(fmods['allow privileges'] || '')) + '">', null, 'Privilege names, separated by commas \u2014 for example developer, user.');
       out += row('fmod-file-css-class-' + fi, 'file css class', '<input class="form-control editor-form-control" id="fmod-file-css-class-' + fi + '" data-fmod="file css class" data-field-idx="' + fi + '" value="' + esc(String(fmods['file css class'] || '')) + '">');
       out += row('fmod-object-labeler-' + fi, 'object labeler', '<input class="form-control editor-form-control font-monospace" id="fmod-object-labeler-' + fi + '" data-fmod="object labeler" data-field-idx="' + fi + '" value="' + esc(String(fmods['object labeler'] || '')) + '" placeholder="lambda y: y.name">');
       return out;
@@ -7743,9 +8042,26 @@
   }
 
   var _uploadedFiles = [];
+  // What the create-project screen filled in for the author, so a later upload
+  // can update its own guess without stepping on anything they typed.
+  var _suggestedValues = {};
+
+  function _newProjectSection(id, title, expanded, bodyHtml) {
+    var headingId = 'new-project-heading-' + id;
+    var panelId = 'new-project-panel-' + id;
+    var html = '<div class="accordion-item">';
+    html += '<h2 class="accordion-header" id="' + headingId + '">';
+    html += '<button class="accordion-button' + (expanded ? '' : ' collapsed') + '" type="button" data-bs-toggle="collapse" data-bs-target="#' + panelId + '" aria-expanded="' + (expanded ? 'true' : 'false') + '" aria-controls="' + panelId + '">' + esc(title) + '</button>';
+    html += '</h2>';
+    html += '<div id="' + panelId + '" class="accordion-collapse collapse' + (expanded ? ' show' : '') + '" aria-labelledby="' + headingId + '">';
+    html += '<div class="accordion-body">' + bodyHtml + '</div>';
+    html += '</div></div>';
+    return html;
+  }
 
   function renderNewProject() {
     _uploadedFiles = [];
+    _suggestedValues = { 'new-project-name': 'NewProject' };
     var html = '<div class="editor-new-project-shell">';
 
     // Header
@@ -7761,46 +8077,101 @@
     html += '</div></div>';
     html += '</div></div>';
 
-    // File upload zone
-    html += '<div class="editor-card"><div class="editor-card-header">Template files (optional)</div><div class="editor-card-body">';
-    html += '<div class="mb-3"><label class="editor-tiny" for="new-project-github-url">GitHub repository URL (optional)</label>';
-    html += '<input class="form-control form-control-sm mt-1" id="new-project-github-url" type="url" placeholder="https://github.com/owner/docassemble-package">';
-    html += '<div class="text-muted small mt-1">Import from any public GitHub repository, or a private repository available through your connected account.</div></div>';
-    html += '<div class="text-muted small text-center mb-3">or upload a document</div>';
-    html += '<div class="editor-dropzone" id="upload-dropzone">';
-    html += '<div class="editor-dropzone-icon">&#128196;</div>';
-    html += '<div style="font-weight:600">Drag &amp; drop PDF or DOCX files here</div>';
-    html += '<div class="text-muted small mt-1">or click to browse</div>';
-    html += '<div class="text-warning-emphasis small mt-2">If you add more than one file, Weaver automates the first file and keeps the others in Templates for you to connect later.</div>';
-    html += '<input type="file" id="upload-file-input" multiple accept=".pdf,.docx,application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document" style="display:none">';
-    html += '</div>';
-    html += '<div id="upload-file-list" class="mt-2"></div>';
-    html += '</div></div>';
+    // The screen asks for a lot at once, so each group is an accordion section.
+    // They are independent rather than exclusive (no data-bs-parent): filling a
+    // form is not a wizard, and closing the section you just typed into to open
+    // the next one would be hostile.
+    html += '<div class="accordion editor-new-project-accordion" id="new-project-accordion">';
 
-    // Project form
-    html += '<div class="editor-card"><div class="editor-card-header">Project settings</div><div class="editor-card-body">';
-    html += '<div class="d-grid gap-3">';
-    html += '<div><label class="editor-tiny" for="new-project-name">Project name</label><input class="form-control form-control-sm mt-1" id="new-project-name" value="NewProject"></div>';
-    html += '<div class="form-check form-switch m-0">';
-    html += '<input class="form-check-input" type="checkbox" id="new-project-use-llm-assist" checked>';
-    html += '<label class="form-check-label editor-tiny" for="new-project-use-llm-assist">Use AI assistance for drafting</label>';
-    html += '<div class="text-muted small mt-1">If enabled, Weaver will use your context and reference page to refine labels and screen grouping.</div>';
+    html += _newProjectSection('files', 'Template files', true,
+      '<div class="mb-3"><label class="editor-tiny" for="new-project-github-url">GitHub repository URL (optional)</label>'
+      + '<input class="form-control form-control-sm mt-1" id="new-project-github-url" type="url" placeholder="https://github.com/owner/docassemble-package">'
+      + '<div class="text-muted small mt-1">Import from any public GitHub repository, or a private repository available through your connected account.</div></div>'
+      + '<div class="text-muted small text-center mb-3">or upload a document</div>'
+      + '<div class="editor-dropzone" id="upload-dropzone">'
+      + '<div class="editor-dropzone-icon">&#128196;</div>'
+      + '<div style="font-weight:600">Drag &amp; drop PDF or DOCX files here</div>'
+      + '<div class="text-muted small mt-1">or click to browse</div>'
+      + '<div class="text-warning-emphasis small mt-2">If you add more than one file, Weaver automates the first file and keeps the others in Templates for you to connect later.</div>'
+      + '<input type="file" id="upload-file-input" multiple accept=".pdf,.docx,application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document" style="display:none">'
+      + '</div>'
+      + '<div id="upload-file-list" class="mt-2"></div>');
+
+    // Basics: what an author has to decide, and what the document cannot answer.
+    html += _newProjectSection('basics', 'Project settings', true,
+      '<div class="d-grid gap-3">'
+      + '<div><label class="editor-tiny" for="new-project-name">Project name</label>'
+      + '<input class="form-control form-control-sm mt-1" id="new-project-name" value="NewProject">'
+      + '<div class="text-muted small mt-1">Suggested from the first uploaded document. Playground project names are letters and digits only.</div></div>'
+      + '<div><label class="editor-tiny" for="new-project-filename">Interview filename</label>'
+      + '<input class="form-control form-control-sm mt-1" id="new-project-filename" value="">'
+      + '<div class="text-muted small mt-1">Leave blank and Weaver names the file after the document. AssemblyLine\'s convention is a descriptive name when the package holds one interview, and <code>main.yml</code> for a runnable file in a package with several.</div></div>'
+      + '<div class="row g-3"><div class="col-md-6"><label class="editor-tiny" for="new-project-output-type">Output</label>'
+      + '<select class="form-select form-select-sm mt-1" id="new-project-output-type"><option value="form">Assemble downloadable forms</option><option value="survey">Save answers only</option></select></div>'
+      + '<div class="col-md-6"><label class="editor-tiny" for="new-project-default-state">Default state/province (optional)</label>'
+      + '<input class="form-control form-control-sm mt-1" id="new-project-default-state" placeholder="MA">'
+      + '<div class="text-muted small mt-1">Preselects the state in address questions and sets the jurisdiction.</div></div></div>'
+      + '<div class="form-check form-switch m-0">'
+      + '<input class="form-check-input" type="checkbox" id="new-project-use-llm-assist" checked>'
+      + '<label class="form-check-label editor-tiny" for="new-project-use-llm-assist">Use AI assistance for drafting</label>'
+      + '<div class="text-muted small mt-1">If enabled, Weaver will use your context and reference page to refine labels and screen grouping. Variable names are always derived from the template\'s field labels, with or without this.</div>'
+      + '</div>'
+      + '</div>');
+
+    // Advanced: things Weaver can decide on its own, or that are already right.
+    html += _newProjectSection('advanced', 'Advanced settings', false,
+      '<div class="d-grid gap-3">'
+      + '<div class="row g-3"><div class="col-md-6"><label class="editor-tiny" for="new-project-form-type">AssemblyLine form type</label>'
+      + '<select class="form-select form-select-sm mt-1" id="new-project-form-type"><option value="auto">Let Weaver decide</option><option value="starts_case">Starts a case</option><option value="existing_case">Existing case</option><option value="appeal">Appeal</option><option value="other_form">Other form</option><option value="letter">Letter</option><option value="other">Other</option></select>'
+      + '<div class="text-muted small mt-1">Drives party wording and the next-steps document.</div></div>'
+      + '<div class="col-md-6"><label class="editor-tiny" for="new-project-user-role">Typical user role</label>'
+      + '<select class="form-select form-select-sm mt-1" id="new-project-user-role"><option value="auto">Let Weaver decide</option><option value="plaintiff">Starts the case/request</option><option value="defendant">Responds to it</option><option value="unknown">Ask the user</option></select></div></div>'
+      + '<div class="form-check form-switch m-0"><input class="form-check-input" type="checkbox" id="new-project-include-next-steps" checked><label class="form-check-label editor-tiny" for="new-project-include-next-steps">Include a next steps document</label><div class="text-muted small mt-1">The generated DOCX is a reusable shell. Later settings changes do not overwrite custom Word edits.</div></div>'
+      + '<div class="form-check form-switch m-0"><input class="form-check-input" type="checkbox" id="new-project-enable-navigation" checked><label class="form-check-label editor-tiny" for="new-project-enable-navigation">Enable left navigation</label></div>'
+      + '<div class="form-check form-switch m-0"><input class="form-check-input" type="checkbox" id="new-project-copy-baseline-questions" checked><label class="form-check-label editor-tiny" for="new-project-copy-baseline-questions">Copy the AssemblyLine questions about people</label><div class="text-muted small mt-1">Writes editable copies of the name, address, and contact question wording into your interview instead of leaving it in AssemblyLine\'s question library. It does not change how template field labels become variables.</div></div>'
+      + '</div>');
+
+    // Publishing metadata. AssemblyLine and CourtFormsOnline read these from the
+    // interview's `metadata` block; a project created without them starts out
+    // failing the shared metadata style rule, and nothing else can supply the
+    // jurisdiction or the landing page for you.
+    html += _newProjectSection('metadata', 'Publishing metadata', false,
+      '<p class="text-muted small">These become the interview\'s <code>metadata</code> block. Anything you skip Weaver fills in with a guess, and you can revise it later in AssemblyLine settings.</p>'
+      + '<div class="d-grid gap-3">'
+      + '<div class="row g-3"><div class="col-md-8"><label class="editor-tiny" for="new-project-title">Title</label>'
+      + '<input class="form-control form-control-sm mt-1" id="new-project-title">'
+      + '<div class="text-muted small mt-1">The form name people see in listings and on the interview\'s first screen. Suggested from the uploaded document\'s name.</div></div>'
+      + '<div class="col-md-4"><label class="editor-tiny" for="new-project-short-title">Short title</label>'
+      + '<input class="form-control form-control-sm mt-1" id="new-project-short-title" maxlength="25">'
+      + '<div class="text-muted small mt-1">Up to 25 characters, used where space is tight.</div></div></div>'
+      + '<div><label class="editor-tiny" for="new-project-description">Description</label>'
+      + '<textarea class="form-control form-control-sm mt-1" id="new-project-description" rows="2"></textarea>'
+      + '<div class="text-muted small mt-1">One or two sentences saying what the form does. Shown on listing pages.</div></div>'
+      + '<div class="row g-3"><div class="col-md-6"><label class="editor-tiny" for="new-project-jurisdiction">Jurisdiction code</label>'
+      + '<input class="form-control form-control-sm mt-1" id="new-project-jurisdiction" placeholder="NAM-US-US+MA">'
+      + '<div class="text-muted small mt-1">Leave blank to derive it from the default state.</div></div>'
+      + '<div class="col-md-6"><label class="editor-tiny" for="new-project-landing-page-url">Public landing page URL</label>'
+      + '<input class="form-control form-control-sm mt-1" id="new-project-landing-page-url" type="url">'
+      + '<div class="text-muted small mt-1">Where this form is published for the public. Defaults to courtformsonline.org.</div></div></div>'
+      + '<div><label class="editor-tiny" for="new-project-list-topics">LIST topics</label>'
+      + '<div class="input-group input-group-sm mt-1"><input class="form-control" id="new-project-list-topics">'
+      + '<button class="btn btn-outline-secondary" type="button" data-open-list-topics="new-project-list-topics"><i class="fa-solid fa-list-check me-1" aria-hidden="true"></i>Choose topics</button></div>'
+      + '<div class="text-muted small mt-1">Codes from the LIST/NSMI taxonomy, for example <code>HO-00-00-00-00, HO-05-00-00-00</code>. Referral sites use them to categorise the form.</div></div>'
+      + '</div>');
+
+    html += _newProjectSection('context', 'Drafting context', false,
+      '<div class="d-grid gap-3">'
+      + '<div><label class="editor-tiny" for="new-project-help-page-url">Reference page URL (optional)</label>'
+      + '<input class="form-control form-control-sm mt-1" id="new-project-help-page-url" type="url" placeholder="https://example.com/help"></div>'
+      + '<div><label class="editor-tiny" for="new-project-help-page-title">Reference page title (optional)</label>'
+      + '<input class="form-control form-control-sm mt-1" id="new-project-help-page-title">'
+      + '<div class="text-muted small mt-1">The title shown to users on the link to that reference page.</div></div>'
+      + '<div><label class="editor-tiny" for="new-project-notes">Extra context for Weaver (optional)</label>'
+      + '<textarea class="form-control form-control-sm mt-1" id="new-project-notes" rows="4" placeholder="E.g. special instructions or local context"></textarea>'
+      + '<div class="text-muted small mt-1">This text is passed through as drafting context and works whether or not AI is enabled.</div></div>'
+      + '</div>');
+
     html += '</div>';
-    html += '<div class="row g-3"><div class="col-md-6"><label class="editor-tiny" for="new-project-output-type">Output</label><select class="form-select form-select-sm mt-1" id="new-project-output-type"><option value="form">Assemble downloadable forms</option><option value="survey">Save answers only</option></select></div>';
-    html += '<div class="col-md-6"><label class="editor-tiny" for="new-project-form-type">AssemblyLine form type</label><select class="form-select form-select-sm mt-1" id="new-project-form-type"><option value="auto">Let Weaver decide</option><option value="starts_case">Starts a case</option><option value="existing_case">Existing case</option><option value="appeal">Appeal</option><option value="other_form">Other form</option><option value="letter">Letter</option><option value="other">Other</option></select></div></div>';
-    html += '<div class="row g-3"><div class="col-md-6"><label class="editor-tiny" for="new-project-default-state">Default state/province (optional)</label><input class="form-control form-control-sm mt-1" id="new-project-default-state" placeholder="MA"></div>';
-    html += '<div class="col-md-6"><label class="editor-tiny" for="new-project-user-role">Typical user role</label><select class="form-select form-select-sm mt-1" id="new-project-user-role"><option value="auto">Let Weaver decide</option><option value="plaintiff">Starts the case/request</option><option value="defendant">Responds to it</option><option value="unknown">Ask the user</option></select></div></div>';
-    html += '<div class="form-check form-switch m-0"><input class="form-check-input" type="checkbox" id="new-project-include-next-steps" checked><label class="form-check-label editor-tiny" for="new-project-include-next-steps">Include a next steps document</label><div class="text-muted small mt-1">The generated DOCX is a reusable shell. Later settings changes do not overwrite custom Word edits.</div></div>';
-    html += '<div class="form-check form-switch m-0"><input class="form-check-input" type="checkbox" id="new-project-enable-navigation" checked><label class="form-check-label editor-tiny" for="new-project-enable-navigation">Enable left navigation</label></div>';
-    html += '<div class="form-check form-switch m-0"><input class="form-check-input" type="checkbox" id="new-project-copy-baseline-questions" checked><label class="form-check-label editor-tiny" for="new-project-copy-baseline-questions">Copy the AssemblyLine questions about people</label><div class="text-muted small mt-1">Writes editable copies of the name, address, and contact questions into your interview instead of leaving them in AssemblyLine\'s generic object blocks.</div></div>';
-    html += '<div><label class="editor-tiny" for="new-project-help-page-url">Reference page URL (optional)</label>';
-    html += '<input class="form-control form-control-sm mt-1" id="new-project-help-page-url" type="url" placeholder="https://example.com/help"></div>';
-    html += '<div><label class="editor-tiny" for="new-project-help-page-title">Reference page title (optional)</label>';
-    html += '<input class="form-control form-control-sm mt-1" id="new-project-help-page-title" placeholder="Page title shown to users"></div>';
-    html += '<div><label class="editor-tiny" for="new-project-notes">Extra context for Weaver (optional)</label>';
-    html += '<textarea class="form-control form-control-sm mt-1" id="new-project-notes" rows="4" placeholder="E.g. desired title, jurisdiction, special instructions, local context"></textarea>';
-    html += '<div class="text-muted small mt-1">This text is passed through as drafting context and works whether or not AI is enabled.</div></div>';
-    html += '</div></div></div>';
 
     html += '<div class="editor-upload-modal d-none" id="upload-progress-modal" role="dialog" aria-modal="true" aria-labelledby="upload-progress-title">';
     html += '<div class="editor-upload-modal-backdrop"></div>';
@@ -7847,6 +8218,66 @@
       if (!isDupe) _uploadedFiles.push(f);
     }
     _renderFileList();
+    _suggestNamesFromUpload();
+  }
+
+  // The server derives the interview's title from the document's filename the
+  // same way (`_apply_exact_name_to_interview`). Filling the fields in here
+  // means the author sees that guess while they can still change it, instead of
+  // meeting it after the project exists.
+  function _titleFromFilename(filename) {
+    var base = String(filename || '').replace(/^.*[\\/]/, '').replace(/\.[^.]+$/, '').trim();
+    if (!base) return '';
+    // Underscores separate words; hyphens usually belong to a form number
+    // (MC-030, CJ-P 34), so they stay.
+    var words = base.replace(/_+/g, ' ').replace(/\s+/g, ' ').trim().split(' ');
+    var titled = words.map(function (word) {
+      // Leave anything carrying a capital or a digit alone: those are acronyms
+      // and form numbers, and lowercasing them makes the guess worse.
+      if (/[A-Z0-9]/.test(word)) return word;
+      return word.toLowerCase();
+    });
+    if (titled.length && !/[A-Z0-9]/.test(titled[0])) {
+      titled[0] = titled[0].charAt(0).toUpperCase() + titled[0].slice(1);
+    }
+    return titled.join(' ').trim();
+  }
+
+  function _projectNameFromTitle(title) {
+    // Mirrors normalize_project_name: playground names are alphanumeric only
+    // and cannot start with a digit.
+    var parts = String(title || '').split(/[^A-Za-z0-9]+/).filter(Boolean);
+    var name = parts.map(function (part) {
+      return part.charAt(0).toUpperCase() + part.slice(1);
+    }).join('');
+    if (!name) return '';
+    if (/^[0-9]/.test(name)) name = 'P' + name;
+    if (name.toLowerCase() === 'default') name = name + 'Project';
+    return name;
+  }
+
+  function _suggestNamesFromUpload() {
+    if (!_uploadedFiles.length) return;
+    var title = _titleFromFilename(_uploadedFiles[0].name);
+    if (!title) return;
+    var shortTitle = title.slice(0, 25);
+    var projectName = _projectNameFromTitle(title);
+
+    // Only fill a field the author has not touched. `_suggestedValues` records
+    // what we put there, so replacing the first document updates a suggestion
+    // but never overwrites something typed by hand.
+    function suggest(elementId, value) {
+      var input = document.getElementById(elementId);
+      if (!input || !value) return;
+      var current = String(input.value || '').trim();
+      if (current && current !== _suggestedValues[elementId]) return;
+      input.value = value;
+      _suggestedValues[elementId] = value;
+    }
+
+    suggest('new-project-name', projectName);
+    suggest('new-project-title', title);
+    suggest('new-project-short-title', shortTitle);
   }
 
   function _renderFileList() {
@@ -8462,6 +8893,38 @@
       }
       renderOutline();
       renderCanvas();
+      return;
+    }
+
+    // LIST topic picker
+    if (target.closest('[data-open-list-topics]')) {
+      var topicTrigger = target.closest('[data-open-list-topics]');
+      openListTopicsPicker(
+        topicTrigger.getAttribute('data-open-list-topics'),
+        topicTrigger.getAttribute('data-topic-separator') === 'newline' ? '\n' : ', '
+      );
+      return;
+    }
+    if (target.id === 'list-topics-apply') {
+      applyListTopicsSelection();
+      return;
+    }
+    if (target.id === 'list-topics-expand' || target.id === 'list-topics-collapse') {
+      var shouldOpen = target.id === 'list-topics-expand';
+      document.querySelectorAll('#list-topics-tree [data-topic-group]').forEach(function (group) {
+        group.open = shouldOpen;
+      });
+      return;
+    }
+    if (target.id === 'list-topics-clear') {
+      document.querySelectorAll('#list-topics-tree input[data-topic-code]').forEach(function (box) {
+        box.checked = false;
+      });
+      updateListTopicsCounts();
+      return;
+    }
+    if (target.matches('#list-topics-tree input[data-topic-code]')) {
+      updateListTopicsCounts();
       return;
     }
 
@@ -9719,6 +10182,7 @@
       var removeIdx = parseInt(removeBtn.getAttribute('data-remove-upload'), 10);
       _uploadedFiles.splice(removeIdx, 1);
       _renderFileList();
+      _suggestNamesFromUpload();
       return;
     }
 
@@ -9736,6 +10200,13 @@
       var enableNavigationInput = document.getElementById('new-project-enable-navigation');
       var copyBaselineQuestionsInput = document.getElementById('new-project-copy-baseline-questions');
       var githubUrlInput = document.getElementById('new-project-github-url');
+      var filenameInput = document.getElementById('new-project-filename');
+      var titleInput = document.getElementById('new-project-title');
+      var shortTitleInput = document.getElementById('new-project-short-title');
+      var descriptionInput = document.getElementById('new-project-description');
+      var jurisdictionInput = document.getElementById('new-project-jurisdiction');
+      var landingPageUrlInput = document.getElementById('new-project-landing-page-url');
+      var listTopicsInput = document.getElementById('new-project-list-topics');
       var projectName = nameInput ? nameInput.value : 'NewProject';
       var notes = notesInput ? notesInput.value : '';
       var helpPageUrl = helpPageUrlInput ? helpPageUrlInput.value : '';
@@ -9770,6 +10241,13 @@
         formData.append('include_next_steps', includeNextSteps ? 'true' : 'false');
         formData.append('enable_navigation', enableNavigation ? 'true' : 'false');
         formData.append('copy_baseline_questions', copyBaselineQuestions ? 'true' : 'false');
+        formData.append('interview_filename', filenameInput ? filenameInput.value.trim() : '');
+        formData.append('interview_title', titleInput ? titleInput.value.trim() : '');
+        formData.append('interview_short_title', shortTitleInput ? shortTitleInput.value.trim() : '');
+        formData.append('interview_description', descriptionInput ? descriptionInput.value.trim() : '');
+        formData.append('jurisdiction', jurisdictionInput ? jurisdictionInput.value.trim() : '');
+        formData.append('landing_page_url', landingPageUrlInput ? landingPageUrlInput.value.trim() : '');
+        formData.append('list_topics', listTopicsInput ? listTopicsInput.value.trim() : '');
         _uploadedFiles.forEach(function (f) { formData.append('files', f, f.name); });
         apiUploadDetailed('/api/new-project', formData)
           .then(function (response) {
@@ -9786,7 +10264,7 @@
                 var jobData = jobPayload.data || {};
                 _hideUploadProgressModal();
                 state.project = jobData.project || queuedProject;
-                state.filename = jobData.filename || 'interview.yml';
+                state.filename = jobData.filename || 'main.yml';
                 state.canvasMode = 'question';
                 _uploadedFiles = [];
                 _showSuccessBanner('Project "' + esc(state.project) + '" created successfully.');
@@ -9858,6 +10336,10 @@
   // Track dirty state from inline inputs
   document.addEventListener('input', function (e) {
     var target = e.target;
+    if (target.id === 'list-topics-filter') {
+      applyListTopicsFilter();
+      return;
+    }
     if (target.id === 'assemblyline-settings-filter') {
       state.assemblyLineSettingsFilter = target.value || '';
       applyAssemblyLineSettingsFilter();

--- a/docassemble/ALWeaver/data/templates/editor.html
+++ b/docassemble/ALWeaver/data/templates/editor.html
@@ -375,6 +375,43 @@
   </div>
 </div>
 
+<!-- LIST topic picker -->
+<div class="modal fade" id="list-topics-modal" tabindex="-1" aria-labelledby="list-topics-modal-title">
+  <div class="modal-dialog modal-lg modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="list-topics-modal-title">Choose LIST topics</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p class="text-muted small">
+          Topics come from the <a href="https://taxonomy.legal" target="_blank" rel="noopener">LIST taxonomy</a>
+          (formerly NSMIv2). They help people find this form once it is published.
+        </p>
+        <label class="editor-tiny" for="list-topics-filter">Filter topics</label>
+        <div class="input-group input-group-sm mt-1 mb-2">
+          <span class="input-group-text"><i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i></span>
+          <input class="form-control" id="list-topics-filter" type="search" autocomplete="off">
+        </div>
+        <div class="d-flex justify-content-between align-items-center gap-2 mb-2">
+          <div class="editor-tiny" id="list-topics-selected-count" role="status" aria-live="polite"></div>
+          <div class="d-flex gap-2">
+            <button type="button" class="btn btn-sm btn-outline-secondary" id="list-topics-expand">Expand all</button>
+            <button type="button" class="btn btn-sm btn-outline-secondary" id="list-topics-collapse">Collapse all</button>
+            <button type="button" class="btn btn-sm btn-outline-secondary" id="list-topics-clear">Clear all</button>
+          </div>
+        </div>
+        <div id="list-topics-tree"></div>
+        <div class="alert alert-light border d-none mt-2" id="list-topics-empty">No topics match that filter.</div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-sm btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-sm btn-primary" id="list-topics-apply">Use these topics</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <!-- Insert Block Modal -->
 <div class="modal fade" id="insert-modal" tabindex="-1">
   <div class="modal-dialog">
@@ -388,6 +425,7 @@
           <button type="button" class="btn btn-primary text-start" data-insert="question">New question screen</button>          <button type="button" class="btn btn-outline-secondary text-start" data-insert="ai-screen"><i class="fa-solid fa-wand-magic-sparkles me-1" aria-hidden="true"></i>AI draft screen</button>          <button type="button" class="btn btn-outline-secondary text-start" data-insert="review">New review screen</button>          <button type="button" class="btn btn-outline-secondary text-start" data-insert="code">New code block</button>
           <button type="button" class="btn btn-outline-secondary text-start" data-insert="objects">New objects block</button>
           <button type="button" class="btn btn-outline-secondary text-start" data-insert="attachment">New attachment block</button>
+          <button type="button" class="btn btn-outline-secondary text-start" data-insert="comment">New comment block</button>
           <button type="button" class="btn btn-outline-secondary text-start" data-insert="other">New YAML block</button>
         </div>
         <div class="mt-3">

--- a/docassemble/ALWeaver/editor_utils.py
+++ b/docassemble/ALWeaver/editor_utils.py
@@ -59,6 +59,7 @@ BLOCK_TYPE_TABLE = "table"
 BLOCK_TYPE_TEMPLATE = "template"
 BLOCK_TYPE_TERMS = "terms"
 BLOCK_TYPE_SECTIONS = "sections"
+BLOCK_TYPE_COMMENT = "comment"
 BLOCK_TYPE_COMMENTED = "commented"
 BLOCK_TYPE_OTHER = "other"
 
@@ -66,6 +67,14 @@ BLOCK_TYPE_OTHER = "other"
 _METADATA_KEYS = {"metadata"}
 _INCLUDE_KEYS = {"include", "includes"}
 _DEFAULT_SCREEN_KEYS = {"default screen parts"}
+# Keys that may sit alongside `comment:` without making the block something else.
+_COMMENT_ONLY_ALLOWED_KEYS = {
+    "comment",
+    "id",
+    "_commented",
+    "_commented_type",
+    "_commented_yaml",
+}
 
 _METADATA_DOCUMENT_TYPES = {
     BLOCK_TYPE_METADATA,
@@ -518,6 +527,10 @@ def _detect_block_type(block: Dict[str, Any]) -> str:
         return BLOCK_TYPE_CODE
     if "objects" in block:
         return BLOCK_TYPE_OBJECTS
+    if "comment" in block and not (set(block) - _COMMENT_ONLY_ALLOWED_KEYS):
+        # A standalone `comment:` document is prose about the interview, not a
+        # nameless "other" block.
+        return BLOCK_TYPE_COMMENT
     return BLOCK_TYPE_OTHER
 
 
@@ -557,9 +570,36 @@ def _extract_order_block_label(code_str: str, block: Dict[str, Any]) -> str:
     return lines[0].strip()[:60] if lines else "Code block"
 
 
+def _first_line_title(text: str, limit: int = 70) -> str:
+    """Title a prose block by its first non-empty line, trimmed for the outline."""
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped:
+            if len(stripped) > limit:
+                return stripped[: limit - 1].rstrip() + "\u2026"
+            return stripped
+    return ""
+
+
+def _question_title(text: str) -> str:
+    """Title a question by its first line of actual prose.
+
+    A generated question often opens with Mako -- `% if user_started_case:` --
+    and copying that into the outline gives a row that looks like every other
+    row that starts the same way. Skip the directives and title the block by
+    what the user will read.
+    """
+    prose_lines = [
+        line
+        for line in text.splitlines()
+        if line.strip() and not line.lstrip().startswith(("%", "#"))
+    ]
+    return _first_line_title("\n".join(prose_lines)) or _first_line_title(text)
+
+
 def _extract_title(block: Dict[str, Any], block_type: str) -> str:
     if block_type == BLOCK_TYPE_QUESTION:
-        return str(block.get("question", "Untitled question"))
+        return _question_title(str(block.get("question") or "")) or "Untitled question"
     if block_type == BLOCK_TYPE_CODE:
         code_str = str(block.get("code", ""))
         block_id_key = str(block.get("id", ""))
@@ -577,6 +617,8 @@ def _extract_title(block: Dict[str, Any], block_type: str) -> str:
         return (
             str(meta.get("title", "Metadata")) if isinstance(meta, dict) else "Metadata"
         )
+    if block_type == BLOCK_TYPE_COMMENT:
+        return _first_line_title(str(block.get("comment") or "")) or "Comment"
     if block_type == BLOCK_TYPE_INCLUDES:
         return "Includes"
     if block_type == BLOCK_TYPE_DEFAULT_SCREEN_PARTS:
@@ -601,6 +643,10 @@ def _extract_title(block: Dict[str, Any], block_type: str) -> str:
         if block.get("variable name") == "al_nav_sections":
             return "AL navigation sections (al_nav_sections)"
         return "Sections"
+    for key in block:
+        if str(key).startswith("_"):
+            continue
+        return str(key).replace("_", " ").capitalize()
     return "Block"
 
 

--- a/docassemble/ALWeaver/test_assemblyline_settings.py
+++ b/docassemble/ALWeaver/test_assemblyline_settings.py
@@ -4,6 +4,8 @@ import yaml
 
 from docassemble.ALWeaver.assemblyline_settings import (
     MANAGED_BLOCK_ID,
+    METADATA_DOCUMENT_ID,
+    SETTINGS_SCHEMA,
     read_settings,
     update_settings,
 )
@@ -46,7 +48,11 @@ class AssemblyLineSettingsTest(unittest.TestCase):
             },
         )
         self.assertIn("# author-owned code remains untouched", updated)
-        self.assertIn('AL_DEFAULT_COUNTRY = "CA"', updated)
+        # The author's own block keeps its comment and its structure, and the
+        # changed value is written there rather than duplicated in Weaver's
+        # block -- two assignments of one name would let document order decide.
+        self.assertIn("AL_DEFAULT_COUNTRY = 'US'", updated)
+        self.assertEqual(updated.count("AL_DEFAULT_COUNTRY = "), 1)
         self.assertLess(
             updated.index(f"id: {MANAGED_BLOCK_ID}"), updated.index("id: main order")
         )
@@ -143,6 +149,314 @@ class AssemblyLineSettingsTest(unittest.TestCase):
     def test_rejects_runtime_logic_as_a_setting(self):
         with self.assertRaisesRegex(ValueError, "Unsupported settings"):
             update_settings(SOURCE, {"addresses_to_search": "[broken"})
+
+
+METADATA_WITH_LISTS = """metadata:
+  title: >-
+    Test form
+  description: |-
+    A test form
+  LIST_topics:
+    - "CO-00-00-00-00"
+  # Keep legacy tags behavior for compatibility with downstream tools.
+  tags:
+    - "CO-00-00-00-00"
+
+  authors:
+    - Court Forms Online
+---
+code: |
+  x = 1
+"""
+
+
+class MetadataListEditingTest(unittest.TestCase):
+    """A metadata list has to survive being edited into more than one item.
+
+    PyYAML ends a block sequence's node where the *next* token begins, so the
+    node text runs past the last item and over any comment or blank line before
+    the following key. Replacing that whole span used to glue the next key onto
+    the last item, which the round-trip guard then rejected with "did not
+    round-trip safely" -- every multi-item list in `metadata` was unwritable.
+    """
+
+    def _metadata(self, source):
+        return yaml.safe_load(source.split("---")[0])["metadata"]
+
+    def test_a_list_can_grow_past_one_item(self):
+        updated = update_settings(
+            METADATA_WITH_LISTS,
+            {"LIST_topics": ["HO-00-00-00-00", "HO-05-00-00-00", "HO-06-00-00-00"]},
+        )
+        self.assertEqual(
+            self._metadata(updated)["LIST_topics"],
+            ["HO-00-00-00-00", "HO-05-00-00-00", "HO-06-00-00-00"],
+        )
+
+    def test_editing_a_list_leaves_the_following_key_alone(self):
+        updated = update_settings(
+            METADATA_WITH_LISTS, {"LIST_topics": ["HO-00-00-00-00", "HO-05-00-00-00"]}
+        )
+        self.assertIn("\n  tags:\n", updated)
+        self.assertEqual(self._metadata(updated)["tags"], ["CO-00-00-00-00"])
+        # The comment sits inside the span PyYAML reports for the sequence.
+        self.assertIn(
+            "# Keep legacy tags behavior for compatibility with downstream tools.",
+            updated,
+        )
+
+    def test_a_blank_line_between_keys_survives(self):
+        updated = update_settings(METADATA_WITH_LISTS, {"authors": ["A", "B"]})
+        self.assertIn('- "CO-00-00-00-00"\n\n  authors:', updated)
+        self.assertEqual(self._metadata(updated)["authors"], ["A", "B"])
+
+    def test_a_list_can_shrink_and_empty(self):
+        shrunk = update_settings(METADATA_WITH_LISTS, {"authors": ["Solo"]})
+        self.assertEqual(self._metadata(shrunk)["authors"], ["Solo"])
+        emptied = update_settings(METADATA_WITH_LISTS, {"authors": []})
+        self.assertEqual(self._metadata(emptied)["authors"], [])
+
+    def test_a_list_as_the_final_key_still_works(self):
+        source = "metadata:\n  title: A\n  authors:\n    - One\n"
+        updated = update_settings(source, {"authors": ["One", "Two"]})
+        self.assertEqual(self._metadata(updated)["authors"], ["One", "Two"])
+
+    def test_a_literal_block_still_round_trips(self):
+        updated = update_settings(
+            METADATA_WITH_LISTS, {"description": "First line\nSecond line"}
+        )
+        self.assertEqual(
+            self._metadata(updated)["description"], "First line\nSecond line"
+        )
+        self.assertIn("\n  LIST_topics:\n", updated)
+
+    def test_untouched_values_keep_their_original_quoting(self):
+        updated = update_settings(METADATA_WITH_LISTS, {"authors": ["A"]})
+        self.assertIn('  tags:\n    - "CO-00-00-00-00"', updated)
+
+
+class SettingsTransparencyTest(unittest.TestCase):
+    """The panel has to be able to say where every value it writes ends up."""
+
+    def test_each_section_names_the_documents_it_writes_to(self):
+        sections = {section["id"]: section for section in SETTINGS_SCHEMA}
+
+        # Publishing identity spans both: metadata keys plus allowed_courts.
+        self.assertEqual(
+            [document["id"] for document in sections["identity"]["documents"]],
+            [METADATA_DOCUMENT_ID, MANAGED_BLOCK_ID],
+        )
+        # Predefined variables are code only.
+        for section_id in ("organization", "interview", "language", "next_steps"):
+            with self.subTest(section_id=section_id):
+                self.assertEqual(
+                    [document["id"] for document in sections[section_id]["documents"]],
+                    [MANAGED_BLOCK_ID],
+                )
+        # The read-only notes section writes nothing.
+        self.assertEqual(sections["advanced"]["documents"], [])
+
+    def test_documents_follow_the_field_scopes_rather_than_a_hand_written_list(self):
+        for section in SETTINGS_SCHEMA:
+            scopes = {field.get("scope") for field in section.get("fields", [])}
+            ids = [document["id"] for document in section["documents"]]
+            with self.subTest(section=section["id"]):
+                self.assertEqual(
+                    METADATA_DOCUMENT_ID in ids, bool(scopes & {"metadata", "both"})
+                )
+                self.assertEqual(MANAGED_BLOCK_ID in ids, bool(scopes & {None, "both"}))
+
+    def test_every_document_carries_an_explanation(self):
+        for section in SETTINGS_SCHEMA:
+            for document in section["documents"]:
+                with self.subTest(section=section["id"], document=document["id"]):
+                    self.assertTrue(document["description"])
+                    self.assertIn(document["kind"], {"metadata", "code"})
+
+    def test_read_settings_reports_where_a_value_currently_lives(self):
+        result = read_settings(SOURCE)
+        # SOURCE sets AL_DEFAULT_COUNTRY in an author-owned block, not Weaver's.
+        self.assertEqual(result["sources"]["AL_DEFAULT_COUNTRY"], "code block")
+        self.assertNotEqual(result["sources"]["AL_DEFAULT_COUNTRY"], MANAGED_BLOCK_ID)
+        self.assertEqual(result["managed_block_id"], MANAGED_BLOCK_ID)
+        self.assertEqual(result["metadata_document_id"], METADATA_DOCUMENT_ID)
+
+    def test_the_panel_explains_both_kinds_of_setting(self):
+        explainer = read_settings(SOURCE)["explainer"]
+        self.assertIn("metadata", explainer)
+        self.assertIn("al_form_type", explainer)
+        # Popover content travels through a double-quoted HTML attribute.
+        self.assertNotIn('"', explainer)
+
+
+AUTHOR_OWNED_SOURCE = """metadata:
+  title: Original
+---
+# author-owned code
+code: |
+  # my own settings
+  AL_DEFAULT_COUNTRY = "CA"
+  AL_ORGANIZATION_TITLE = org_title()
+  something_else = compute()
+---
+id: main order
+mandatory: True
+code: |
+  interview_order = True
+"""
+
+
+class AuthorOwnedAssignmentTest(unittest.TestCase):
+    """A setting the author already assigns has exactly one home.
+
+    Writing Weaver's own copy on top of an author's assignment leaves two blocks
+    setting one name, with the winner decided by document order. The panel edits
+    the assignment where it already lives instead.
+    """
+
+    def _author_block(self, source):
+        return source.split("---")[1]
+
+    def _saved(self, **overrides):
+        current = read_settings(AUTHOR_OWNED_SOURCE)["values"]
+        return update_settings(AUTHOR_OWNED_SOURCE, {**current, **overrides})
+
+    def test_a_changed_value_is_rewritten_in_the_authors_own_block(self):
+        saved = self._saved(AL_DEFAULT_COUNTRY="US")
+        self.assertIn("AL_DEFAULT_COUNTRY = 'US'", self._author_block(saved))
+        self.assertEqual(read_settings(saved)["values"]["AL_DEFAULT_COUNTRY"], "US")
+
+    def test_the_managed_block_does_not_repeat_it(self):
+        saved = self._saved(AL_DEFAULT_COUNTRY="US")
+        managed = saved.split("id: " + MANAGED_BLOCK_ID)[1]
+        self.assertNotIn("AL_DEFAULT_COUNTRY = ", managed)
+        self.assertIn(
+            "# AL_DEFAULT_COUNTRY is set in one of your own code blocks, not here.",
+            managed,
+        )
+        # Exactly one assignment survives anywhere in the file.
+        self.assertEqual(saved.count("AL_DEFAULT_COUNTRY = "), 1)
+
+    def test_the_rest_of_the_authors_block_is_untouched(self):
+        saved = self._saved(AL_DEFAULT_COUNTRY="US")
+        block = self._author_block(saved)
+        self.assertIn("# my own settings", block)
+        self.assertIn("something_else = compute()", block)
+
+    def test_saving_without_changes_does_not_rewrite_author_code(self):
+        saved = self._saved()
+        # Down to the author's own quoting.
+        self.assertIn('AL_DEFAULT_COUNTRY = "CA"', self._author_block(saved))
+        self.assertEqual(saved.count("AL_DEFAULT_COUNTRY = "), 1)
+
+    def test_a_computed_value_is_never_flattened_into_a_string(self):
+        """`AL_ORGANIZATION_TITLE = org_title()` reaches the panel as its source
+        text. Writing that back through repr() would turn working code into the
+        string "org_title()"."""
+        saved = self._saved()
+        self.assertIn("AL_ORGANIZATION_TITLE = org_title()", self._author_block(saved))
+        self.assertNotIn("'org_title()'", saved)
+        managed = saved.split("id: " + MANAGED_BLOCK_ID)[1]
+        self.assertNotIn("AL_ORGANIZATION_TITLE = ", managed)
+
+    def test_a_computed_value_is_read_only_and_survives_a_submitted_value(self):
+        """The control is disabled, but a stale or hand-made request must not be
+        able to replace the author's expression either."""
+        saved = self._saved(AL_ORGANIZATION_TITLE="Legal Aid")
+        self.assertIn("AL_ORGANIZATION_TITLE = org_title()", self._author_block(saved))
+        self.assertNotIn("Legal Aid", saved)
+        self.assertEqual(
+            read_settings(saved)["values"]["AL_ORGANIZATION_TITLE"], "org_title()"
+        )
+
+    def test_settings_with_no_author_assignment_still_use_the_managed_block(self):
+        saved = self._saved(al_typed_signature_prefix="/sig/")
+        managed = saved.split("id: " + MANAGED_BLOCK_ID)[1]
+        self.assertIn("al_typed_signature_prefix = '/sig/'", managed)
+
+    def test_the_managed_block_is_still_rewritten_in_place_on_a_second_save(self):
+        once = self._saved(AL_DEFAULT_COUNTRY="US")
+        twice = update_settings(once, read_settings(once)["values"])
+        self.assertEqual(twice.count("id: " + MANAGED_BLOCK_ID), 1)
+        self.assertEqual(twice.count("AL_DEFAULT_COUNTRY = "), 1)
+        self.assertEqual(read_settings(twice)["values"]["AL_DEFAULT_COUNTRY"], "US")
+
+
+COMPUTED_CHOICE_SOURCE = """metadata:
+  title: Original
+---
+# author-owned code
+code: |
+  al_form_type = form_type_for(case)
+  al_form_requires_digital_signature = needs_signature(case)
+  AL_DEFAULT_COUNTRY = "CA"
+---
+id: main order
+mandatory: True
+code: |
+  interview_order = True
+"""
+
+
+class ComputedSettingTest(unittest.TestCase):
+    """A setting the interview computes is reported, never written.
+
+    Rendering `al_form_type = form_type_for(case)` back through the panel would
+    have to pick one of the allowed choices, replacing working code with a
+    guess. `_coerce_value` used to reject the expression outright, so an
+    interview computing any choice- or boolean-typed setting could not be saved
+    from this panel at all.
+    """
+
+    def test_computed_settings_are_reported_with_the_block_that_holds_them(self):
+        result = read_settings(COMPUTED_CHOICE_SOURCE)
+        self.assertEqual(
+            result["computed"],
+            {
+                "al_form_type": "code block",
+                "al_form_requires_digital_signature": "code block",
+            },
+        )
+        # A plain literal in the same block is not computed.
+        self.assertNotIn("AL_DEFAULT_COUNTRY", result["computed"])
+        self.assertEqual(result["values"]["al_form_type"], "form_type_for(case)")
+
+    def test_the_panel_can_still_save(self):
+        current = read_settings(COMPUTED_CHOICE_SOURCE)["values"]
+        saved = update_settings(
+            COMPUTED_CHOICE_SOURCE, {**current, "AL_DEFAULT_COUNTRY": "US"}
+        )
+        self.assertEqual(read_settings(saved)["values"]["AL_DEFAULT_COUNTRY"], "US")
+
+    def test_the_computed_expressions_are_untouched(self):
+        current = read_settings(COMPUTED_CHOICE_SOURCE)["values"]
+        saved = update_settings(
+            COMPUTED_CHOICE_SOURCE, {**current, "AL_DEFAULT_COUNTRY": "US"}
+        )
+        author_block = saved.split("---")[1]
+        self.assertIn("al_form_type = form_type_for(case)", author_block)
+        self.assertIn(
+            "al_form_requires_digital_signature = needs_signature(case)", author_block
+        )
+
+    def test_the_managed_block_neither_writes_nor_hides_them(self):
+        current = read_settings(COMPUTED_CHOICE_SOURCE)["values"]
+        saved = update_settings(COMPUTED_CHOICE_SOURCE, dict(current))
+        managed = saved.split("id: " + MANAGED_BLOCK_ID)[1]
+        self.assertNotIn("al_form_type = ", managed)
+        self.assertIn(
+            "# al_form_type is computed by your own code, and is left alone.", managed
+        )
+        self.assertEqual(saved.count("al_form_type = "), 1)
+
+    def test_a_literal_that_looks_like_a_choice_is_still_editable(self):
+        source = COMPUTED_CHOICE_SOURCE.replace(
+            "al_form_type = form_type_for(case)", 'al_form_type = "appeal"'
+        )
+        self.assertNotIn("al_form_type", read_settings(source)["computed"])
+        current = read_settings(source)["values"]
+        saved = update_settings(source, {**current, "al_form_type": "starts_case"})
+        self.assertEqual(read_settings(saved)["values"]["al_form_type"], "starts_case")
 
 
 if __name__ == "__main__":

--- a/docassemble/ALWeaver/test_editor_api.py
+++ b/docassemble/ALWeaver/test_editor_api.py
@@ -1311,5 +1311,205 @@ class TestEditorApiFileCreation(unittest.TestCase):
         self.assertEqual(response.get_json()["error"]["code"], "revision_conflict")
 
 
+class TestEditorNewProjectNaming(unittest.TestCase):
+    """A generated project is named after its document, not "interview.yml"."""
+
+    def _run_upload_job(self, yaml_filename, interview_filename=None):
+        with (
+            patch.object(api_editor, "_update_new_project_job_state"),
+            patch.object(api_editor, "playground_write_yaml") as mock_write,
+            patch.object(api_editor, "_copy_files_to_section"),
+            patch.object(
+                api_editor,
+                "generate_interview_from_bytes",
+                return_value={
+                    "yaml_text": "metadata:\n  title: Eviction\n",
+                    "yaml_filename": yaml_filename,
+                    "input_filename": "eviction.pdf",
+                    "generated_template_files": [],
+                },
+            ),
+        ):
+            result = api_editor._complete_new_project_upload_job(
+                job_id="job-1",
+                uid=7,
+                project_name="Eviction",
+                request_id="req-1",
+                uploaded_files=[
+                    {
+                        "filename": "eviction.pdf",
+                        "content_bytes": b"%PDF-1.4",
+                        "mimetype": "application/pdf",
+                    }
+                ],
+                generation_options={},
+                debug_requested=False,
+                interview_filename=interview_filename,
+            )
+        return result, mock_write
+
+    def test_generated_project_keeps_the_descriptive_name_weaver_derived(self):
+        result, mock_write = self._run_upload_job("eviction.yml")
+        self.assertEqual(result["filename"], "eviction.yml")
+        self.assertEqual(mock_write.call_args.args[2], "eviction.yml")
+
+    def test_author_supplied_filename_wins(self):
+        result, mock_write = self._run_upload_job(
+            "eviction.yml", interview_filename="main.yml"
+        )
+        self.assertEqual(result["filename"], "main.yml")
+        self.assertEqual(mock_write.call_args.args[2], "main.yml")
+
+    def test_an_unusable_derived_name_falls_back_to_the_assemblyline_default(self):
+        result, _mock_write = self._run_upload_job("")
+        self.assertEqual(result["filename"], "main.yml")
+
+    def test_blank_project_uses_main_yml(self):
+        with (
+            patch.object(api_editor, "playground_write_yaml") as mock_write,
+            patch.object(api_editor, "get_list_of_projects", return_value=[]),
+            patch.object(
+                api_editor, "next_available_project_name", return_value="Blank"
+            ),
+            patch.object(api_editor, "create_project"),
+        ):
+            with api_editor.app.test_request_context(
+                "/al/editor/api/new-project", json={"project_name": "Blank"}
+            ):
+                response = api_editor._new_project_from_template(7, "req-1")
+        self.assertEqual(response.get_json()["data"]["filename"], "main.yml")
+        self.assertEqual(mock_write.call_args.args[2], "main.yml")
+
+    def test_publishing_metadata_reaches_the_generator(self):
+        pdf_path = Path(__file__).parent / "test/test_dropdown_fields.pdf"
+        with (
+            patch.object(api_editor, "_editor_auth_check", return_value=True),
+            patch.object(api_editor, "_current_user_id", return_value=7),
+            patch.object(api_editor, "get_list_of_projects", return_value=[]),
+            patch.object(api_editor, "_editor_async_is_configured", return_value=True),
+            patch.object(
+                api_editor, "next_available_project_name", return_value="Meta"
+            ),
+            patch.object(api_editor, "create_project"),
+            patch.object(api_editor, "_start_new_project_upload_job") as mock_start_job,
+        ):
+            mock_start_job.return_value = {
+                "job_id": "job-1",
+                "job_url": "/al/editor/api/new-project/jobs/job-1",
+                "state": {"status": "queued"},
+            }
+            with api_editor.app.test_client() as client:
+                with pdf_path.open("rb") as handle:
+                    client.post(
+                        "/al/editor/api/new-project",
+                        data={
+                            "project_name": "Meta",
+                            "interview_title": "Petition to enforce the sanitary code",
+                            "interview_short_title": "Sanitary code",
+                            "interview_description": "Ask the court to inspect.",
+                            "jurisdiction": "NAM-US-US+MA",
+                            "landing_page_url": "https://example.org/sanitary",
+                            "list_topics": "HO-00-00-00-00, HO-05-00-00-00",
+                            "interview_filename": "sanitary_code.yml",
+                            "default_state": "MA",
+                            "files": (BytesIO(handle.read()), pdf_path.name),
+                        },
+                        content_type="multipart/form-data",
+                    )
+
+        kwargs = mock_start_job.call_args.kwargs
+        overrides = kwargs["generation_options"]["interview_overrides"]
+        self.assertEqual(kwargs["interview_filename"], "sanitary_code.yml")
+        self.assertEqual(overrides["title"], "Petition to enforce the sanitary code")
+        self.assertEqual(overrides["short_title"], "Sanitary code")
+        self.assertEqual(overrides["description"], "Ask the court to inspect.")
+        self.assertEqual(overrides["landing_page_url"], "https://example.org/sanitary")
+        self.assertTrue(overrides["has_other_categories"])
+        self.assertEqual(
+            overrides["other_categories"], "HO-00-00-00-00, HO-05-00-00-00"
+        )
+        # An explicit jurisdiction is not overwritten by the default state.
+        self.assertEqual(overrides["jurisdiction"], "NAM-US-US+MA")
+        self.assertEqual(overrides["state"], "MA")
+
+
+class TestEditorStyleCheckSeverity(unittest.TestCase):
+    def test_style_findings_never_report_as_errors(self):
+        demoted = api_editor._demote_style_findings(
+            [
+                {
+                    "rule_id": "missing-metadata-fields",
+                    "level": "error",
+                    "severity": "error",
+                    "message": "x",
+                },
+                {
+                    "rule_id": "vague-button",
+                    "level": "warning",
+                    "severity": "warning",
+                    "message": "y",
+                },
+                {
+                    "rule_id": "prefer-person-objects",
+                    "level": "info",
+                    "severity": "info",
+                    "message": "z",
+                },
+            ]
+        )
+        self.assertEqual(
+            [item["level"] for item in demoted], ["warning", "warning", "info"]
+        )
+        self.assertEqual(
+            [item["severity"] for item in demoted], ["warning", "warning", "info"]
+        )
+        self.assertEqual(demoted[0]["style_original_level"], "error")
+        self.assertNotIn("style_original_level", demoted[1])
+
+
+class TestEditorListTopics(unittest.TestCase):
+    """The picker offers the same codes the question-driven Weaver offers."""
+
+    def test_taxonomy_is_grouped_with_the_heading_code_first(self):
+        groups = api_editor._list_topic_groups()
+        self.assertTrue(groups)
+
+        by_label = {group["label"]: group for group in groups}
+        self.assertIn("Housing", by_label)
+        housing = by_label["Housing"]
+        # A group leads with its own broadest code.
+        self.assertEqual(housing["topics"][0]["code"], "HO-00-00-00-00")
+        self.assertTrue(housing["topics"][0]["heading"])
+        codes = [topic["code"] for topic in housing["topics"]]
+        self.assertIn("HO-05-00-00-00", codes)
+        self.assertEqual(len(codes), len(set(codes)))
+        for topic in housing["topics"]:
+            self.assertTrue(topic["label"])
+
+        # Relevance order, the same custom order get_LIST_codes applies.
+        self.assertEqual(groups[0]["label"], "Housing")
+
+    def test_endpoint_returns_the_groups_to_an_authenticated_developer(self):
+        with (
+            patch.object(api_editor, "_editor_auth_check", return_value=True),
+            api_editor.app.test_request_context("/al/editor/api/list-topics"),
+        ):
+            payload = api_editor.editor_api_list_topics().get_json()
+
+        self.assertTrue(payload["success"])
+        self.assertTrue(payload["data"]["groups"])
+        self.assertEqual(payload["data"]["docs_url"], "https://taxonomy.legal")
+
+    def test_endpoint_refuses_an_unauthenticated_request(self):
+        with (
+            patch.object(api_editor, "_editor_auth_check", return_value=False),
+            api_editor.app.test_request_context("/al/editor/api/list-topics"),
+        ):
+            response = api_editor.editor_api_list_topics()
+
+        status = response[1] if isinstance(response, tuple) else response.status_code
+        self.assertEqual(status, 401)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/docassemble/ALWeaver/test_editor_frontend.py
+++ b/docassemble/ALWeaver/test_editor_frontend.py
@@ -451,6 +451,155 @@ class TestEditorFrontend(unittest.TestCase):
         self.assertIn("field.pair ? 'col-12 col-md-6' : 'col-12'", editor)
         self.assertIn("input.value === '' ? '' : Number(input.value)", editor)
 
+    def test_assemblyline_settings_explain_themselves_and_flag_server_overrides(self):
+        """Guidance that lived on the question-driven Weaver's screens has to
+        travel with the control, and a setting that overrides the whole server
+        has to say so."""
+        editor = (self.package_dir / "data/static/editor.js").read_text()
+
+        self.assertIn("editor-al-setting-help", editor)
+        self.assertIn("_settingServerDefaultHtml", editor)
+        self.assertIn("Overrides ", editor)
+        self.assertIn("Comes from ", editor)
+        self.assertIn("server_defaults", editor)
+        # Help text is searchable, so an author can find a setting by what it does.
+        self.assertIn("field.help || ''", editor)
+
+    def test_assemblyline_settings_say_which_yaml_block_holds_each_section(self):
+        editor = (self.package_dir / "data/static/editor.js").read_text()
+
+        self.assertIn("function _settingsSectionDocumentsHtml(", editor)
+        self.assertIn("section.documents", editor)
+        self.assertIn(">Saved to<", editor)
+        # A value Weaver found in someone else's code block is flagged.
+        self.assertIn("function _settingSourceHtml(", editor)
+        self.assertIn("Weaver does not add a second copy", editor)
+        # And the page explains what it is for.
+        self.assertIn("function _settingsExplainerHtml(", editor)
+        self.assertIn('data-bs-toggle="popover"', editor)
+        self.assertIn("function _initSettingsPopovers(", editor)
+
+    def test_a_computed_setting_is_read_only_and_says_where_to_edit_it(self):
+        editor = (self.package_dir / "data/static/editor.js").read_text()
+
+        self.assertIn("function _settingComputedBlock(", editor)
+        self.assertIn("function _settingComputedHtml(", editor)
+        self.assertIn("readonly disabled aria-disabled=", editor)
+        # It has to say where the real answer lives and how to change it.
+        self.assertIn("open that block in the outline, or use YAML source", editor)
+        self.assertIn("Saving here leaves it exactly as it is", editor)
+        # A disabled control is still in the DOM, so the save has to skip it.
+        self.assertIn("if (computed[key]) return;", editor)
+
+    def test_escaping_covers_quotes_because_almost_every_call_is_an_attribute(self):
+        """`esc()` output lands in title=, data-bs-content= and friends, so a
+        quote in the value would close the attribute early."""
+        editor = (self.package_dir / "data/static/editor.js").read_text()
+
+        self.assertIn("function esc(text) {", editor)
+        self.assertIn(".replace(/\"/g, '&quot;')", editor)
+        self.assertIn("""replace(/'/g, '&#39;')""", editor)
+
+    def test_the_style_check_does_not_dress_itself_up_as_a_blocking_error(self):
+        editor = (self.package_dir / "data/static/editor.js").read_text()
+
+        self.assertIn("var isStyleMode = state.validationMode === 'style'", editor)
+        self.assertIn("var hasProblems = !isStyleMode &&", editor)
+        self.assertIn("'Style suggestions'", editor)
+        self.assertIn("None of these stop the interview from running", editor)
+
+    def test_new_project_collects_publishing_metadata_and_the_filename(self):
+        editor = (self.package_dir / "data/static/editor.js").read_text()
+
+        for element_id in (
+            "new-project-filename",
+            "new-project-title",
+            "new-project-short-title",
+            "new-project-description",
+            "new-project-jurisdiction",
+            "new-project-landing-page-url",
+            "new-project-list-topics",
+        ):
+            with self.subTest(element_id=element_id):
+                self.assertIn('id="%s"' % element_id, editor)
+        for form_key in (
+            "interview_filename",
+            "interview_title",
+            "interview_short_title",
+            "interview_description",
+            "jurisdiction",
+            "landing_page_url",
+            "list_topics",
+        ):
+            with self.subTest(form_key=form_key):
+                self.assertIn("formData.append('%s'" % form_key, editor)
+        # The old hard-coded name must not survive as a fallback.
+        self.assertNotIn("'interview.yml'", editor)
+
+    def test_a_comment_block_can_be_inserted_like_any_other(self):
+        template = (self.package_dir / "data/templates/editor.html").read_text()
+        editor = (self.package_dir / "data/static/editor.js").read_text()
+
+        self.assertIn('data-insert="comment"', template)
+        self.assertIn("if (kind === 'comment')", editor)
+
+    def test_the_outline_previews_a_block_on_hover(self):
+        editor = (self.package_dir / "data/static/editor.js").read_text()
+
+        self.assertIn("function blockQuickView(", editor)
+        self.assertIn("esc(blockQuickView(block))", editor)
+        self.assertIn("if (type === 'comment') return 'Comment'", editor)
+
+    def test_create_project_groups_its_settings_into_accordion_sections(self):
+        editor = (self.package_dir / "data/static/editor.js").read_text()
+
+        self.assertIn("function _newProjectSection(", editor)
+        self.assertIn('class="accordion editor-new-project-accordion"', editor)
+        for section in ("files", "basics", "advanced", "metadata", "context"):
+            with self.subTest(section=section):
+                self.assertIn("_newProjectSection('%s'" % section, editor)
+        # Independent sections, not a wizard: closing what you just filled in to
+        # open the next one would be hostile.
+        self.assertNotIn('data-bs-parent="#new-project-accordion"', editor)
+        # The advanced group is the collapsed one.
+        self.assertIn(
+            "_newProjectSection('advanced', 'Advanced settings', false", editor
+        )
+        self.assertIn("_newProjectSection('basics', 'Project settings', true", editor)
+
+    def test_uploading_a_document_suggests_the_project_name_and_title(self):
+        editor = (self.package_dir / "data/static/editor.js").read_text()
+
+        self.assertIn("function _titleFromFilename(", editor)
+        self.assertIn("function _projectNameFromTitle(", editor)
+        self.assertIn("function _suggestNamesFromUpload(", editor)
+        self.assertIn("suggest('new-project-name', projectName)", editor)
+        self.assertIn("suggest('new-project-title', title)", editor)
+        self.assertIn("suggest('new-project-short-title', shortTitle)", editor)
+        # A suggestion never overwrites something the author typed.
+        self.assertIn(
+            "if (current && current !== _suggestedValues[elementId]) return;", editor
+        )
+
+    def test_list_topics_have_a_picker_instead_of_codes_typed_from_memory(self):
+        template = (self.package_dir / "data/templates/editor.html").read_text()
+        editor = (self.package_dir / "data/static/editor.js").read_text()
+
+        self.assertIn('id="list-topics-modal"', template)
+        self.assertIn('id="list-topics-tree"', template)
+        self.assertIn('id="list-topics-filter"', template)
+        self.assertIn('id="list-topics-apply"', template)
+        self.assertIn("/api/list-topics", editor)
+        self.assertIn("function openListTopicsPicker(", editor)
+        self.assertIn("function applyListTopicsSelection(", editor)
+        # Built the way ALToolbox's al_tree_select is: real disclosure groups
+        # around real checkboxes, so keyboard and screen readers work unaided.
+        self.assertIn('<details class="editor-topic-group"', editor)
+        self.assertIn('type="checkbox"', editor)
+        # Both places that hold topic codes can open it.
+        self.assertIn('data-open-list-topics="new-project-list-topics"', editor)
+        self.assertIn("field.key === 'LIST_topics'", editor)
+
     def test_new_project_offers_to_copy_the_assemblyline_person_questions(self):
         editor = (self.package_dir / "data/static/editor.js").read_text()
 

--- a/docassemble/ALWeaver/test_editor_source_preservation.py
+++ b/docassemble/ALWeaver/test_editor_source_preservation.py
@@ -171,5 +171,51 @@ class TestEditorSourcePreservation(unittest.TestCase):
             update_block_in_yaml(duplicated, "intro", "id: intro\nquestion: Edited\n")
 
 
+class TestEditorBlockTitles(unittest.TestCase):
+    """The outline has to name a block well enough to find it again."""
+
+    def test_a_standalone_comment_is_titled_by_its_first_line(self):
+        source = (
+            "---\n"
+            "comment: |\n"
+            "  The questions below are copies of the questions in AssemblyLine's\n"
+            "  ql_baseline.yml, rewritten to name this interview's own objects.\n"
+        )
+        block = parse_interview_yaml(source)["blocks"][0]
+        self.assertEqual(block["type"], "comment")
+        self.assertEqual(
+            block["title"],
+            "The questions below are copies of the questions in AssemblyLine's",
+        )
+
+    def test_a_long_comment_first_line_is_trimmed(self):
+        source = "comment: |\n  " + ("word " * 40).strip() + "\n"
+        block = parse_interview_yaml(source)["blocks"][0]
+        self.assertLessEqual(len(block["title"]), 70)
+        self.assertTrue(block["title"].endswith("\u2026"))
+
+    def test_a_comment_alongside_other_keys_is_not_a_comment_block(self):
+        source = "comment: Explains the screen\nquestion: |\n  Hello\n"
+        block = parse_interview_yaml(source)["blocks"][0]
+        self.assertEqual(block["type"], "question")
+
+    def test_a_question_is_titled_by_its_prose_not_its_mako(self):
+        source = (
+            "question: |\n"
+            "  % if user_started_case:\n"
+            "  Name of the defendant\n"
+            "  % else:\n"
+            "  Name of the plaintiff\n"
+            "  % endif\n"
+        )
+        block = parse_interview_yaml(source)["blocks"][0]
+        self.assertEqual(block["title"], "Name of the defendant")
+
+    def test_an_unrecognised_block_is_named_after_its_first_key(self):
+        source = "features:\n  navigation: True\n"
+        block = parse_interview_yaml(source)["blocks"][0]
+        self.assertEqual(block["title"], "Features")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/docassemble/ALWeaver/test_editor_upload_field_naming.py
+++ b/docassemble/ALWeaver/test_editor_upload_field_naming.py
@@ -1,0 +1,117 @@
+# do not pre-load
+
+"""The graphical editor's upload path must produce AssemblyLine variable names.
+
+`api_editor.py` builds one exact set of generation options when an author drops a
+PDF on the new-project screen.  These tests run `generate_interview_from_path()`
+with that same set, against a template whose fields already carry canonical AL
+labels, and assert the mapped names come out the other side.
+"""
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from . import interview_generator as interview_generator_module
+from .interview_generator import generate_interview_from_path
+
+PDF_PATH = Path(__file__).parent / "test/test_petition_to_enforce_sanitary_code.pdf"
+
+# The options `editor_api_new_project()` sends for a form project with every
+# switch left at its default (api_editor.py, `generation_options`).
+EDITOR_UPLOAD_OPTIONS = {
+    "create_package_zip": False,
+    "include_next_steps": True,
+    "include_download_screen": True,
+    "copy_baseline_questions": True,
+    "use_llm_assist": False,
+    "normalize_field_names": False,
+    "interview_overrides": {"enable_navigation": True, "next_steps_enabled": True},
+}
+
+# PDF label -> the AssemblyLine variable it has to become.
+EXPECTED_MAPPINGS = {
+    "user_name_first": "users[0].name.first",
+    # `_name_full` maps to the object itself, which renders as the full name.
+    "user25_name_full": "users[24]",
+    "other_party37_address_zip": "other_parties[36].address.zip",
+    "plaintiff1_address_street": "plaintiffs[0].address.address",
+    "plaintiff1_address_city": "plaintiffs[0].address.city",
+    "plaintiff1_address_state": "plaintiffs[0].address.state",
+    "plaintiff1_address_zip": "plaintiffs[0].address.zip",
+    "plaintiff1_phone": "plaintiffs[0].phone_number",
+    "plaintiff2_email": "plaintiffs[1].email",
+    "plaintiff2_signature": "plaintiffs[1].signature",
+    "court1_address_county": "courts[0].address.county",
+}
+
+
+class TestEditorUploadFieldNaming(unittest.TestCase):
+    @staticmethod
+    def _offline_cluster_screens(fields, tools_token=None):
+        """Deterministic fallback grouping for test runs without OpenAI credentials."""
+        del tools_token
+        unique_fields = list(dict.fromkeys(fields or []))
+        grouped = {}
+        for index in range(0, len(unique_fields), 4):
+            grouped[f"Screen {index // 4 + 1}"] = unique_fields[index : index + 4]
+        return grouped
+
+    def setUp(self):
+        self._cluster_patch = None
+        if not os.environ.get("OPENAI_API_KEY"):
+            self._cluster_patch = patch.object(
+                interview_generator_module.formfyxer,
+                "cluster_screens",
+                side_effect=self._offline_cluster_screens,
+            )
+            self._cluster_patch.start()
+
+    def tearDown(self):
+        if self._cluster_patch is not None:
+            self._cluster_patch.stop()
+
+    def _generate(self, **overrides):
+        options = dict(EDITOR_UPLOAD_OPTIONS)
+        options.update(overrides)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = generate_interview_from_path(
+                str(PDF_PATH),
+                output_dir=tmpdir,
+                exact_name=PDF_PATH.name,
+                **options,
+            )
+            self.assertTrue(result.yaml_path)
+            return Path(result.yaml_path).read_text(encoding="utf-8")
+
+    def test_al_labels_become_al_variables(self):
+        yaml_text = self._generate()
+        missing = [
+            f"{raw} -> {mapped}"
+            for raw, mapped in EXPECTED_MAPPINGS.items()
+            if mapped not in yaml_text
+        ]
+        self.assertFalse(
+            missing,
+            "The editor's upload options did not map these AssemblyLine PDF labels:\n"
+            + "\n".join(missing),
+        )
+
+    def test_raw_al_labels_are_not_left_as_variables(self):
+        yaml_text = self._generate()
+        leaked = [
+            raw
+            for raw in EXPECTED_MAPPINGS
+            if f"field: {raw}" in yaml_text or f"\n  - {raw}:" in yaml_text
+        ]
+        self.assertFalse(
+            leaked,
+            "These raw PDF labels were used as interview variables: "
+            + ", ".join(leaked),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/editor_assemblyline_settings.md
+++ b/docs/editor_assemblyline_settings.md
@@ -14,10 +14,66 @@ The settings endpoint uses an expected source revision and validates the whole
 candidate interview before writing. It replaces only the metadata document and
 the Weaver-owned block; author-owned code blocks are not rewritten.
 
-The settings panel is searchable by section, friendly label, or exact metadata
-key/magic-variable name. Each control displays that exact name. Controls use a
-single-column layout by default; only related pairs, such as title/short title,
-country/state, repository owner/name, and the two timing values, share a row.
+The settings panel is searchable by section, friendly label, help text, or exact
+metadata key/magic-variable name. Each control displays that exact name. Controls
+use a single-column layout by default; only related pairs, such as title/short
+title, country/state, repository owner/name, and the two timing values, share a
+row.
+
+Every control also carries help text. The question-driven Weaver explained each
+value on the screen that asked for it; the graphical panel shows all of them at
+once, so the explanation -- where the value appears and what else it changes --
+travels with the control in `FIELD_HELP`.
+
+Each section also names the YAML documents its values are written to --
+`metadata` for publishing values, the Weaver-owned
+`alweaver assemblyline settings` block for predefined variables. That list is
+derived from the fields' own `scope`, not written out by hand, so it cannot drift
+when a field moves between the two. When `read_settings()` finds one of those variables already assigned in an
+author-owned code block, that block keeps ownership of the name: the control says
+so, `rewrite_external_code_assignments()` edits the assignment where it already
+lives, and the key is left out of the managed block, which carries a comment
+saying where it went. Writing Weaver's copy as well would leave two blocks
+assigning one name with the winner decided by document order.
+
+Only a value the author actually changed on the panel is written, so unchanged
+author code keeps its own quoting and spacing byte for byte. Every rewrite is
+re-read before it is kept, and a block whose `code:` is not a literal block
+scalar is skipped rather than guessed at.
+
+A setting the interview *computes* is a separate case, and the panel does not
+own it at all. `_code_assignments()` reports whether each assignment is a literal
+or an expression, and `read_settings()` returns the expressions as `computed`,
+mapped to the block holding them. Those controls render read-only: whatever the
+field's normal control would be, the expression is shown as disabled monospace
+text, because a checkbox or a dropdown would have to choose some position and
+would misreport what the interview does. The note under the control says the
+value is worked out while the interview runs, names the block, and tells the
+author to open that block in the outline or in YAML source and edit it there.
+
+`update_settings()` ignores anything submitted for a computed key rather than
+validating it, and the managed block records `# <name> is computed by your own
+code, and is left alone.` in place of an assignment. That is also what makes the
+panel usable at all on such an interview: `_coerce_value()` judges a value
+against the field's kind, so an expression sitting in a choice- or boolean-typed
+setting used to fail validation and block every save with "Form type has an
+unsupported value".
+
+A "What is this?" popover on the panel heading carries `PANEL_EXPLAINER`, which
+states the distinction the page rests on: publishing metadata describes the form
+to listing sites, while predefined variables have a special meaning to
+AssemblyLine and change how the interview behaves. Both are ordinary YAML the
+author can open and edit directly, which is the reason each section names its
+block and each control shows its exact name.
+
+Some AssemblyLine settings also exist server-wide, and writing one here overrides
+the whole server for this interview only. `SERVER_DEFAULTS` records which
+Docassemble configuration key supplies each of those (`AL_ORGANIZATION_TITLE` from
+`appname`, `AL_ORGANIZATION_HOMEPAGE` from `app homepage`), and
+`ASSEMBLY_LINE_FALLBACKS` records what `al_settings.yml` falls back to when the
+server says nothing. The GET endpoint resolves both and returns them as
+`server_defaults`, so each such control can name the value it is standing in front
+of and flag when the interview is actually overriding it.
 
 ## Question-driven workflow comparison
 


### PR DESCRIPTION
## Summary

This PR improves the graphical Weaver editor in four main areas: AssemblyLine settings management, LIST taxonomy topic selection, new project publishing metadata collection, and editor block/outline enhancements.

### 1. AssemblyLine Settings & Source Preservation
- **Computed Settings Handling**: Detects whether a setting is assigned as a literal value or a runtime expression. Computed settings are displayed read-only in the UI and skipped on save to prevent overwriting dynamic Python expressions.
- **In-Place Author Code Updates**: When a setting is defined in an author-owned code block, `rewrite_external_code_assignments()` updates the value in place within that block rather than duplicating the assignment into the Weaver managed block.
- **Document Ownership & Comments**: The managed settings block (`alweaver assemblyline settings`) clearly comments any variables assigned in author blocks or computed at runtime.
- **Server Defaults & Fallbacks**: Resolves server-wide Docassemble configuration defaults (`_resolve_server_defaults()`) and AssemblyLine fallback values, highlighting when an interview overrides the server default.
- **PyYAML Block Formatting**: Fixes PyYAML block sequence layout preservation in `_update_metadata()` so multi-line and block sequences do not corrupt or swallow subsequent YAML keys.

### 2. LIST Taxonomy Topic Picker
- Added `GET /al/editor/api/list-topics` to expose hierarchical legal LIST taxonomy (NSMIv2) topic codes.
- Added a searchable, accessible topic tree picker modal (`<details>`/`<summary>` and checkboxes) in the editor UI for selecting topic codes without typing codes manually.

### 3. Project Creation & Upload Workflow
- Added accordion sections to the New Project modal to capture publishing metadata (interview title, short title, description, jurisdiction, landing page URL, and LIST topics) at creation time.
- Supported custom interview filenames and normalized default naming (using descriptive document-based filenames or `main.yml` instead of a hardcoded `interview.yml`).
- Propagated overrides through background upload jobs and Celery worker tasks.

### 4. Editor Block Types & Outline Improvements
- Added support for `comment` block type detection, styling badge, and insertion menu option ("New comment block").
- Improved question block title extraction to strip leading Mako logic directives (e.g. `% if ...`) and display the first line of human-readable prose.

### 5. Tests & Documentation
- Added new test file `test_editor_upload_field_naming.py` and expanded test suites for settings, API, and frontend.
- Updated documentation in `docs/editor_assemblyline_settings.md`, `architecture.md`, and `docassemble/AGENTS.md`.