### PR TITLE
Prevent field dropdown labels from covering variable names and simplify badges

### DIFF
--- a/docassemble/ALWeaver/data/static/editor.css
+++ b/docassemble/ALWeaver/data/static/editor.css
@@ -951,7 +951,8 @@ html, body {
 }
 
 .editor-field-type-dropdown {
-  min-width: 190px;
+  width: 100%;
+  min-width: 0;
 }
 
 .editor-field-type-btn {
@@ -960,6 +961,7 @@ html, body {
   gap: 6px;
   justify-content: space-between;
   width: 100%;
+  min-width: 0;
   padding: 6px 10px;
   font-size: 12px;
   text-transform: capitalize;
@@ -967,6 +969,10 @@ html, body {
 
 .editor-field-type-btn span {
   flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   text-align: left;
 }
 

--- a/docassemble/ALWeaver/data/static/editor.js
+++ b/docassemble/ALWeaver/data/static/editor.js
@@ -6644,10 +6644,10 @@
             html += '<input class="form-check-input editor-field-required-switch" type="checkbox" role="switch" id="field-required-' + fi + '" data-field-idx="' + fi + '"' + (isRequired ? ' checked' : '') + '>';
             html += '<label class="form-check-label editor-tiny" for="field-required-' + fi + '">Required</label>';
             html += '</div>';
-            var activeIndicators = _fieldActiveIndicators(dtype, fmods, choices, codeExpr);
+            var activeIndicators = _fieldActiveIndicators(fmods);
             if (activeIndicators.length > 0) {
               html += '<div class="editor-field-indicators" aria-label="Active options">';
-              activeIndicators.slice(0, 3).forEach(function (tag) { html += '<span class="badge text-bg-light">' + esc(tag) + '</span>'; });
+              activeIndicators.forEach(function (tag) { html += '<span class="badge text-bg-light">' + esc(tag) + '</span>'; });
               html += '</div>';
             }
           }
@@ -7193,13 +7193,13 @@
     return map[key] || 'fa-input-text';
   }
 
-  function _fieldActiveIndicators(dtype, fmods, choices, codeExpr) {
+  function _fieldActiveIndicators(fmods) {
     var indicators = [];
-    if (CHOICE_TYPES.indexOf(dtype) !== -1 && choices) indicators.push('choices');
-    if (codeExpr) indicators.push('code');
-    if (fmods['show if'] || fmods['hide if'] || fmods['enable if'] || fmods['disable if']) indicators.push('logic');
-    if (fmods.default || fmods.help || fmods.hint) indicators.push('display');
-    if (fmods.validate || fmods['validation code']) indicators.push('validation');
+    // Only flag consequential settings that are otherwise hidden in the
+    // settings panel. Choices and code are visible in the field editor, while
+    // a generic "display" badge does not tell an author what needs attention.
+    if (fmods['show if'] || fmods['hide if'] || fmods['enable if'] || fmods['disable if']) indicators.push('Conditional');
+    if (fmods.validate || fmods['validation code']) indicators.push('Validation');
     return indicators;
   }
 

--- a/docassemble/ALWeaver/test_editor_frontend.py
+++ b/docassemble/ALWeaver/test_editor_frontend.py
@@ -282,6 +282,19 @@ class TestEditorFrontend(unittest.TestCase):
         self.assertNotIn("markdownPreviewMode", editor)
         self.assertNotIn("md-preview-wrapper", css)
 
+    def test_question_field_controls_shrink_without_unhelpful_badges(self):
+        editor = (self.package_dir / "data/static/editor.js").read_text()
+        css = (self.package_dir / "data/static/editor.css").read_text()
+
+        self.assertIn("indicators.push('Conditional')", editor)
+        self.assertIn("indicators.push('Validation')", editor)
+        self.assertNotIn("indicators.push('choices')", editor)
+        self.assertNotIn("indicators.push('display')", editor)
+        self.assertIn(
+            ".editor-field-type-dropdown {\n  width: 100%;\n  min-width: 0;", css
+        )
+        self.assertIn("text-overflow: ellipsis;", css)
+
     def test_the_assistant_is_absent_until_its_feature_flag_is_on(self):
         """The assistant drawer ships in the template but must not be reachable
         on an installation that has not opted in. The toggle is hidden and the


### PR DESCRIPTION
## Summary

Fixes an issue where field datatype dropdown labels could overflow or push layout, covering variable names and crowding neighboring controls. Also cleans up redundant field indicator badges so only hidden/consequential settings are flagged.

## Changes

- **Dropdown Layout & Truncation ([editor.css](file:///home/quinten/docassemble-ALWeaver/docassemble/ALWeaver/data/static/editor.css))**:
  - Removed rigid `min-width: 190px` on `.editor-field-type-dropdown` in favor of responsive `width: 100%; min-width: 0;`.
  - Added text truncation (`text-overflow: ellipsis`, `overflow: hidden`, `white-space: nowrap`, `min-width: 0`) on `.editor-field-type-btn span` to prevent long type labels from overflowing.
- **Prune Redundant Field Badges ([editor.js](file:///home/quinten/docassemble-ALWeaver/docassemble/ALWeaver/data/static/editor.js))**:
  - Simplified `_fieldActiveIndicators()` to only surface settings hidden behind the modal/settings drawer (`Conditional` for show/hide/enable/disable logic, and `Validation` for validate/validation code).
  - Dropped redundant badges like `choices` and `code` (which are already visible in the field editor row) and generic `display` badges.
  - Capitalized badge tags for consistency.
- **Tests ([test_editor_frontend.py](file:///home/quinten/docassemble-ALWeaver/docassemble/ALWeaver/test_editor_frontend.py))**:
  - Added `test_question_field_controls_shrink_without_unhelpful_badges` to verify indicator logic and CSS rules.

## Validation

- `python3 -m unittest docassemble.ALWeaver.test_editor_frontend` passed (32/32 tests).
- `node --check docassemble/ALWeaver/data/static/editor.js` syntax check passed.
- Manually confirmed correct wrapping at different screen widths