### PR TITLE
Cleaner 'add block' layout, correctness fixes for comment-only and raw YAML block types

### DIFF
--- a/docassemble/ALWeaver/api_editor.py
+++ b/docassemble/ALWeaver/api_editor.py
@@ -139,6 +139,8 @@ try:
         delete_saved_file,
         generate_draft_order,
         insert_block_in_yaml,
+        inserted_block_id_by_position,
+        is_comment_only_yaml,
         parse_interview_yaml,
         metadata_source_slice,
         parse_order_code,
@@ -1185,12 +1187,23 @@ def _ensure_dayamlchecker_valid(yaml_text: str) -> None:
 def _validate_block_yaml_payload(block_yaml: str) -> None:
     """Validate a single block payload before saving/inserting.
 
-    Reject placeholder-only blocks that contain no functional keys.
+    Two shapes look like placeholders but are legitimate documents, and both
+    are what the "Add a block" modal hands over:
+
+    * a document of nothing but YAML comments — a blank new block, before its
+      author has typed anything over it;
+    * a standalone ``comment:`` block — prose about the interview.
+
+    What is rejected is an ``id`` with nothing beside it that gives the block a
+    type. The id names a block, there is no block there for it to name, and
+    docassemble reports "couldn't identify a block type" on the whole file.
     """
     try:
         parsed = yaml.safe_load(block_yaml)
     except yaml.YAMLError as exc:
         raise ValueError(f"Invalid YAML: {exc}") from exc
+    if parsed is None and is_comment_only_yaml(block_yaml):
+        return
     if not isinstance(parsed, dict):
         raise ValueError("block_yaml must contain exactly one YAML mapping block")
 
@@ -1199,9 +1212,10 @@ def _validate_block_yaml_payload(block_yaml: str) -> None:
     }
     if not normalized_keys:
         raise ValueError("Block must contain at least one key")
-    if normalized_keys.issubset({"id", "comment"}):
+    if "id" in normalized_keys and normalized_keys.issubset({"id", "comment"}):
         raise ValueError(
-            "Block is incomplete: add at least one functional key besides id/comment"
+            "Block is incomplete: an id needs a block beside it to name, "
+            "so add a key like question, code, or objects — or drop the id"
         )
 
 
@@ -6304,9 +6318,11 @@ def editor_api_insert_block() -> Response:
         id_match = re.search(r"(?m)^id:\s*['\"]?([^'\"\n]+)['\"]?\s*$", block_text)
         if id_match:
             inserted_block_id = id_match.group(1).strip()
-        elif updated_model["blocks"]:
-            inserted_block_id = (
-                str(updated_model["blocks"][-1].get("id") or "").strip() or None
+        else:
+            # A block with no id of its own — a comment, or a blank new block —
+            # is identified by where it landed, not by being last in the file.
+            inserted_block_id = inserted_block_id_by_position(
+                updated_model["blocks"], insert_after_id
             )
 
         return jsonify(

--- a/docassemble/ALWeaver/data/static/editor.css
+++ b/docassemble/ALWeaver/data/static/editor.css
@@ -3612,3 +3612,174 @@ html, body {
 .editor-al-setting-computed {
   color: var(--editor-muted);
 }
+
+/* ===== Add-a-block modal =====
+   A grouped card list rather than a stack of buttons: each row carries an
+   icon tile, a name, one line of plain-language explanation, and a round
+   plus affordance on the right. The whole card is the button. */
+
+.editor-insert-dialog {
+  max-width: 520px;
+}
+
+.editor-insert-content {
+  border: 0;
+  border-radius: 14px;
+  overflow: hidden;
+}
+
+.editor-insert-header {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--editor-border);
+  background: #fff;
+}
+
+.editor-insert-title {
+  grid-column: 2;
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.editor-insert-cancel {
+  justify-self: start;
+  padding: 2px 4px;
+  border: 0;
+  font-size: 14px;
+  text-decoration: none;
+  color: var(--editor-primary);
+}
+
+.editor-insert-cancel:hover,
+.editor-insert-cancel:focus-visible {
+  text-decoration: underline;
+}
+
+/* Balances the Cancel button so the title stays optically centered. */
+.editor-insert-header-spacer {
+  grid-column: 3;
+}
+
+.editor-insert-body {
+  padding: 12px;
+  background: var(--editor-bg);
+}
+
+.editor-insert-group-label {
+  margin: 4px 4px 6px;
+  color: var(--editor-muted);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.editor-insert-group-label + .editor-insert-list {
+  margin-bottom: 16px;
+}
+
+.editor-insert-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.editor-insert-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: var(--editor-card-shadow);
+  text-align: left;
+  color: var(--editor-fg);
+  transition: border-color 0.12s ease, box-shadow 0.12s ease, transform 0.12s ease;
+}
+
+.editor-insert-card:hover {
+  border-color: var(--editor-primary);
+  box-shadow: 0 2px 8px rgba(13, 57, 112, 0.14);
+}
+
+.editor-insert-card:focus-visible {
+  outline: 2px solid var(--editor-primary);
+  outline-offset: 2px;
+}
+
+.editor-insert-card:active {
+  transform: scale(0.995);
+}
+
+.editor-insert-icon {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  background: var(--editor-primary-bg);
+  color: var(--editor-primary);
+  font-size: 16px;
+}
+
+.editor-insert-text {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.editor-insert-name {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.editor-insert-desc {
+  color: var(--editor-muted);
+  font-size: 12px;
+}
+
+.editor-insert-plus {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--editor-primary-bg);
+  color: var(--editor-primary);
+  font-size: 12px;
+  transition: background-color 0.12s ease, color 0.12s ease;
+}
+
+.editor-insert-card:hover .editor-insert-plus {
+  background: var(--editor-primary);
+  color: #fff;
+}
+
+.editor-insert-footnote {
+  margin-top: 4px;
+  padding: 4px;
+  font-size: 12px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .editor-insert-card {
+    transition: none;
+  }
+  .editor-insert-card:active {
+    transform: none;
+  }
+}

--- a/docassemble/ALWeaver/data/static/editor.js
+++ b/docassemble/ALWeaver/data/static/editor.js
@@ -503,70 +503,10 @@
     if (instance) instance.hide();
   }
 
+  /* The block templates live in editor_serializers.js so a test can require
+     them and run every one of them past DAYamlChecker. */
   function makeNewBlockYaml(kind) {
-    var stamp = Date.now();
-    if (kind === 'question') {
-      return (
-        'id: question_' + stamp + '\n' +
-        'question: New question\n' +
-        'subquestion: |\n' +
-        '  \n' +
-        'fields:\n' +
-        '  - New field: new_field_' + stamp + '\n'
-      );
-    }
-    if (kind === 'code') {
-      return (
-        'id: code_' + stamp + '\n' +
-        'code: |\n' +
-        '  # Write Python here\n' +
-        '  pass\n'
-      );
-    }
-    if (kind === 'objects') {
-      return (
-        'id: objects_' + stamp + '\n' +
-        'objects:\n' +
-        '  - user: Individual\n'
-      );
-    }
-    if (kind === 'comment') {
-      // No id: a comment block is prose about the interview, and docassemble
-      // has nothing to reach it by.
-      return (
-        'comment: |\n' +
-        '  Explain what the blocks below do, and why.\n'
-      );
-    }
-    if (kind === 'attachment') {
-      return (
-        'id: attachment_' + stamp + '\n' +
-        'question: Download your document\n' +
-        'subquestion: |\n' +
-        '  Your document is ready.\n' +
-        'attachments:\n' +
-        '  - name: Draft document\n' +
-        '    filename: draft_document\n' +
-        '    docx template file: draft_template.docx\n'
-      );
-    }
-    if (kind === 'review') {
-      return (
-        'id: review_screen_' + stamp + '\n' +
-        'event: review_form\n' +
-        'question: Review your answers\n' +
-        'review:\n' +
-        '  - Edit: new_field_' + stamp + '\n' +
-        '    button: |\n' +
-        '      New answer: ${ showifdef("new_field_' + stamp + '") }\n'
-      );
-    }
-    return (
-      'id: block_' + stamp + '\n' +
-      'code: |\n' +
-      '  # New block\n' +
-      '  pass\n'
-    );
+    return window.ALWeaverSerializers.makeNewBlockYaml(kind, Date.now());
   }
 
   // -------------------------------------------------------------------------

--- a/docassemble/ALWeaver/data/static/editor_serializers.js
+++ b/docassemble/ALWeaver/data/static/editor_serializers.js
@@ -410,9 +410,86 @@
     return true;
   }
 
+  /* -------------------------------------------------------------------------
+     Templates for the blocks the "Add a block" modal authors.
+
+     Every one of these has to survive DAYamlChecker on insertion, which rules
+     out shapes that look reasonable but are not valid docassemble: an `id` is
+     only meaningful alongside a key that gives the block a type, so the
+     comment block carries none.
+     ------------------------------------------------------------------------- */
+  function makeNewBlockYaml(kind, stamp) {
+    stamp = stamp || Date.now();
+    if (kind === 'question' || kind === 'ai-screen') {
+      return (
+        'id: question_' + stamp + '\n' +
+        'question: New question\n' +
+        'subquestion: |\n' +
+        '  \n' +
+        'fields:\n' +
+        '  - New field: new_field_' + stamp + '\n'
+      );
+    }
+    if (kind === 'code') {
+      return (
+        'id: code_' + stamp + '\n' +
+        'code: |\n' +
+        '  # Write Python here\n' +
+        '  pass\n'
+      );
+    }
+    if (kind === 'objects') {
+      return (
+        'id: objects_' + stamp + '\n' +
+        'objects:\n' +
+        '  - user: Individual\n'
+      );
+    }
+    if (kind === 'comment') {
+      // No id: a comment block is prose about the interview, docassemble has
+      // nothing to reach it by, and an id with no type key beside it is an
+      // error ("couldn't identify a block type").
+      return (
+        'comment: |\n' +
+        '  Explain what the blocks below do, and why.\n'
+      );
+    }
+    if (kind === 'attachment') {
+      return (
+        'id: attachment_' + stamp + '\n' +
+        'question: Download your document\n' +
+        'subquestion: |\n' +
+        '  Your document is ready.\n' +
+        'attachments:\n' +
+        '  - name: Draft document\n' +
+        '    filename: draft_document\n' +
+        '    docx template file: draft_template.docx\n'
+      );
+    }
+    if (kind === 'review') {
+      return (
+        'id: review_screen_' + stamp + '\n' +
+        'event: review_form\n' +
+        'question: Review your answers\n' +
+        'review:\n' +
+        '  - Edit: new_field_' + stamp + '\n' +
+        '    button: |\n' +
+        '      New answer: ${ showifdef("new_field_' + stamp + '") }\n'
+      );
+    }
+    // The raw block is the "none of the above" choice, so it must not arrive
+    // as a code block: a `code:` key types it as one, and saving would then
+    // re-serialize whatever was typed under a `code: |` leader, indented.
+    // A YAML comment leaves the block genuinely empty — docassemble reads
+    // nothing here, and the checker has no keys to object to — so the author
+    // starts at column one with no structure to delete first.
+    return '# replace with any docassemble YAML\n';
+  }
+
   return {
     escapeYamlStr: escapeYamlStr,
     serializeQuestionToYaml: serializeQuestionToYaml,
+    makeNewBlockYaml: makeNewBlockYaml,
     splitUsingArgs: splitUsingArgs,
     readPeopleListQuantity: readPeopleListQuantity,
     composePeopleListUsingArgs: composePeopleListUsingArgs,

--- a/docassemble/ALWeaver/data/templates/editor.html
+++ b/docassemble/ALWeaver/data/templates/editor.html
@@ -413,27 +413,91 @@
 </div>
 
 <!-- Insert Block Modal -->
-<div class="modal fade" id="insert-modal" tabindex="-1">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title">Insert block</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+<div class="modal fade" id="insert-modal" tabindex="-1" aria-labelledby="insert-modal-title">
+  <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable editor-insert-dialog">
+    <div class="modal-content editor-insert-content">
+      <div class="modal-header editor-insert-header">
+        <button type="button" class="btn btn-link editor-insert-cancel" data-bs-dismiss="modal">Cancel</button>
+        <h5 class="modal-title editor-insert-title" id="insert-modal-title">Add a block</h5>
+        <span class="editor-insert-header-spacer" aria-hidden="true"></span>
       </div>
-      <div class="modal-body">
-        <div class="d-grid gap-2">
-          <button type="button" class="btn btn-primary text-start" data-insert="question">New question screen</button>          <button type="button" class="btn btn-outline-secondary text-start" data-insert="ai-screen"><i class="fa-solid fa-wand-magic-sparkles me-1" aria-hidden="true"></i>AI draft screen</button>          <button type="button" class="btn btn-outline-secondary text-start" data-insert="review">New review screen</button>          <button type="button" class="btn btn-outline-secondary text-start" data-insert="code">New code block</button>
-          <button type="button" class="btn btn-outline-secondary text-start" data-insert="objects">New objects block</button>
-          <button type="button" class="btn btn-outline-secondary text-start" data-insert="attachment">New attachment block</button>
-          <button type="button" class="btn btn-outline-secondary text-start" data-insert="comment">New comment block</button>
-          <button type="button" class="btn btn-outline-secondary text-start" data-insert="other">New YAML block</button>
+      <div class="modal-body editor-insert-body">
+        <div class="editor-insert-group-label">Screens</div>
+        <div class="editor-insert-list">
+          <button type="button" class="editor-insert-card" data-insert="question">
+            <span class="editor-insert-icon"><i class="fa-solid fa-rectangle-list" aria-hidden="true"></i></span>
+            <span class="editor-insert-text">
+              <span class="editor-insert-name">Question screen</span>
+              <span class="editor-insert-desc">Ask the user one or more fields.</span>
+            </span>
+            <span class="editor-insert-plus" aria-hidden="true"><i class="fa-solid fa-plus"></i></span>
+          </button>
+          <button type="button" class="editor-insert-card" data-insert="ai-screen">
+            <span class="editor-insert-icon"><i class="fa-solid fa-wand-magic-sparkles" aria-hidden="true"></i></span>
+            <span class="editor-insert-text">
+              <span class="editor-insert-name">AI draft screen</span>
+              <span class="editor-insert-desc">Draft a question screen from a short prompt.</span>
+            </span>
+            <span class="editor-insert-plus" aria-hidden="true"><i class="fa-solid fa-plus"></i></span>
+          </button>
+          <button type="button" class="editor-insert-card" data-insert="review">
+            <span class="editor-insert-icon"><i class="fa-solid fa-list-check" aria-hidden="true"></i></span>
+            <span class="editor-insert-text">
+              <span class="editor-insert-name">Review screen</span>
+              <span class="editor-insert-desc">Let the user check and edit their answers.</span>
+            </span>
+            <span class="editor-insert-plus" aria-hidden="true"><i class="fa-solid fa-plus"></i></span>
+          </button>
         </div>
-        <div class="mt-3">
+        <div class="editor-insert-group-label">Logic and data</div>
+        <div class="editor-insert-list">
+          <button type="button" class="editor-insert-card" data-insert="code">
+            <span class="editor-insert-icon"><i class="fa-solid fa-code" aria-hidden="true"></i></span>
+            <span class="editor-insert-text">
+              <span class="editor-insert-name">Code block</span>
+              <span class="editor-insert-desc">Python that sets variables or controls the flow.</span>
+            </span>
+            <span class="editor-insert-plus" aria-hidden="true"><i class="fa-solid fa-plus"></i></span>
+          </button>
+          <button type="button" class="editor-insert-card" data-insert="objects">
+            <span class="editor-insert-icon"><i class="fa-solid fa-cubes" aria-hidden="true"></i></span>
+            <span class="editor-insert-text">
+              <span class="editor-insert-name">Objects block</span>
+              <span class="editor-insert-desc">Declare people, lists, and other objects.</span>
+            </span>
+            <span class="editor-insert-plus" aria-hidden="true"><i class="fa-solid fa-plus"></i></span>
+          </button>
+          <button type="button" class="editor-insert-card" data-insert="attachment">
+            <span class="editor-insert-icon"><i class="fa-solid fa-file-lines" aria-hidden="true"></i></span>
+            <span class="editor-insert-text">
+              <span class="editor-insert-name">Attachment block</span>
+              <span class="editor-insert-desc">Assemble a PDF or Word document.</span>
+            </span>
+            <span class="editor-insert-plus" aria-hidden="true"><i class="fa-solid fa-plus"></i></span>
+          </button>
+        </div>
+        <div class="editor-insert-group-label">Other</div>
+        <div class="editor-insert-list">
+          <button type="button" class="editor-insert-card" data-insert="comment">
+            <span class="editor-insert-icon"><i class="fa-solid fa-comment-dots" aria-hidden="true"></i></span>
+            <span class="editor-insert-text">
+              <span class="editor-insert-name">Comment block</span>
+              <span class="editor-insert-desc">A note to yourself that the interview ignores.</span>
+            </span>
+            <span class="editor-insert-plus" aria-hidden="true"><i class="fa-solid fa-plus"></i></span>
+          </button>
+          <button type="button" class="editor-insert-card" data-insert="other">
+            <span class="editor-insert-icon"><i class="fa-solid fa-file-code" aria-hidden="true"></i></span>
+            <span class="editor-insert-text">
+              <span class="editor-insert-name">Raw YAML block</span>
+              <span class="editor-insert-desc">Start from a blank line and write any block by hand.</span>
+            </span>
+            <span class="editor-insert-plus" aria-hidden="true"><i class="fa-solid fa-plus"></i></span>
+          </button>
+        </div>
+        <div class="editor-insert-footnote">
           <a href="https://docassemble.org/docs/initial.html" target="_blank" rel="noopener">Block type docs</a>
         </div>
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-sm btn-secondary" data-bs-dismiss="modal">Cancel</button>
       </div>
     </div>
   </div>

--- a/docassemble/ALWeaver/editor_utils.py
+++ b/docassemble/ALWeaver/editor_utils.py
@@ -19,6 +19,7 @@ from .docassemble_compat import create_playground, create_saved_file
 
 __all__ = [
     "parse_interview_yaml",
+    "is_comment_only_yaml",
     "source_revision",
     "metadata_source_slice",
     "update_metadata_documents_in_yaml",
@@ -28,6 +29,7 @@ __all__ = [
     "generate_draft_order",
     "canonicalize_block_yaml",
     "insert_block_in_yaml",
+    "inserted_block_id_by_position",
     "update_block_in_yaml",
     "delete_block_from_yaml",
     "comment_out_block_in_yaml",
@@ -479,6 +481,19 @@ def _stable_block_id(index: int, block: Dict[str, Any]) -> str:
     return f"block-{index}-{digest}"
 
 
+def is_comment_only_yaml(text: str) -> bool:
+    """True when a YAML document holds nothing but comments and blank lines.
+
+    Such a document is not a block — docassemble reads no keys out of it — but
+    it is what a blank new block starts as, before its author types a block
+    over it.
+    """
+    lines = [line for line in text.splitlines() if line.strip()]
+    if not lines:
+        return False
+    return all(line.lstrip().startswith("#") for line in lines)
+
+
 def _uncomment_yaml_block(block_yaml: str) -> str:
     uncommented_lines = []
     for line in block_yaml.splitlines(keepends=True):
@@ -698,12 +713,6 @@ def parse_interview_yaml(raw_yaml: str) -> Dict[str, Any]:
         raw_yaml: the original YAML text
     """
 
-    def _is_comment_only_segment(segment: str) -> bool:
-        lines = [line for line in segment.splitlines() if line.strip()]
-        if not lines:
-            return False
-        return all(line.lstrip().startswith("#") for line in lines)
-
     segments: List[Dict[str, Any]] = []
     body_start = 0
     for separator in _YAML_DOCUMENT_SEPARATOR_RE.finditer(raw_yaml):
@@ -741,24 +750,38 @@ def parse_interview_yaml(raw_yaml: str) -> Dict[str, Any]:
         if not segment_text:
             continue
 
-        if _is_comment_only_segment(segment_text_raw):
+        if is_comment_only_yaml(segment_text_raw):
             uncommented = _uncomment_yaml_block(segment_text)
             try:
                 parsed_commented = yaml.safe_load(uncommented)
             except yaml.YAMLError:
                 parsed_commented = None
-            underlying_type = BLOCK_TYPE_OTHER
-            if isinstance(parsed_commented, dict):
-                doc = dict(parsed_commented)
-                underlying_type = _detect_block_type(doc)
-            elif parsed_commented is None:
-                doc = {"_raw": uncommented}
-            else:
-                doc = {"_raw": str(parsed_commented)}
-            if isinstance(doc, dict):
-                doc["_commented"] = True
-                doc["_commented_type"] = underlying_type
-                doc["_commented_yaml"] = segment_text
+            if not isinstance(parsed_commented, dict):
+                # Prose, not a disabled block: there is no block underneath to
+                # re-enable, and uncommenting it would only produce invalid
+                # YAML. Treated as an editable note so an author can type a
+                # real block over it.
+                note_doc: Dict[str, Any] = {"_raw": segment_text}
+                blocks.append(
+                    {
+                        "id": _stable_block_id(i, note_doc),
+                        "index": i,
+                        "line_start": line_start,
+                        "line_end": line_end,
+                        "type": BLOCK_TYPE_OTHER,
+                        "title": _first_line_title(uncommented) or "Note",
+                        "variable": None,
+                        "tags": [BLOCK_TYPE_OTHER, "note"],
+                        "yaml": segment_text,
+                        "data": note_doc,
+                    }
+                )
+                continue
+            doc = dict(parsed_commented)
+            underlying_type = _detect_block_type(doc)
+            doc["_commented"] = True
+            doc["_commented_type"] = underlying_type
+            doc["_commented_yaml"] = segment_text
             block_type = BLOCK_TYPE_COMMENTED
             block_id = _stable_block_id(i, doc)
             tags = [BLOCK_TYPE_COMMENTED]
@@ -1136,9 +1159,14 @@ def insert_block_in_yaml(
         inserted_value = yaml.safe_load(edited_body)
     except yaml.YAMLError as exc:
         raise ValueError(f"Invalid YAML: {exc}") from exc
-    if not isinstance(inserted_value, dict):
+    is_note = inserted_value is None and is_comment_only_yaml(edited_body)
+    if not isinstance(inserted_value, dict) and not is_note:
+        # A document of nothing but YAML comments is allowed: it is what a
+        # blank new block starts as, before its author types a block over it.
         raise ValueError("block_yaml must contain exactly one YAML mapping block")
-    inserted_id = str(inserted_value.get("id") or "").strip()
+    inserted_id = (
+        "" if is_note else str((inserted_value or {}).get("id") or "").strip()
+    )
     if inserted_id:
         existing_ids = {
             str(block.get("id") or "").strip()
@@ -1167,6 +1195,28 @@ def insert_block_in_yaml(
     prefix = full_yaml[:end]
     line_break = "" if prefix.endswith(("\n", "\r")) else newline
     return prefix + line_break + separator + document + full_yaml[end:]
+
+
+def inserted_block_id_by_position(
+    blocks: List[Dict[str, Any]], insert_after_id: Optional[str]
+) -> Optional[str]:
+    """Name the block an id-less insertion just created, by its position.
+
+    ``insert_block_in_yaml`` puts the new document either at the top of the
+    file or immediately after the block it was anchored to, so that is where
+    it is looked for. Falling back to "the last block in the file" would
+    select some unrelated block whenever the insertion was not at the end.
+    """
+    if not blocks:
+        return None
+    if not insert_after_id:
+        return str(blocks[0].get("id") or "").strip() or None
+    for position, block in enumerate(blocks):
+        if str(block.get("id") or "").strip() == insert_after_id:
+            if position + 1 < len(blocks):
+                return str(blocks[position + 1].get("id") or "").strip() or None
+            return None
+    return None
 
 
 def delete_block_from_yaml(full_yaml: str, block_id: str) -> str:

--- a/docassemble/ALWeaver/test_editor_api.py
+++ b/docassemble/ALWeaver/test_editor_api.py
@@ -71,6 +71,15 @@ def _load_api_editor_for_tests():
         "delete_saved_file": lambda *args, **kwargs: None,
         "generate_draft_order": lambda *args, **kwargs: {},
         "insert_block_in_yaml": lambda content, block_yaml, insert_after_id=None: content,
+        "inserted_block_id_by_position": lambda blocks, insert_after_id: None,
+        "is_comment_only_yaml": lambda text: bool(
+            [line for line in text.splitlines() if line.strip()]
+        )
+        and all(
+            line.lstrip().startswith("#")
+            for line in text.splitlines()
+            if line.strip()
+        ),
         "parse_interview_yaml": lambda *args, **kwargs: {
             "blocks": [],
             "metadata_blocks": [],
@@ -1509,6 +1518,35 @@ class TestEditorListTopics(unittest.TestCase):
 
         status = response[1] if isinstance(response, tuple) else response.status_code
         self.assertEqual(status, 401)
+
+
+class TestEditorBlockPayloadValidation(unittest.TestCase):
+    """What the "Add a block" modal hands the API has to be accepted."""
+
+    def accepts(self, block_yaml):
+        api_editor._validate_block_yaml_payload(block_yaml)
+
+    def test_a_standalone_comment_block_is_a_real_block(self):
+        # Prose about the interview. docassemble reads it, the checker passes
+        # it, and the modal offers it — so the API cannot refuse it.
+        self.accepts("comment: |\n  Explain what the blocks below do.\n")
+
+    def test_a_blank_new_block_of_only_yaml_comments_is_allowed(self):
+        # What "Raw YAML block" inserts, before anything is typed over it.
+        self.accepts("# replace with any docassemble YAML\n")
+        self.accepts("# one\n\n# two\n")
+
+    def test_an_id_with_nothing_to_name_is_refused(self):
+        for payload in ("id: c1\n", "id: c1\ncomment: |\n  Just prose.\n"):
+            with self.subTest(payload=payload):
+                with self.assertRaisesRegex(ValueError, "incomplete"):
+                    self.accepts(payload)
+
+    def test_a_document_that_is_not_a_block_is_still_refused(self):
+        for payload in ("- one\n- two\n", "just a string\n", "{}\n"):
+            with self.subTest(payload=payload):
+                with self.assertRaises(ValueError):
+                    self.accepts(payload)
 
 
 if __name__ == "__main__":

--- a/docassemble/ALWeaver/test_editor_frontend.py
+++ b/docassemble/ALWeaver/test_editor_frontend.py
@@ -551,10 +551,12 @@ class TestEditorFrontend(unittest.TestCase):
 
     def test_a_comment_block_can_be_inserted_like_any_other(self):
         template = (self.package_dir / "data/templates/editor.html").read_text()
-        editor = (self.package_dir / "data/static/editor.js").read_text()
+        serializers = (
+            self.package_dir / "data/static/editor_serializers.js"
+        ).read_text()
 
         self.assertIn('data-insert="comment"', template)
-        self.assertIn("if (kind === 'comment')", editor)
+        self.assertIn("if (kind === 'comment')", serializers)
 
     def test_the_outline_previews_a_block_on_hover(self):
         editor = (self.package_dir / "data/static/editor.js").read_text()

--- a/docassemble/ALWeaver/test_editor_source_preservation.py
+++ b/docassemble/ALWeaver/test_editor_source_preservation.py
@@ -1,9 +1,16 @@
 # do not pre-load
 """Regression tests for lossless graphical-editor block operations."""
 
+import json
+from pathlib import Path
+import subprocess
 import unittest
 
+import yaml
+
 from .editor_utils import (
+    inserted_block_id_by_position,
+    is_comment_only_yaml,
     comment_out_block_in_yaml,
     delete_block_from_yaml,
     enable_commented_block_in_yaml,
@@ -215,6 +222,177 @@ class TestEditorBlockTitles(unittest.TestCase):
         source = "features:\n  navigation: True\n"
         block = parse_interview_yaml(source)["blocks"][0]
         self.assertEqual(block["title"], "Features")
+
+
+class TestNewBlockTemplates(unittest.TestCase):
+    """Every block the "Add a block" modal authors has to survive the checker.
+
+    The templates are read out of editor_serializers.js rather than restated
+    here, so a template that changes in the browser cannot quietly stop being
+    valid docassemble.
+    """
+
+    # Every kind the modal offers. "ai-screen" starts life as a question
+    # block, so the caller collapses it to "question" before inserting.
+    KINDS = (
+        "question",
+        "ai-screen",
+        "review",
+        "code",
+        "objects",
+        "attachment",
+        "comment",
+        "other",
+    )
+
+    # A plausible host interview: metadata, an order block, and two screens.
+    HOST = (
+        "metadata:\n"
+        "  title: Test interview\n"
+        "---\n"
+        "mandatory: True\n"
+        "code: |\n"
+        "  intro_screen\n"
+        "  final_screen\n"
+        "---\n"
+        "id: intro\n"
+        "question: |\n"
+        "  Welcome\n"
+        "continue button field: intro_screen\n"
+        "---\n"
+        "id: final\n"
+        "event: final_screen\n"
+        "question: |\n"
+        "  All done\n"
+    )
+
+    @classmethod
+    def setUpClass(cls):
+        package_dir = Path(__file__).resolve().parent
+        script = (
+            "const s = require(%s);"
+            "const out = {};"
+            "%s.forEach(function (k) { out[k] = s.makeNewBlockYaml(k, 1700000000000); });"
+            "process.stdout.write(JSON.stringify(out));"
+            % (
+                json.dumps(str(package_dir / "data/static/editor_serializers.js")),
+                json.dumps(list(cls.KINDS)),
+            )
+        )
+        completed = subprocess.run(
+            ["node", "-e", script], check=False, capture_output=True, text=True
+        )
+        if completed.returncode != 0:
+            raise unittest.SkipTest(f"node is unavailable: {completed.stderr}")
+        cls.templates = json.loads(completed.stdout)
+
+    def checker_errors(self, raw_yaml):
+        from dayamlchecker.yaml_structure import find_errors_from_string
+
+        return [
+            str(getattr(error, "err_str", "") or error)
+            for error in find_errors_from_string(raw_yaml, input_file="test.yml")
+        ]
+
+    def test_the_host_interview_starts_clean(self):
+        # Otherwise a template could inherit a pass from a file already broken.
+        self.assertEqual(self.checker_errors(self.HOST), [])
+
+    def test_every_new_block_passes_the_checker_wherever_it_lands(self):
+        for kind in self.KINDS:
+            block_yaml = self.templates[kind]
+            self.assertTrue(block_yaml.strip(), kind)
+            for insert_after_id in (None, "intro", "final"):
+                with self.subTest(kind=kind, insert_after_id=insert_after_id):
+                    updated = insert_block_in_yaml(
+                        self.HOST, block_yaml, insert_after_id
+                    )
+                    errors = self.checker_errors(updated)
+                    self.assertEqual(errors, [], f"{kind}:\n{block_yaml}")
+
+    def test_a_new_block_is_exactly_one_parsable_block(self):
+        for kind in self.KINDS:
+            with self.subTest(kind=kind):
+                blocks = parse_interview_yaml(self.templates[kind])["blocks"]
+                self.assertEqual(len(blocks), 1)
+
+    def test_the_comment_block_carries_no_id(self):
+        # An id needs a key beside it that gives the block a type; on its own
+        # the checker reports "couldn't identify a block type".
+        self.assertNotIn("id:", self.templates["comment"])
+        with_id = "id: comment_1\n" + self.templates["comment"]
+        self.assertNotEqual(self.checker_errors(self.HOST + "---\n" + with_id), [])
+
+    def test_the_ai_screen_starts_from_the_question_template(self):
+        self.assertEqual(self.templates["ai-screen"], self.templates["question"])
+
+    def test_the_raw_yaml_block_is_not_secretly_a_code_block(self):
+        # A `code:` key would type the block as code, and saving it would then
+        # re-serialize whatever the author typed under a `code: |` leader.
+        raw = self.templates["other"]
+        self.assertNotIn("code:", raw)
+        updated = insert_block_in_yaml(self.HOST, raw, "intro")
+        block = next(
+            item
+            for item in parse_interview_yaml(updated)["blocks"]
+            if item["yaml"].strip() == raw.strip()
+        )
+        self.assertNotIn(block["type"], ("code", "question", "objects", "review"))
+
+    def test_the_raw_yaml_block_starts_unindented_on_a_single_line(self):
+        raw = self.templates["other"].rstrip("\n")
+        self.assertNotIn("\n", raw)
+        self.assertEqual(raw, raw.lstrip())
+
+    def test_the_raw_yaml_block_is_only_a_yaml_comment(self):
+        # Nothing is set: docassemble reads no keys out of the block, so the
+        # author starts at column one with no structure to delete first.
+        raw = self.templates["other"]
+        self.assertTrue(is_comment_only_yaml(raw), raw)
+        self.assertIsNone(yaml.safe_load(raw))
+
+    def test_a_blank_raw_block_can_still_be_selected_after_insertion(self):
+        # It has no id of its own, so the outline needs it found by position.
+        raw = self.templates["other"]
+        for insert_after_id in (None, "intro", "final"):
+            with self.subTest(insert_after_id=insert_after_id):
+                updated = insert_block_in_yaml(self.HOST, raw, insert_after_id)
+                blocks = parse_interview_yaml(updated)["blocks"]
+                found = inserted_block_id_by_position(blocks, insert_after_id)
+                selected = next(b for b in blocks if b["id"] == found)
+                self.assertEqual(selected["yaml"].strip(), raw.strip())
+
+    def test_an_unknown_anchor_selects_nothing_rather_than_a_stray_block(self):
+        blocks = parse_interview_yaml(self.HOST)["blocks"]
+        self.assertIsNone(inserted_block_id_by_position(blocks, "missing"))
+        self.assertIsNone(inserted_block_id_by_position([], None))
+
+    def test_a_blank_raw_block_is_editable_not_a_disabled_block(self):
+        # A disabled block renders read-only, with nothing but "re-enable".
+        updated = insert_block_in_yaml(self.HOST, self.templates["other"], "intro")
+        blocks = parse_interview_yaml(updated)["blocks"]
+        block = next(b for b in blocks if b["title"] != "" and "#" in b["yaml"])
+        self.assertNotEqual(block["type"], "commented")
+
+    def test_a_commented_out_block_is_still_recognised_as_one(self):
+        # The note case must not swallow real blocks that were commented out.
+        disabled = "# id: parked\n# question: |\n#   Parked for now\n"
+        updated = insert_block_in_yaml(self.HOST, disabled, "intro")
+        blocks = parse_interview_yaml(updated)["blocks"]
+        block = next(b for b in blocks if b["yaml"].strip() == disabled.strip())
+        self.assertEqual(block["type"], "commented")
+        self.assertEqual(block["data"]["_commented_type"], "question")
+
+    def test_what_an_author_types_into_a_raw_block_still_checks_out(self):
+        # The raw block exists for the kinds the modal has no card for.
+        for typed in (
+            "features:\n  navigation: True\n",
+            "modules:\n  - .my_module\n",
+            "terms:\n  lease: A rental contract.\n",
+        ):
+            with self.subTest(typed=typed):
+                updated = insert_block_in_yaml(self.HOST, typed, "intro")
+                self.assertEqual(self.checker_errors(updated), [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
New layout: 
<img width="710" height="963" alt="image" src="https://github.com/user-attachments/assets/6f113e93-4e5d-4fe4-aa49-53467f9420bd" />
