### PR TITLE
Mark generated block IDs as dirty

### DIFF
--- a/docassemble/ALWeaver/data/static/editor.js
+++ b/docassemble/ALWeaver/data/static/editor.js
@@ -9511,7 +9511,7 @@
       var allBlocks = state.blocks || [];
       var newId = generateBlockId(questionText, allBlocks, currentBlock ? currentBlock.id : null);
       idEl.value = newId;
-      idEl.dispatchEvent(new Event('input'));
+      idEl.dispatchEvent(new Event('input', { bubbles: true }));
       return;
     }
     if (target.id === 'add-question-event') {

--- a/docassemble/ALWeaver/test_editor_frontend.py
+++ b/docassemble/ALWeaver/test_editor_frontend.py
@@ -155,6 +155,13 @@ class TestEditorFrontend(unittest.TestCase):
             editor,
         )
 
+    def test_generated_block_id_marks_the_interview_dirty(self):
+        editor = (self.package_dir / "data/static/editor.js").read_text()
+
+        self.assertIn(
+            "idEl.dispatchEvent(new Event('input', { bubbles: true }))", editor
+        )
+
     def test_project_pull_actions_are_scoped_to_synced_projects(self):
         editor = (self.package_dir / "data/static/editor.js").read_text()
 


### PR DESCRIPTION
## What changed

- Bubble the generated block ID's synthetic `input` event to the editor's dirty-state listener.
- Add a focused frontend regression assertion for the event wiring.

## Why

Using the auto-generate control could change only a block ID without marking the interview dirty, leaving Save disabled until the user changed another field. The field-level handler received the non-bubbling event, but the document-level dirty-state handler did not.

## Impact

Generating a block ID now immediately enables the normal save flow.

## Validation

- `node --check docassemble/ALWeaver/data/static/editor.js`
- `.venv/bin/black --check docassemble/ALWeaver/test_editor_frontend.py`
- `.venv/bin/mypy docassemble/ALWeaver/test_editor_frontend.py`
- `.venv/bin/python -m pytest docassemble/ALWeaver/test_editor_frontend.py -q` (from `/tmp`; 32 passed, 28 subtests passed)
