### PR TITLE
Group the generated review screen by question, and let it be re-synced

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -56,6 +56,17 @@ cover sheet is drafted in one pass. (An older `data/sources/output_patterns.yml`
 `assembly_line.yml` still names it in a `DAInterview.using(template_path=...)`
 argument that is not read.)
 
+`review_screen.py` decides what the generated review screen contains, and
+`output_defs.mako` only renders it. Entries are grouped by the question screen
+that asked for them, in asking order, so the recap reads like the interview
+rather than like a list of variables; lists keep a `.revisit` entry of their own,
+because "Edit" there has to reach the whole list. Every value is written so an
+undefined variable renders empty -- `showifdef()`, or a `defined()` guard around
+`currency()` and `yesno()`, which would otherwise report a confident wrong answer
+for a question nobody was asked. The same module decides what a revisit table's
+`edit:` may contain: Docassemble seeks every variable named there, so signatures
+are left out rather than demanded from a table row.
+
 This directory also contains test files for unit testing with ALKiln (see below for more information.)
 
 ### Static files in docassemble/ALWeaver/data/static
@@ -342,7 +353,23 @@ kinds of interviews that the Weaver can produce.
 - `editor_agent.py` runs the bounded agent loop and the explicit final validation pass
 - `document_bundles.py` reads and edits the documents an interview assembles, and reports which template files nothing in the interview uses yet: which `ALDocument` fills which template, what order each `ALDocumentBundle` lists them in, and the `enabled` rule that decides whether one is in the download. Both edits rewrite a single keyword argument inside one `objects:` declaration, leaving the rest of the block's text and comments alone
 - `template_analysis.py` is the engine behind the editor's **Import into this interview** action: it runs the generator over one template and keeps only what an existing interview is missing -- the `attachment` block, screens for fields nothing asks about yet, and the `objects` those screens need. On a template already imported it offers a freshly read attachment block instead, which is how a form the court has revised gets its new fields. Reading a template stays available for the life of a project, not only while it is being created
+- `review_screen.py` groups the review screen a generated interview gets: one entry per question screen, in asking order, with `.revisit` entries for lists, and it decides which attributes a revisit table's `edit:` may name
+- `review_screen_sync.py` re-drafts a review screen for an interview that already exists, so one that has drifted from the questions can be brought back in line without hand-editing
+- `variable_report.py` drafts a starter DOCX template from the questions an interview already asks, for intakes where the answers are the output and there is no form to start from
 - `editor_modules.py` decides what saving a Playground Python module means: which names Docassemble will actually load, whether the source compiles, whether the module can go live immediately, and which projects are waiting on a restart
+
+`review_screen_sync.py` re-drafts a review screen for an interview that already
+exists, which the generation path cannot do -- by then the questions live in
+YAML, not in the Weaver's field model. It imports ALDashboard's
+`review_screen_generator` at runtime (optional, like the linter integration) and
+adds three things: it resolves what "the interview" means by walking the
+project's include graph in both directions, since review screens usually live in
+a `review.yml` that the interviews include rather than the other way round; it
+keeps the interview's own `id`, `event` and question text, so the download
+screen's "Edit answers" button still resolves; and it replaces the old review
+block, revisit screens and tables in place rather than appending a second review
+screen. The result goes to the full-YAML view for the author to read before
+saving.
 
 ## Testing
 

--- a/architecture.md
+++ b/architecture.md
@@ -368,8 +368,12 @@ a `review.yml` that the interviews include rather than the other way round; it
 keeps the interview's own `id`, `event` and question text, so the download
 screen's "Edit answers" button still resolves; and it replaces the old review
 block, revisit screens and tables in place rather than appending a second review
-screen. The result goes to the full-YAML view for the author to read before
-saving.
+screen. Because re-drafting is a large edit to one part of a file, the endpoint
+returns a unified diff alongside the new source and the editor confirms it in a
+modal -- what leaves, what arrives -- rather than reopening the whole interview
+in a source editor. Applying saves the file and returns to the review block;
+"Edit the whole file instead" is there for anyone who wants to hand-edit the
+result first.
 
 ## Testing
 

--- a/architecture.md
+++ b/architecture.md
@@ -367,8 +367,13 @@ project's include graph in both directions, since review screens usually live in
 a `review.yml` that the interviews include rather than the other way round; it
 keeps the interview's own `id`, `event` and question text, so the download
 screen's "Edit answers" button still resolves; and it replaces the old review
-block, revisit screens and tables in place rather than appending a second review
-screen. Because re-drafting is a large edit to one part of a file, the endpoint
+block in place, along with the revisit screens and tables it actually
+regenerates, rather than appending a second review screen. What the draft cannot
+see it keeps: AssemblyLine declares `plaintiffs`, `courts` and `docket_number` in
+a package the include walk does not follow, so lists the file already reviews are
+fed back to the generator as object declarations, entries with no counterpart in
+the draft are carried over instead of dropped, and a table the draft did not
+regenerate stays where it is -- the revisit screen displaying it still needs it. Because re-drafting is a large edit to one part of a file, the endpoint
 returns a unified diff alongside the new source and the editor confirms it in a
 modal -- what leaves, what arrives -- rather than reopening the whole interview
 in a source editor. Applying saves the file and returns to the review block;

--- a/docassemble/ALWeaver/api_editor.py
+++ b/docassemble/ALWeaver/api_editor.py
@@ -188,8 +188,11 @@ from .variable_report import (
 )
 from .review_screen_sync import (
     ALDashboardUnavailable,
+    carry_over_unmatched_entries,
     collect_interview_yaml_texts,
+    ensure_revisit_tables,
     generate_review_screen_yaml,
+    inferred_objects_document,
     review_screen_identity,
     sync_review_screen,
 )
@@ -718,16 +721,7 @@ def _build_file_response_data(
     inserted_block_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     model = parse_interview_yaml(updated_content)
-    order_step_map: Dict[str, List[Dict[str, Any]]] = {}
-    order_steps: list = []
-    for idx in model.get("order_blocks", []):
-        block = model["blocks"][idx]
-        code = block.get("data", {}).get("code", "")
-        if code:
-            parsed_steps = parse_order_code(code)
-            order_step_map[block["id"]] = parsed_steps
-            if not order_steps:
-                order_steps = parsed_steps
+    order_step_map, order_steps = _order_steps_from_model(model)
     return {
         "project": project,
         "filename": filename,
@@ -846,6 +840,32 @@ def _list_editor_section_files(
             }
         )
     return items
+
+
+def _order_steps_from_model(model: Dict[str, Any]) -> Tuple[Dict[str, Any], list]:
+    """Parse every interview-order block a parsed file contains.
+
+    ``order_blocks`` holds *document* indices, which are what ``block["index"]``
+    records; they are not positions in ``blocks``, because empty documents never
+    become blocks. Reading them as positions returns the wrong block in any file
+    with a blank document, and raises IndexError when the order block is the
+    last one -- which is every file that opens with `---` and ends with its
+    mandatory code.
+    """
+    wanted = set(model.get("order_blocks") or [])
+    order_step_map: Dict[str, Any] = {}
+    order_steps: list = []
+    for block in model.get("blocks", []):
+        if block.get("index") not in wanted:
+            continue
+        code = (block.get("data") or {}).get("code", "")
+        if not code:
+            continue
+        parsed_steps = parse_order_code(code)
+        order_step_map[block["id"]] = parsed_steps
+        if not order_steps:
+            order_steps = parsed_steps
+    return order_step_map, order_steps
 
 
 def _project_yaml_filenames(user_id: int, project: str) -> List[str]:
@@ -3059,17 +3079,7 @@ def editor_api_get_file() -> Response:
         filename = _normalize_filename(request.args.get("filename"))
         raw_yaml = playground_read_yaml(uid, project, filename)
         model = parse_interview_yaml(raw_yaml)
-
-        order_step_map: Dict[str, List[Dict[str, Any]]] = {}
-        order_steps: list = []
-        for idx in model.get("order_blocks", []):
-            block = model["blocks"][idx]
-            code = block.get("data", {}).get("code", "")
-            if code:
-                parsed_steps = parse_order_code(code)
-                order_step_map[block["id"]] = parsed_steps
-                if not order_steps:
-                    order_steps = parsed_steps
+        order_step_map, order_steps = _order_steps_from_model(model)
 
         return jsonify(
             {
@@ -7055,18 +7065,31 @@ def editor_api_draft_review_screen() -> Response:
             read_project_file, filename, _project_yaml_filenames(uid, project)
         )
         identity = review_screen_identity(raw_yaml)
-        review_yaml = generate_review_screen_yaml(
+        # AssemblyLine declares `plaintiffs`, `defendants` and `courts` in its
+        # own package, which the include walk does not follow. Telling the
+        # generator about the lists this file already reviews keeps their
+        # entries instead of silently dropping them.
+        inferred_objects = inferred_objects_document(yaml_texts)
+        generator_inputs = list(yaml_texts)
+        if inferred_objects:
+            generator_inputs.append(inferred_objects)
+        review_yaml = ensure_revisit_tables(
+            generate_review_screen_yaml(
+                generator_inputs,
+                screen_id=identity.get("id"),
+                event_name=identity.get("event"),
+                question_text=identity.get("question"),
+            ),
             yaml_texts,
-            screen_id=identity.get("id"),
-            event_name=identity.get("event"),
-            question_text=identity.get("question"),
         )
+        review_yaml, kept_entries = carry_over_unmatched_entries(review_yaml, raw_yaml)
 
         data: Dict[str, Any] = {
             "review_yaml": review_yaml,
             "sources": sources,
             "had_review_screen": bool(identity.get("found")),
             "replaced": False,
+            "kept_entries": kept_entries,
             "revision": source_revision(raw_yaml),
         }
         if mode == "sync":

--- a/docassemble/ALWeaver/api_editor.py
+++ b/docassemble/ALWeaver/api_editor.py
@@ -23,11 +23,13 @@ Provides:
     POST /al/editor/api/template/import — read a template already in a project
     GET  /al/editor/api/template/import/jobs/<id> — poll a template import
     POST /al/editor/api/template/apply — add the accepted parts of one to the YAML
+    GET  /al/editor/api/template/variable-report/suggestion — its title and filename
+    POST /al/editor/api/template/variable-report — draft a DOCX template from the questions
     GET  /al/editor/api/documents — the documents an interview assembles
     POST /al/editor/api/documents — reorder documents or change what enables them
     GET  /al/editor/api/parse-order — parse order code into structured steps
     POST /al/editor/api/draft-order — generate a draft order from blocks
-    POST /al/editor/api/draft-review-screen — generate draft review YAML
+    POST /al/editor/api/draft-review-screen — draft or re-sync the review screen
     GET  /al/editor/api/preview-url — get the interview preview URL
     GET  /al/editor/api/list-topics — LIST taxonomy codes for the topic picker
     GET  /al/editor/api/weaver/validate — validate a saved YAML file
@@ -180,6 +182,17 @@ except Exception as _editor_utils_import_err:
     )
     raise
 
+from .variable_report import (
+    suggested_report_names,
+    write_variable_report_docx,
+)
+from .review_screen_sync import (
+    ALDashboardUnavailable,
+    collect_interview_yaml_texts,
+    generate_review_screen_yaml,
+    review_screen_identity,
+    sync_review_screen,
+)
 from .source_document import (
     apply_range_operations,
     parse_source_document,
@@ -831,6 +844,24 @@ def _list_editor_section_files(
             }
         )
     return items
+
+
+def _project_yaml_filenames(user_id: int, project: str) -> List[str]:
+    """Interview filenames in a project, for walking its include graph.
+
+    A review screen usually sits in a file of its own that the interviews
+    include, so working out what an interview is made of means looking at more
+    than the file that is open.
+    """
+    try:
+        return [
+            _normalize_filename(item["filename"])
+            for item in playground_list_yaml_files(user_id, project)
+            if isinstance(item, dict) and item.get("filename")
+        ]
+    except Exception as exc:
+        log(f"ALWeaver editor: could not list project YAML files: {exc!r}", "warning")
+        return []
 
 
 def _read_project_text_file(
@@ -2591,6 +2622,169 @@ def editor_api_new_section_file() -> Response:
         )
     except Exception as exc:
         log(f"ALWeaver editor: new section-file error: {exc!r}", "error")
+        return jsonify_with_status(
+            {
+                "success": False,
+                "request_id": request_id,
+                "error": {"type": "server_error", "message": str(exc)},
+            },
+            500,
+        )
+
+
+@app.route(
+    f"{EDITOR_BASE_PATH}/api/template/variable-report/suggestion", methods=["GET"]
+)
+def editor_api_template_variable_report_suggestion() -> Response:
+    """The title, filename and source files a variable report would use."""
+    request_id = str(uuid.uuid4())
+    if not _editor_auth_check():
+        return _auth_fail(request_id)
+    try:
+        uid = _current_user_id()
+        project = _normalize_project(request.args.get("project"))
+        filename = _normalize_filename(request.args.get("filename"))
+
+        raw_yaml = playground_read_yaml(uid, project, filename)
+
+        def read_project_file(name: str) -> str:
+            if name == filename:
+                return raw_yaml
+            return playground_read_yaml(uid, project, _normalize_filename(name))
+
+        sources, yaml_texts = collect_interview_yaml_texts(
+            read_project_file, filename, _project_yaml_filenames(uid, project)
+        )
+        suggested = suggested_report_names(yaml_texts, primary_filename=filename)
+        return jsonify(
+            {
+                "success": True,
+                "request_id": request_id,
+                "data": {
+                    "title": suggested["title"],
+                    "filename": suggested["filename"],
+                    "sources": sources,
+                },
+            }
+        )
+    except ALDashboardUnavailable as exc:
+        return jsonify_with_status(
+            {
+                "success": False,
+                "request_id": request_id,
+                "error": {"type": "unavailable", "message": str(exc)},
+            },
+            503,
+        )
+    except (ValueError, FileNotFoundError) as exc:
+        status = 404 if isinstance(exc, FileNotFoundError) else 400
+        return jsonify_with_status(
+            {
+                "success": False,
+                "request_id": request_id,
+                "error": {"type": "validation_error", "message": str(exc)},
+            },
+            status,
+        )
+    except Exception as exc:
+        log(f"ALWeaver editor: variable-report suggestion error: {exc!r}", "error")
+        return jsonify_with_status(
+            {
+                "success": False,
+                "request_id": request_id,
+                "error": {"type": "server_error", "message": str(exc)},
+            },
+            500,
+        )
+
+
+@app.route(f"{EDITOR_BASE_PATH}/api/template/variable-report", methods=["POST"])
+def editor_api_template_variable_report() -> Response:
+    """Draft a starter DOCX template from the interview's own questions.
+
+    The document is written into the project's templates folder, so it shows up
+    beside uploaded templates and can be imported from Document setup like any
+    other file.
+    """
+    request_id = str(uuid.uuid4())
+    if not _editor_auth_check():
+        return _auth_fail(request_id)
+    try:
+        uid = _current_user_id()
+        post_data = request.get_json(silent=True) or {}
+        project = _normalize_project(post_data.get("project"))
+        filename = _normalize_filename(post_data.get("filename"))
+        show_variable_names = bool(post_data.get("show_variable_names"))
+
+        raw_yaml = playground_read_yaml(uid, project, filename)
+
+        def read_project_file(name: str) -> str:
+            if name == filename:
+                return raw_yaml
+            return playground_read_yaml(uid, project, _normalize_filename(name))
+
+        sources, yaml_texts = collect_interview_yaml_texts(
+            read_project_file, filename, _project_yaml_filenames(uid, project)
+        )
+        suggested = suggested_report_names(yaml_texts, primary_filename=filename)
+        report_title = str(post_data.get("title") or suggested["title"]).strip()
+        output_filename = _normalize_storage_filename(
+            post_data.get("output_filename") or suggested["filename"]
+        )
+        if not output_filename.lower().endswith(".docx"):
+            output_filename += ".docx"
+
+        storage_section = EDITOR_SECTION_TO_STORAGE["templates"]
+        area, directory = _editor_storage_directory(uid, project, storage_section)
+        path = os.path.join(directory, output_filename)
+        if os.path.exists(path) and not post_data.get("overwrite"):
+            raise ValueError(
+                f"{output_filename} already exists. Rename it, or choose to replace it."
+            )
+
+        summary = write_variable_report_docx(
+            yaml_texts,
+            path,
+            report_title=report_title or None,
+            show_variable_names=show_variable_names,
+        )
+        area.finalize()
+
+        return jsonify(
+            {
+                "success": True,
+                "request_id": request_id,
+                "data": {
+                    "project": project,
+                    "section": "templates",
+                    "filename": output_filename,
+                    "title": report_title,
+                    "sources": sources,
+                    **summary,
+                },
+            }
+        )
+    except ALDashboardUnavailable as exc:
+        return jsonify_with_status(
+            {
+                "success": False,
+                "request_id": request_id,
+                "error": {"type": "unavailable", "message": str(exc)},
+            },
+            503,
+        )
+    except (ValueError, FileNotFoundError) as exc:
+        status = 404 if isinstance(exc, FileNotFoundError) else 400
+        return jsonify_with_status(
+            {
+                "success": False,
+                "request_id": request_id,
+                "error": {"type": "validation_error", "message": str(exc)},
+            },
+            status,
+        )
+    except Exception as exc:
+        log(f"ALWeaver editor: template variable-report error: {exc!r}", "error")
         return jsonify_with_status(
             {
                 "success": False,
@@ -6828,7 +7022,13 @@ def editor_api_draft_order() -> Response:
 
 @app.route(f"{EDITOR_BASE_PATH}/api/draft-review-screen", methods=["POST"])
 def editor_api_draft_review_screen() -> Response:
-    """Generate draft review-screen YAML using ALDashboard when available."""
+    """Draft a review screen for an interview, or re-sync the one it has.
+
+    Reads the interview and every project file it includes, so a review screen
+    stays current with variables that moved into another file. ``mode: "sync"``
+    also returns the whole file with the old review screen, revisit screens and
+    tables replaced in place, for the author to look over before saving.
+    """
     request_id = str(uuid.uuid4())
     if not _editor_auth_check():
         return _auth_fail(request_id)
@@ -6838,18 +7038,53 @@ def editor_api_draft_review_screen() -> Response:
         project = _normalize_project(post_data.get("project"))
         filename = _normalize_filename(post_data.get("filename"))
 
+        mode = str(post_data.get("mode") or "append").strip().lower()
+        if mode not in ("append", "sync"):
+            raise ValueError("mode must be 'append' or 'sync'.")
+
         raw_yaml = playground_read_yaml(uid, project, filename)
-        from docassemble.ALDashboard.review_screen_generator import (
-            generate_review_screen_yaml,
+
+        def read_project_file(name: str) -> str:
+            if name == filename:
+                return raw_yaml
+            return playground_read_yaml(uid, project, _normalize_filename(name))
+
+        sources, yaml_texts = collect_interview_yaml_texts(
+            read_project_file, filename, _project_yaml_filenames(uid, project)
+        )
+        identity = review_screen_identity(raw_yaml)
+        review_yaml = generate_review_screen_yaml(
+            yaml_texts,
+            screen_id=identity.get("id"),
+            event_name=identity.get("event"),
+            question_text=identity.get("question"),
         )
 
-        review_yaml = generate_review_screen_yaml([raw_yaml])
+        data = {
+            "review_yaml": review_yaml,
+            "sources": sources,
+            "had_review_screen": bool(identity.get("found")),
+            "replaced": False,
+        }
+        if mode == "sync":
+            data["full_yaml"], data["replaced"] = sync_review_screen(
+                raw_yaml, review_yaml
+            )
         return jsonify(
             {
                 "success": True,
                 "request_id": request_id,
-                "data": {"review_yaml": review_yaml},
+                "data": data,
             }
+        )
+    except ALDashboardUnavailable as exc:
+        return jsonify_with_status(
+            {
+                "success": False,
+                "request_id": request_id,
+                "error": {"type": "unavailable", "message": str(exc)},
+            },
+            503,
         )
     except (ValueError, FileNotFoundError) as exc:
         status = 404 if isinstance(exc, FileNotFoundError) else 400

--- a/docassemble/ALWeaver/api_editor.py
+++ b/docassemble/ALWeaver/api_editor.py
@@ -218,11 +218,13 @@ from .editor_agent_models import (
     WeaverAgentSession,
     clear_progress,
     delete_agent_session,
+    diff_stats,
     load_agent_session,
     load_progress,
     progress_is_live,
     store_agent_session,
     store_progress,
+    truncate_diff,
 )
 from .editor_agent_validation import (
     SEVERITY_ERROR,
@@ -7060,16 +7062,23 @@ def editor_api_draft_review_screen() -> Response:
             question_text=identity.get("question"),
         )
 
-        data = {
+        data: Dict[str, Any] = {
             "review_yaml": review_yaml,
             "sources": sources,
             "had_review_screen": bool(identity.get("found")),
             "replaced": False,
+            "revision": source_revision(raw_yaml),
         }
         if mode == "sync":
             data["full_yaml"], data["replaced"] = sync_review_screen(
                 raw_yaml, review_yaml
             )
+            # The drafted block on its own does not show what a sync will do to
+            # the file: what is being dropped matters as much as what arrives.
+            diff_text = unified_source_diff(raw_yaml, data["full_yaml"], filename)
+            data["diff"] = truncate_diff(diff_text)
+            data["diff"].update(diff_stats(diff_text))
+            data["unchanged"] = not diff_text
         return jsonify(
             {
                 "success": True,

--- a/docassemble/ALWeaver/data/static/editor.css
+++ b/docassemble/ALWeaver/data/static/editor.css
@@ -4073,3 +4073,24 @@ html, body {
     transform: none;
   }
 }
+
+/* Choice cards in the "add a template" picker: a radio and its explanation
+   read as one clickable block rather than a bare radio with prose beside it. */
+.editor-choice-card {
+  border: 1px solid var(--editor-border);
+  border-radius: var(--editor-radius);
+  padding: 10px 12px 10px 34px;
+}
+
+.editor-choice-card:has(.form-check-input:checked) {
+  border-color: var(--bs-primary, #0d6efd);
+  background: rgba(13, 110, 253, 0.04);
+}
+
+.editor-choice-card .form-check-input {
+  margin-left: -22px;
+}
+
+.editor-choice-card .form-check-label {
+  cursor: pointer;
+}

--- a/docassemble/ALWeaver/data/static/editor.css
+++ b/docassemble/ALWeaver/data/static/editor.css
@@ -4094,3 +4094,45 @@ html, body {
 .editor-choice-card .form-check-label {
   cursor: pointer;
 }
+
+/* Unified diff, coloured per line. The agent panel shows diffs in a plain
+   monospace block; a diff someone is about to accept earns the colour. */
+.editor-diff-body {
+  max-height: 52vh;
+  overflow: auto;
+  background: var(--editor-bg);
+  border: 1px solid var(--editor-border);
+  border-radius: 6px;
+  padding: 0;
+  margin: 0;
+  font-size: 0.78rem;
+  line-height: 1.45;
+}
+
+.editor-diff-line {
+  display: block;
+  padding: 0 10px;
+  white-space: pre;
+}
+
+.editor-diff-add {
+  background: rgba(25, 135, 84, 0.12);
+  color: #0f5132;
+}
+
+.editor-diff-del {
+  background: rgba(220, 53, 69, 0.1);
+  color: #842029;
+}
+
+.editor-diff-hunk {
+  background: var(--editor-border);
+  color: var(--editor-muted);
+  font-weight: 600;
+}
+
+.editor-diff-empty {
+  padding: 24px 12px;
+  text-align: center;
+  color: var(--editor-muted);
+}

--- a/docassemble/ALWeaver/data/static/editor.js
+++ b/docassemble/ALWeaver/data/static/editor.js
@@ -8494,6 +8494,138 @@
   }
 
   // -------------------------------------------------------------------------
+  // Sync review screen
+  //
+  // Re-drafting a review screen is a big edit to one part of a file, so the
+  // review point is that part -- what leaves, what arrives -- not the whole
+  // interview reopened in a source editor. Applying writes the file and comes
+  // back to the review block; the escape hatch into full YAML is still there
+  // for anyone who wants to hand-edit the result first.
+  // -------------------------------------------------------------------------
+  var _reviewSync = { data: null, tab: 'diff' };
+
+  function renderUnifiedDiffHtml(diffText) {
+    if (!diffText) {
+      return '<div class="editor-diff-empty">The drafted review screen matches the one already in this file.</div>';
+    }
+    var html = '<pre class="editor-diff-body">';
+    diffText.split('\n').forEach(function (line) {
+      // The ---/+++ file headers say nothing here: it is always this one file.
+      if (line.indexOf('---') === 0 || line.indexOf('+++') === 0) return;
+      var cls = 'editor-diff-line';
+      if (line.indexOf('@@') === 0) cls += ' editor-diff-hunk';
+      else if (line.indexOf('+') === 0) cls += ' editor-diff-add';
+      else if (line.indexOf('-') === 0) cls += ' editor-diff-del';
+      html += '<code class="' + cls + '">' + esc(line || ' ') + '</code>';
+    });
+    html += '</pre>';
+    return html;
+  }
+
+  function renderReviewSyncBody() {
+    var body = document.getElementById('review-sync-body');
+    var data = _reviewSync.data;
+    if (!body || !data) return;
+    document.querySelectorAll('[data-review-sync-tab]').forEach(function (button) {
+      var active = button.getAttribute('data-review-sync-tab') === _reviewSync.tab;
+      button.className = 'btn ' + (active ? 'btn-primary' : 'btn-outline-secondary');
+    });
+    if (_reviewSync.tab === 'draft') {
+      body.innerHTML = '<pre class="editor-diff-body"><code class="editor-diff-line">'
+        + esc(data.review_yaml || '') + '</code></pre>';
+      return;
+    }
+    var diff = data.diff || {};
+    var html = renderUnifiedDiffHtml(diff.diff || '');
+    if (diff.truncated) {
+      html += '<p class="editor-agent-diff-note">This diff is too large to show in full. '
+        + 'Use "Edit the whole file instead" to read all of it.</p>';
+    }
+    body.innerHTML = html;
+  }
+
+  function openReviewSyncModal(data) {
+    _reviewSync.data = data;
+    _reviewSync.tab = 'diff';
+    var summary = document.getElementById('review-sync-summary');
+    if (summary) {
+      var sources = data.sources || [];
+      var diff = data.diff || {};
+      var parts = [];
+      parts.push(sources.length > 1
+        ? 'Read ' + sources.length + ' files: ' + sources.join(', ')
+        : 'Read ' + (sources[0] || state.filename));
+      parts.push(data.replaced
+        ? 'replaces the review screen this file has'
+        : 'adds a review screen to this file');
+      if (diff.added || diff.removed) {
+        parts.push('+' + Number(diff.added || 0) + ' \u2212' + Number(diff.removed || 0) + ' lines');
+      }
+      summary.textContent = parts.join(' \u00b7 ');
+    }
+    var apply = document.getElementById('review-sync-apply');
+    if (apply) {
+      apply.disabled = Boolean(data.unchanged);
+      apply.textContent = data.replaced ? 'Replace review screen' : 'Add review screen';
+    }
+    renderReviewSyncBody();
+    var modal = getOrCreateBootstrapModal('review-sync-modal');
+    if (modal) modal.show();
+  }
+
+  function selectReviewBlockAfterSync() {
+    for (var i = 0; i < state.blocks.length; i++) {
+      if (state.blocks[i].type === 'review') {
+        state.selectedBlockId = state.blocks[i].id;
+        dirtyState.setActiveBlock(state.selectedBlockId);
+        renderOutline();
+        renderCanvas();
+        return;
+      }
+    }
+  }
+
+  function applyReviewSync() {
+    var data = _reviewSync.data;
+    if (!data || !data.full_yaml) return;
+    var apply = document.getElementById('review-sync-apply');
+    if (apply) apply.disabled = true;
+    apiPost('/api/file', {
+      project: state.project,
+      filename: state.filename,
+      content: data.full_yaml,
+    }).then(function (res) {
+      if (apply) apply.disabled = false;
+      if (!res.success) {
+        window.alert((res.error && res.error.message) || 'Unable to save the review screen.');
+        return;
+      }
+      closeBootstrapModal('review-sync-modal');
+      loadFile().then(function () {
+        selectReviewBlockAfterSync();
+        _showSuccessBanner(data.replaced
+          ? 'Review screen re-drafted and saved.'
+          : 'Review screen added and saved.');
+      });
+    }).catch(function (error) {
+      if (apply) apply.disabled = false;
+      if (isSupersededRequest(error)) return;
+      window.alert('Unable to save the review screen.');
+    });
+  }
+
+  function openReviewSyncInFullYaml() {
+    var data = _reviewSync.data;
+    if (!data || !data.full_yaml) return;
+    closeBootstrapModal('review-sync-modal');
+    state.canvasMode = 'full-yaml';
+    state.fullYamlTab = 'full';
+    state.fullYamlStash.full = data.full_yaml;
+    markInterviewDirty('sync-review-screen');
+    renderCanvas();
+  }
+
+  // -------------------------------------------------------------------------
   // Add a template
   //
   // "+ New" under Templates opens a picker rather than a filename prompt,
@@ -9850,6 +9982,20 @@
       openNewTemplateModal();
       return;
     }
+    var reviewSyncTab = target.closest ? target.closest('[data-review-sync-tab]') : null;
+    if (reviewSyncTab) {
+      _reviewSync.tab = reviewSyncTab.getAttribute('data-review-sync-tab');
+      renderReviewSyncBody();
+      return;
+    }
+    if (target.id === 'review-sync-apply') {
+      applyReviewSync();
+      return;
+    }
+    if (target.id === 'review-sync-full-yaml') {
+      openReviewSyncInFullYaml();
+      return;
+    }
     if (target.id === 'new-template-create') {
       createNewTemplate();
       return;
@@ -10791,28 +10937,19 @@
 
     if (target.id === 'draft-review-screen') {
       if (!state.project || !state.filename) return;
-      // Re-drafted, not appended: a second review screen next to the stale one
-      // is how these files got out of sync in the first place. The result opens
-      // in the full-YAML view so the author reads the replacement before saving.
-      apiPost('/api/draft-review-screen', { project: state.project, filename: state.filename, mode: 'sync' })
-        .then(function (res) {
-          if (res.success && res.data && (res.data.full_yaml || res.data.review_yaml)) {
-            state.canvasMode = 'full-yaml';
-            state.fullYamlTab = 'full';
-            state.fullYamlStash.full = res.data.full_yaml
-              || ((state.rawYaml || '').replace(/\s*$/, '\n---\n') + res.data.review_yaml.trim() + '\n');
-            markInterviewDirty('sync-review-screen');
-            renderCanvas();
-            var sources = res.data.sources || [];
-            _showSuccessBanner(
-              (res.data.replaced ? 'Review screen re-drafted from ' : 'Review screen drafted from ')
-              + (sources.length > 1 ? sources.length + ' files' : esc(sources[0] || state.filename))
-              + '. Look it over, then save.'
-            );
-            return;
-          }
-          window.alert((res.error && res.error.message) || 'Unable to draft review screen.');
-        });
+      // The draft is built from the file on disk, so anything unsaved has to go
+      // in first or applying the result would quietly throw it away.
+      promptAndSaveUnsavedChanges('sync the review screen').then(function (saved) {
+        if (!saved) return;
+        apiPost('/api/draft-review-screen', { project: state.project, filename: state.filename, mode: 'sync' })
+          .then(function (res) {
+            if (res.success && res.data && res.data.full_yaml) {
+              openReviewSyncModal(res.data);
+              return;
+            }
+            window.alert((res.error && res.error.message) || 'Unable to draft review screen.');
+          });
+      });
       return;
     }
 

--- a/docassemble/ALWeaver/data/static/editor.js
+++ b/docassemble/ALWeaver/data/static/editor.js
@@ -8558,6 +8558,11 @@
       parts.push(data.replaced
         ? 'replaces the review screen this file has'
         : 'adds a review screen to this file');
+      if (data.kept_entries) {
+        parts.push('keeps ' + data.kept_entries
+          + (data.kept_entries === 1 ? ' entry' : ' entries')
+          + ' the draft did not cover');
+      }
       if (diff.added || diff.removed) {
         parts.push('+' + Number(diff.added || 0) + ' \u2212' + Number(diff.removed || 0) + ' lines');
       }
@@ -8610,7 +8615,11 @@
     }).catch(function (error) {
       if (apply) apply.disabled = false;
       if (isSupersededRequest(error)) return;
-      window.alert('Unable to save the review screen.');
+      // The server's message is the useful half -- "Permission denied on
+      // main.yml" is something to act on, "unable to save" is not.
+      window.alert(error && error.message
+        ? 'Unable to save the review screen: ' + error.message
+        : 'Unable to save the review screen.');
     });
   }
 

--- a/docassemble/ALWeaver/data/static/editor.js
+++ b/docassemble/ALWeaver/data/static/editor.js
@@ -6842,7 +6842,7 @@
     html += '</div>';
     html += '<div class="d-flex gap-2 flex-wrap">';
     html += '<button type="button" class="btn btn-sm btn-outline-primary" data-action="open-screen-preview" title="See this screen the way Docassemble will draw it"><i class="fa-regular fa-eye me-1" aria-hidden="true"></i>Preview</button>';
-    html += '<button class="btn btn-sm btn-outline-secondary" id="draft-review-screen"><i class="fa-solid fa-wand-magic-sparkles me-1" aria-hidden="true"></i>Draft review</button>';
+    html += '<button class="btn btn-sm btn-outline-secondary" id="draft-review-screen" title="Re-draft this review screen from the questions the interview asks today, including questions in files it includes"><i class="fa-solid fa-wand-magic-sparkles me-1" aria-hidden="true"></i>Sync from questions</button>';
     html += '<button class="btn btn-sm btn-outline-secondary" id="toggle-edit-mode">' + (isYaml ? 'Structured view' : 'Edit full YAML') + '</button>';
     html += '</div>';
     html += '</div>';
@@ -8493,6 +8493,160 @@
     return 'new_template.txt';
   }
 
+  // -------------------------------------------------------------------------
+  // Add a template
+  //
+  // "+ New" under Templates opens a picker rather than a filename prompt,
+  // because one of the choices does not start from a file at all: the variable
+  // report is drafted from the questions the interview already asks, which is
+  // how someone automates an intake without inventing the output document
+  // first. See ALWeaver#819.
+  // -------------------------------------------------------------------------
+  function newTemplateKind() {
+    var checked = document.querySelector('input[name="new-template-kind"]:checked');
+    return checked ? checked.value : 'blank';
+  }
+
+  function syncNewTemplateFields() {
+    var isReport = newTemplateKind() === 'variable-report';
+    var blank = document.getElementById('new-template-blank-fields');
+    var report = document.getElementById('new-template-report-fields');
+    if (blank) blank.classList.toggle('d-none', isReport);
+    if (report) report.classList.toggle('d-none', !isReport);
+    var create = document.getElementById('new-template-create');
+    if (create) create.textContent = isReport ? 'Draft the document' : 'Create';
+  }
+
+  function setNewTemplateError(message) {
+    var box = document.getElementById('new-template-error');
+    if (!box) return;
+    if (!message) {
+      box.classList.add('d-none');
+      box.textContent = '';
+      return;
+    }
+    box.textContent = message;
+    box.classList.remove('d-none');
+  }
+
+  function openNewTemplateModal() {
+    setNewTemplateError('');
+    var blankName = document.getElementById('new-template-filename');
+    if (blankName) blankName.value = defaultNewFilename('templates');
+    var reportName = document.getElementById('new-template-report-filename');
+    var reportTitle = document.getElementById('new-template-report-title');
+    var sources = document.getElementById('new-template-report-sources');
+    var reportRadio = document.getElementById('new-template-kind-report');
+    var blankRadio = document.getElementById('new-template-kind-blank');
+    if (blankRadio) blankRadio.checked = true;
+    // Drafting from the questions needs an interview to read them from.
+    var haveInterview = Boolean(state.filename);
+    if (reportRadio) {
+      reportRadio.disabled = !haveInterview;
+      var reportCard = reportRadio.closest('.editor-choice-card');
+      if (reportCard) reportCard.classList.toggle('opacity-50', !haveInterview);
+    }
+    if (reportName) reportName.value = '';
+    if (reportTitle) reportTitle.value = '';
+    if (sources) {
+      sources.textContent = haveInterview
+        ? 'Reading ' + state.filename + '\u2026'
+        : 'Open an interview file first to draft a document from its questions.';
+    }
+    syncNewTemplateFields();
+    var modal = getOrCreateBootstrapModal('new-template-modal');
+    if (modal) modal.show();
+    if (haveInterview) loadVariableReportSuggestion();
+  }
+
+  function loadVariableReportSuggestion() {
+    apiGet('/api/template/variable-report/suggestion?project=' + encodeURIComponent(state.project) + '&filename=' + encodeURIComponent(state.filename))
+      .then(function (res) {
+        if (!res.success || !res.data) return;
+        var reportName = document.getElementById('new-template-report-filename');
+        var reportTitle = document.getElementById('new-template-report-title');
+        var sources = document.getElementById('new-template-report-sources');
+        if (reportName && !reportName.value) reportName.value = res.data.filename || '';
+        if (reportTitle && !reportTitle.value) reportTitle.value = res.data.title || '';
+        if (sources) {
+          var names = res.data.sources || [];
+          sources.textContent = names.length > 1
+            ? 'Reads ' + names.length + ' files: ' + names.join(', ')
+            : 'Reads ' + (names[0] || state.filename);
+        }
+      })
+      .catch(function () { /* the suggestion is a convenience, not a gate */ });
+  }
+
+  function createNewTemplate() {
+    if (!state.project) return;
+    setNewTemplateError('');
+    var create = document.getElementById('new-template-create');
+    if (create) create.disabled = true;
+    var finish = function () { if (create) create.disabled = false; };
+
+    if (newTemplateKind() === 'blank') {
+      var nameInput = document.getElementById('new-template-filename');
+      var filename = nameInput ? nameInput.value.trim() : '';
+      if (!filename) {
+        setNewTemplateError('Give the file a name.');
+        finish();
+        return;
+      }
+      apiPost('/api/section-file/new', {
+        project: state.project,
+        section: 'templates',
+        filename: filename,
+        content: '',
+      }).then(function (res) {
+        finish();
+        if (!res.success) {
+          setNewTemplateError((res.error && res.error.message) || 'Unable to create file.');
+          return;
+        }
+        closeBootstrapModal('new-template-modal');
+        state.sectionSelectedFile.templates = filename;
+        state.sectionDirty = false;
+        noteModuleSaveResult(res.data);
+        loadSectionFiles('templates');
+      }).catch(function (error) {
+        finish();
+        setNewTemplateError(error.message || 'Unable to create file.');
+      });
+      return;
+    }
+
+    if (!state.filename) {
+      setNewTemplateError('Open an interview file first.');
+      finish();
+      return;
+    }
+    var titleInput = document.getElementById('new-template-report-title');
+    var reportNameInput = document.getElementById('new-template-report-filename');
+    var varNames = document.getElementById('new-template-report-varnames');
+    apiPost('/api/template/variable-report', {
+      project: state.project,
+      filename: state.filename,
+      title: titleInput ? titleInput.value.trim() : '',
+      output_filename: reportNameInput ? reportNameInput.value.trim() : '',
+      show_variable_names: Boolean(varNames && varNames.checked),
+    }).then(function (res) {
+      finish();
+      if (!res.success) {
+        setNewTemplateError((res.error && res.error.message) || 'Unable to draft the document.');
+        return;
+      }
+      closeBootstrapModal('new-template-modal');
+      state.sectionSelectedFile.templates = res.data.filename;
+      state.sectionDirty = false;
+      loadSectionFiles('templates');
+      _showSuccessBanner('Drafted ' + esc(res.data.filename) + ' from ' + res.data.variables_count + ' variables. Import it under Document setup to assemble it.');
+    }).catch(function (error) {
+      finish();
+      setNewTemplateError(error.message || 'Unable to draft the document.');
+    });
+  }
+
   function renderSectionPreview(fileMeta) {
     if (!fileMeta) {
       return '<div class="editor-card"><div class="editor-card-body text-muted">No file selected.</div></div>';
@@ -9179,6 +9333,7 @@
     html += '<div><h2 style="font-weight:700;font-size:18px;margin:0">Document setup</h2>';
     html += '<div class="editor-tiny text-muted mt-1">' + (state.filename ? esc(state.filename) : 'No interview file open') + '</div></div>';
     html += '<div class="d-flex gap-2 flex-wrap">';
+    html += '<button class="btn btn-sm btn-outline-secondary" id="btn-new-template-setup"><i class="fa-solid fa-plus me-1" aria-hidden="true"></i>New template</button>';
     html += '<button class="btn btn-sm btn-outline-secondary" data-templates-mode="files"><i class="fa-solid fa-file-lines me-1" aria-hidden="true"></i>Template files</button>';
     html += '</div></div>';
     html += renderDocumentsCard();
@@ -9690,6 +9845,15 @@
       );
       return;
     }
+    if (target.id === 'btn-new-template-setup') {
+      if (!state.project) return;
+      openNewTemplateModal();
+      return;
+    }
+    if (target.id === 'new-template-create') {
+      createNewTemplate();
+      return;
+    }
     if (target.id === 'list-topics-apply') {
       applyListTopicsSelection();
       return;
@@ -9902,6 +10066,12 @@
 
     if (target.id === 'btn-new-section-file-inline') {
       if (!state.project || isInterviewView()) return;
+      // Templates are the one section where "new" is a real choice: an empty
+      // file, or a document drafted from the questions the interview asks.
+      if (state.currentView === 'templates') {
+        openNewTemplateModal();
+        return;
+      }
       var inlineNewName = window.prompt('New filename', defaultNewFilename(state.currentView));
       if (!inlineNewName) return;
       var inlineSection = getSectionFromView(state.currentView);
@@ -10621,13 +10791,24 @@
 
     if (target.id === 'draft-review-screen') {
       if (!state.project || !state.filename) return;
-      apiPost('/api/draft-review-screen', { project: state.project, filename: state.filename })
+      // Re-drafted, not appended: a second review screen next to the stale one
+      // is how these files got out of sync in the first place. The result opens
+      // in the full-YAML view so the author reads the replacement before saving.
+      apiPost('/api/draft-review-screen', { project: state.project, filename: state.filename, mode: 'sync' })
         .then(function (res) {
-          if (res.success && res.data && res.data.review_yaml) {
+          if (res.success && res.data && (res.data.full_yaml || res.data.review_yaml)) {
             state.canvasMode = 'full-yaml';
             state.fullYamlTab = 'full';
-            state.fullYamlStash.full = (state.rawYaml || '').replace(/\s*$/, '\n---\n') + res.data.review_yaml.trim() + '\n';
+            state.fullYamlStash.full = res.data.full_yaml
+              || ((state.rawYaml || '').replace(/\s*$/, '\n---\n') + res.data.review_yaml.trim() + '\n');
+            markInterviewDirty('sync-review-screen');
             renderCanvas();
+            var sources = res.data.sources || [];
+            _showSuccessBanner(
+              (res.data.replaced ? 'Review screen re-drafted from ' : 'Review screen drafted from ')
+              + (sources.length > 1 ? sources.length + ' files' : esc(sources[0] || state.filename))
+              + '. Look it over, then save.'
+            );
             return;
           }
           window.alert((res.error && res.error.message) || 'Unable to draft review screen.');
@@ -11234,6 +11415,11 @@
 
   document.addEventListener('change', function (e) {
     var target = e.target;
+    if (target.name === 'new-template-kind') {
+      setNewTemplateError('');
+      syncNewTemplateFields();
+      return;
+    }
     if (target.matches('[data-enabled-mode]')) {
       var group = target.closest('[data-enabled-group]');
       var wantsExpression = target.getAttribute('data-enabled-mode') === 'custom';

--- a/docassemble/ALWeaver/data/templates/editor.html
+++ b/docassemble/ALWeaver/data/templates/editor.html
@@ -425,6 +425,59 @@
   </div>
 </div>
 
+<!-- New template picker -->
+<div class="modal fade" id="new-template-modal" tabindex="-1" aria-labelledby="new-template-modal-title">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="new-template-modal-title">Add a template</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="form-check editor-choice-card">
+          <input class="form-check-input" type="radio" name="new-template-kind" id="new-template-kind-blank" value="blank" checked>
+          <label class="form-check-label" for="new-template-kind-blank">
+            <span class="fw-semibold">Blank template</span>
+            <span class="d-block editor-tiny text-muted">An empty file you fill in yourself. Good for a Markdown or Mako template.</span>
+          </label>
+        </div>
+        <div class="form-check editor-choice-card mt-2">
+          <input class="form-check-input" type="radio" name="new-template-kind" id="new-template-kind-report" value="variable-report">
+          <label class="form-check-label" for="new-template-kind-report">
+            <span class="fw-semibold">Variable report</span>
+            <span class="d-block editor-tiny text-muted">
+              A DOCX drafted from the questions this interview already asks, with a
+              Jinja field for every variable. The same document ALDashboard's
+              interview intake document generator produces. Useful when the answers
+              <em>are</em> the output, so there is no form to start from.
+            </span>
+          </label>
+        </div>
+        <div class="mt-3" id="new-template-blank-fields">
+          <label class="editor-tiny" for="new-template-filename">Filename</label>
+          <input class="form-control form-control-sm mt-1" id="new-template-filename" autocomplete="off">
+        </div>
+        <div class="mt-3 d-none" id="new-template-report-fields">
+          <label class="editor-tiny" for="new-template-report-title">Document title</label>
+          <input class="form-control form-control-sm mt-1" id="new-template-report-title" autocomplete="off">
+          <label class="editor-tiny mt-2" for="new-template-report-filename">Filename</label>
+          <input class="form-control form-control-sm mt-1" id="new-template-report-filename" autocomplete="off">
+          <div class="form-check mt-2">
+            <input class="form-check-input" type="checkbox" id="new-template-report-varnames">
+            <label class="form-check-label editor-tiny" for="new-template-report-varnames">Show variable names beside each label</label>
+          </div>
+          <div class="editor-tiny text-muted mt-2" id="new-template-report-sources"></div>
+        </div>
+        <div class="alert alert-danger mt-3 d-none" id="new-template-error" role="alert"></div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-sm btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-sm btn-primary" id="new-template-create">Create</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <!-- Insert Block Modal -->
 <div class="modal fade" id="insert-modal" tabindex="-1" aria-labelledby="insert-modal-title">
   <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable editor-insert-dialog">

--- a/docassemble/ALWeaver/data/templates/editor.html
+++ b/docassemble/ALWeaver/data/templates/editor.html
@@ -425,6 +425,35 @@
   </div>
 </div>
 
+<!-- Review screen sync -->
+<div class="modal fade" id="review-sync-modal" tabindex="-1" aria-labelledby="review-sync-modal-title">
+  <div class="modal-dialog modal-xl modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <div>
+          <h5 class="modal-title" id="review-sync-modal-title">Sync review screen</h5>
+          <div class="editor-tiny text-muted mt-1" id="review-sync-summary" role="status" aria-live="polite"></div>
+        </div>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="editor-tab-bar mb-2" role="tablist">
+          <button type="button" class="btn btn-primary" data-review-sync-tab="diff">What changes</button>
+          <button type="button" class="btn btn-outline-secondary" data-review-sync-tab="draft">New review screen</button>
+        </div>
+        <div id="review-sync-body"></div>
+      </div>
+      <div class="modal-footer justify-content-between">
+        <button type="button" class="btn btn-sm btn-link" id="review-sync-full-yaml">Edit the whole file instead</button>
+        <div class="d-flex gap-2">
+          <button type="button" class="btn btn-sm btn-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="button" class="btn btn-sm btn-primary" id="review-sync-apply">Replace review screen</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
 <!-- New template picker -->
 <div class="modal fade" id="new-template-modal" tabindex="-1" aria-labelledby="new-template-modal-title">
   <div class="modal-dialog modal-dialog-centered">

--- a/docassemble/ALWeaver/data/templates/output.mako
+++ b/docassemble/ALWeaver/data/templates/output.mako
@@ -453,8 +453,8 @@ event: review_${ interview.interview_label }
 question: |
   Review your answers
 review:
-  % for coll in review_collections:
-${ review_yaml(coll) | trim }\
+  % for entry in review_entries:
+${ review_yaml(entry) | trim }\
   % endfor
 % for coll in review_collections:
   % if coll.var_type == 'list':

--- a/docassemble/ALWeaver/data/templates/output_defs.mako
+++ b/docassemble/ALWeaver/data/templates/output_defs.mako
@@ -58,52 +58,32 @@
     required: False
   % endif
 </%def>\
-<%def name="review_yaml(collection)">\
-  % if collection.var_type == "list":
-  - Edit: ${ collection.var_name }.revisit
-  % else:
-  - Edit: ${ collection.var_name }
-  % endif
-    button: |
-      % if collection.var_type == "list":
-      **${ collection.var_name.capitalize().replace("_", " ") }**
+<%doc>
 
-      <%text>%</%text> for item in ${ collection.var_name }:
+    One review entry: either a bulleted summary of a list, or a screen's worth
+    of `Label: value` lines under the question that asked for them.
+
+    Every value is written so an undefined variable renders as empty. A review
+    screen that forces a definition sends the user back into the interview just
+    for looking at their answers, which is what
+    https://github.com/SuffolkLITLab/docassemble-ALWeaver/issues/482 is about.
+
+</%doc>\
+<%def name="review_yaml(entry)">\
+  - Edit: ${ entry.edit_var }
+    button: |
+      **${ entry.title }**
+  % if entry.list_var:
+
+      <%text>%</%text> for item in ${ entry.list_var }:
         * $<%text>{</%text> item }
       <%text>%</%text> endfor
-      % elif collection.var_type == "object":
-      **${ collection.var_name.capitalize().replace("_", " ") }**
-  
-      % for att, disp_set in collection.attribute_map.items():
-      <%text>%</%text> if defined("${ collection.var_name }.${ disp_set[1] }"):
-      * ${ att }: <%text>${</%text> ${ collection.var_name }.${ disp_set[0] } <%text>}</%text>
-      <%text>%</%text> endif
-      % endfor
-      % else:
-      % if hasattr(collection.fields[0], "label"):
-      **${ collection.fields[0].label }**:
-      % else:
-      **${ collection.fields[0].get_settable_var() }**:
-      % endif # has a label
-      % if hasattr(collection.fields[0], "field_type"):
-      % if collection.fields[0].field_type in ["yesno", "yesnomaybe"]:
-      <%text>${</%text> word(yesno(${ collection.full_display() })) }
-      % elif collection.fields[0].field_type in ["integer", "number", "range", "date"]:
-      <%text>${</%text> ${ collection.full_display() } }
-      % elif collection.fields[0].field_type == "area":
-      > <%text>${</%text> single_paragraph(${ collection.full_display() }) }
-      % elif collection.fields[0].field_type == "file": # add an extra newline for images
+  % else:
+    % for row in entry.rows:
 
-      <%text>${</%text> ${ collection.full_display() } }
-      % elif collection.fields[0].field_type == "currency":
-      <%text>${</%text> currency(${ collection.full_display() }) }
-      % else:
-      <%text>${</%text> ${ collection.full_display() } }
-      % endif
-      % else: # No field type
-      <%text>${</%text> ${ collection.fields[0].final_display_var } }
-      % endif # has field type
-      % endif # collection.var_type
+      ${ row.label }: <%text>${</%text> ${ row.expression } }
+    % endfor
+  % endif
 </%def>\
 <%def name="table_page(collection)">\
 ---
@@ -118,12 +98,23 @@ columns:
   - Name: |
       row_item
   % endif
-% if len(collection.attribute_map) == 0:
+<%
+    edit_attributes = table_edit_attributes(collection)
+%>\
+% if not edit_attributes:
 edit: True
 % else:
+<%doc>
+
+    Docassemble seeks every variable named under `edit:`, defining any the
+    interview never asked. One attribute per group is enough -- the screen that
+    sets `name.first` sets the rest of the name with it -- and signatures are
+    left out on purpose. See ALWeaver#482.
+
+</%doc>\
 edit:
-  % for disp_and_set in collection.attribute_map.values():
-  - ${ disp_and_set[1] }
+  % for attribute in edit_attributes:
+  - ${ attribute }
   % endfor
 % endif
 confirm: True\

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -1,6 +1,7 @@
 from .custom_values import get_matching_deps, get_output_mako_package_and_path
 from .generator_constants import generator_constants
 from .question_library import baseline_question_specs
+from .review_screen import build_review_entries, table_edit_attributes
 from .validate_template_files import matching_reserved_names, has_fields
 from collections import defaultdict
 from dataclasses import field
@@ -6720,13 +6721,17 @@ def _render_interview_yaml(
     else:
         interview_order_lines = []
 
+    review_collections = interview.all_fields.review_collections(screen_reordered)
+
     context = {
         "interview": interview,
         "objects": objects or [],
         "baseline_questions": baseline_question_specs(interview, objects or []),
         "generate_download_screen": include_download_screen,
         "screen_reordered": screen_reordered,
-        "review_collections": interview.all_fields.review_collections(screen_reordered),
+        "review_collections": review_collections,
+        "review_entries": build_review_entries(review_collections, screen_reordered),
+        "table_edit_attributes": table_edit_attributes,
         "navigation_sections": navigation_sections,
         "interview_order_lines": interview_order_lines,
         "package_version_number": __version__,

--- a/docassemble/ALWeaver/review_screen.py
+++ b/docassemble/ALWeaver/review_screen.py
@@ -1,0 +1,308 @@
+"""Build the model behind a generated interview's review screen.
+
+The Weaver used to emit one review "Edit" entry per parent collection, which
+meant one entry per variable for the many interviews whose fields are mostly
+loose primitives. ALDashboard's review screen generator groups by the question
+screen instead, which reads like a recap of the interview rather than a wall of
+single-value rows (SuffolkLITLab/docassemble-ALWeaver#865).
+
+This module holds the grouping decisions so the Mako template only has to
+render them, and so the same rules can be checked by unit tests without
+rendering a whole interview.
+
+Nothing here imports ``interview_generator``: the builders take the collection
+and screen objects that module already produces and only read attributes off
+them. That keeps the import one-directional.
+"""
+
+from dataclasses import dataclass, field as dataclass_field
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple
+
+__all__ = [
+    "ReviewEntry",
+    "ReviewRow",
+    "build_review_entries",
+    "table_edit_attributes",
+]
+
+# Attributes AssemblyLine gathers in `basic_questions_signature_flow`, right
+# before the download screen. Following up on one of these from a review table's
+# "Edit" button re-opens a signature pad the author never meant to re-ask, and
+# any answer given there is overwritten moments later
+# (SuffolkLITLab/docassemble-ALWeaver#482).
+SIGNATURE_ATTRIBUTES = {"signature", "signature_date"}
+
+# Field types the interview never asks a question for, so there is nothing for a
+# review screen to link back to.
+UNASKED_FIELD_TYPES = {"code", "skip this field"}
+
+
+@dataclass
+class ReviewRow:
+    """One ``Label: value`` line inside a review entry's button text."""
+
+    label: str
+    #: A complete Mako expression body, without the surrounding ``${ }``. It is
+    #: always written so that an undefined variable renders as empty rather than
+    #: sending the user back into the interview: a review screen should never
+    #: force the definition of a variable.
+    expression: str
+
+
+@dataclass
+class ReviewEntry:
+    """One entry in the generated ``review:`` block."""
+
+    #: The variable the "Edit" link seeks. For a list this is ``<name>.revisit``;
+    #: for a question screen it is the variable that triggers that screen.
+    edit_var: str
+    #: Bolded heading for the entry -- the question text, or the name of the
+    #: list or object being summarized.
+    title: str
+    rows: List[ReviewRow] = dataclass_field(default_factory=list)
+    #: Set for list collections, which are summarized as a bulleted loop over
+    #: the items rather than as ``Label: value`` rows.
+    list_var: Optional[str] = None
+
+
+def _humanize(var_name: str) -> str:
+    """`my_user_address` -> `My user address`, matching the old review titles."""
+    return str(var_name or "").replace("_", " ").capitalize()
+
+
+def _field_label(field: Any) -> str:
+    """The label to show for a field, falling back to its variable name."""
+    if getattr(field, "has_label", False):
+        label = str(getattr(field, "label", "") or "").strip()
+        if label:
+            return label
+    return _humanize(str(getattr(field, "final_display_var", "") or ""))
+
+
+def _is_signature_field(field: Any) -> bool:
+    if getattr(field, "group", None) is not None and (
+        getattr(getattr(field, "group", None), "value", None) == "signature"
+    ):
+        return True
+    return (
+        str(getattr(field, "final_display_var", "") or "").rsplit(".", 1)[-1]
+        in SIGNATURE_ATTRIBUTES
+    )
+
+
+def _is_asked(field: Any) -> bool:
+    field_type = getattr(field, "field_type", None)
+    return field_type not in UNASKED_FIELD_TYPES
+
+
+def _primitive_expression(field: Any) -> str:
+    """A Mako expression that shows a field's answer without demanding it.
+
+    ``showifdef()`` covers the plain cases in one short call. Anything that
+    needs a formatting function has to guard the call itself, because
+    ``currency('')`` and ``yesno('')`` would happily report a wrong answer for a
+    variable that was never asked.
+    """
+    variable = str(getattr(field, "final_display_var", "") or "")
+    field_type = getattr(field, "field_type", None)
+    if field_type in ("yesno", "yesnomaybe", "yesnoradio", "yesnowide", "noyes"):
+        return f"word(yesno({variable})) if defined('{variable}') else ''"
+    if field_type == "currency":
+        return f"currency({variable}) if defined('{variable}') else ''"
+    if field_type == "area":
+        return f"single_paragraph({variable}) if defined('{variable}') else ''"
+    return f"showifdef('{variable}')"
+
+
+def _object_rows(collection: Any) -> List[ReviewRow]:
+    """Rows for a single (non-list) object, e.g. `trial_court.address`.
+
+    ``attribute_map`` already collapses the sub-attributes of a name or an
+    address into one displayable expression, which is the "better handling of
+    common attributes" #865 asks for: one `Address:` line showing
+    `address.block()`, not six lines of street, unit, city, state, zip.
+    """
+    rows: List[ReviewRow] = []
+    var_name = str(getattr(collection, "var_name", "") or "")
+    for attribute, (display_att, settable_att) in getattr(
+        collection, "attribute_map", {}
+    ).items():
+        if attribute in SIGNATURE_ATTRIBUTES:
+            continue
+        rows.append(
+            ReviewRow(
+                label=_humanize(attribute),
+                expression=(
+                    f"{var_name}.{display_att} "
+                    f"if defined('{var_name}.{settable_att}') else ''"
+                ),
+            )
+        )
+    return rows
+
+
+def _collection_entry(collection: Any) -> Optional[ReviewEntry]:
+    """The entry for a collection whose fields no generated screen asks about.
+
+    AssemblyLine's own question library gathers things like `docket_number` and
+    `trial_court`, so those never appear on a Weaver-authored screen but still
+    belong on the review screen.
+    """
+    var_name = str(getattr(collection, "var_name", "") or "")
+    var_type = getattr(collection, "var_type", "primitive")
+    if not var_name:
+        return None
+
+    if var_type == "list":
+        return ReviewEntry(
+            edit_var=f"{var_name}.revisit",
+            title=_humanize(var_name),
+            list_var=var_name,
+        )
+
+    fields = [
+        field
+        for field in getattr(collection, "fields", [])
+        if _is_asked(field) and not _is_signature_field(field)
+    ]
+    if not fields:
+        return None
+
+    if var_type == "object":
+        rows = _object_rows(collection)
+        if not rows:
+            return None
+        return ReviewEntry(
+            edit_var=var_name,
+            title=_humanize(var_name),
+            rows=rows,
+        )
+
+    first = fields[0]
+    return ReviewEntry(
+        edit_var=str(first.get_settable_var()),
+        title=_field_label(first),
+        rows=[
+            ReviewRow(
+                label=_field_label(first), expression=_primitive_expression(first)
+            )
+        ],
+    )
+
+
+def _screen_entry(
+    screen: Any,
+    collection_for_field: Dict[int, Any],
+) -> Tuple[Optional[ReviewEntry], List[Any], List[Any]]:
+    """Summarize one question screen, and say which collections it covered.
+
+    Returns ``(entry, list_collections, covered_collections)``. Fields that
+    belong to a list are kept out of the entry -- the list gets its own revisit
+    entry instead, because an "Edit" link pointing at `users[i].name.first`
+    would edit whichever item Docassemble happened to be iterating over -- but
+    the screen is still where that list is asked about, so its collection is
+    reported back to be emitted at this position.
+    """
+    rows: List[ReviewRow] = []
+    trigger: Optional[str] = None
+    list_collections: List[Any] = []
+    covered: List[Any] = []
+    for field in getattr(screen, "field_list", []) or []:
+        collection = collection_for_field.get(id(field))
+        if collection is not None and getattr(collection, "var_type", "") == "list":
+            if collection not in list_collections:
+                list_collections.append(collection)
+            continue
+        if not _is_asked(field) or _is_signature_field(field):
+            continue
+        if collection is not None and collection not in covered:
+            covered.append(collection)
+        if trigger is None:
+            trigger = str(field.get_settable_var())
+        rows.append(
+            ReviewRow(
+                label=_field_label(field), expression=_primitive_expression(field)
+            )
+        )
+
+    if trigger is None or not rows:
+        return None, list_collections, covered
+
+    title = " ".join(str(getattr(screen, "question_text", "") or "").split())
+    entry = ReviewEntry(edit_var=trigger, title=title or _humanize(trigger), rows=rows)
+    return entry, list_collections, covered
+
+
+def build_review_entries(
+    collections: Sequence[Any],
+    screens: Optional[Iterable[Any]] = None,
+) -> List[ReviewEntry]:
+    """Group the review screen by question screen, in the order they are asked.
+
+    ``collections`` is the output of ``DAFieldList.review_collections()`` --
+    already filtered and sorted -- and ``screens`` is the interview's draft
+    screen order. Every collection ends up in exactly one entry: a list keeps
+    its own revisit entry, a collection asked on a screen is folded into that
+    screen's entry, and anything left over (AssemblyLine's built-in questions)
+    gets an entry of its own at the position the collection ordering gives it.
+    """
+    collection_for_field: Dict[int, Any] = {}
+    for collection in collections:
+        for field in getattr(collection, "fields", []):
+            collection_for_field.setdefault(id(field), collection)
+
+    entries: List[ReviewEntry] = []
+    emitted: Set[str] = set()
+
+    def emit_collection(collection: Any) -> None:
+        var_name = str(getattr(collection, "var_name", "") or "")
+        if not var_name or var_name in emitted:
+            return
+        entry = _collection_entry(collection)
+        emitted.add(var_name)
+        if entry is not None:
+            entries.append(entry)
+
+    for screen in screens or []:
+        if getattr(screen, "field_list", None) is not None:
+            entry, list_collections, covered = _screen_entry(
+                screen, collection_for_field
+            )
+            for collection in list_collections:
+                emit_collection(collection)
+            for collection in covered:
+                emitted.add(str(getattr(collection, "var_name", "")))
+            if entry is not None:
+                entries.append(entry)
+            continue
+        # A bare field in the screen order: Docassemble asks for it through
+        # AssemblyLine's question library, so review it as its own collection.
+        collection = collection_for_field.get(id(screen))
+        if collection is not None:
+            emit_collection(collection)
+
+    for collection in collections:
+        emit_collection(collection)
+
+    return entries
+
+
+def table_edit_attributes(collection: Any) -> List[str]:
+    """The attributes a list's revisit table should let the user edit.
+
+    Docassemble turns `edit:` into a "follow up" list, and it seeks *every*
+    variable named there, defining any that the interview never asked. Listing
+    a signature that way sends the user to a signature pad they did not ask for
+    and that the signature flow overwrites anyway, so signatures stay out
+    (SuffolkLITLab/docassemble-ALWeaver#482). One attribute per group is enough:
+    the screen that sets `name.first` sets the rest of the name with it.
+    """
+    attributes: List[str] = []
+    for attribute, (_display_att, settable_att) in getattr(
+        collection, "attribute_map", {}
+    ).items():
+        if attribute in SIGNATURE_ATTRIBUTES:
+            continue
+        if settable_att and settable_att not in attributes:
+            attributes.append(settable_att)
+    return attributes

--- a/docassemble/ALWeaver/review_screen_sync.py
+++ b/docassemble/ALWeaver/review_screen_sync.py
@@ -25,11 +25,14 @@ What this module adds on top of the Dashboard's generator:
 """
 
 import re
-from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union
 
 __all__ = [
     "ALDashboardUnavailable",
+    "carry_over_unmatched_entries",
     "collect_interview_yaml_texts",
+    "ensure_revisit_tables",
+    "inferred_objects_document",
     "generate_review_screen_yaml",
     "interview_scope",
     "project_include_chain",
@@ -283,34 +286,235 @@ def review_screen_identity(source_yaml: str) -> Dict[str, Any]:
     return {"found": False}
 
 
-def _generated_list_names(review_yaml: str) -> Set[str]:
+def _generated_tables(yaml_text: str) -> Set[str]:
+    """Lists that ``yaml_text`` defines a `<name>.table` block for."""
     names: Set[str] = set()
-    for document in _documents(review_yaml):
+    for document in _documents(yaml_text):
         parsed = _parsed(document["text"])
         if parsed is None:
             continue
         name = _list_name(parsed.get("table"), ".table")
         if name:
             names.add(name)
+    return names
+
+
+def _generated_revisits(yaml_text: str) -> Set[str]:
+    """Lists that ``yaml_text`` defines a `<name>.revisit` screen for."""
+    names: Set[str] = set()
+    for document in _documents(yaml_text):
+        parsed = _parsed(document["text"])
+        if parsed is None or "review" in parsed:
+            continue
         name = _list_name(parsed.get("continue button field"), ".revisit")
         if name:
             names.add(name)
     return names
 
 
+def _declared_object_names(yaml_texts: Sequence[str]) -> Set[str]:
+    """Every object named in an `objects:` block anywhere in scope."""
+    names: Set[str] = set()
+    for text in yaml_texts:
+        for document in _documents(str(text or "")):
+            parsed = _parsed(document["text"])
+            if parsed is None:
+                continue
+            objects = parsed.get("objects")
+            if isinstance(objects, dict):
+                names.update(str(key) for key in objects)
+            elif isinstance(objects, list):
+                for entry in objects:
+                    if isinstance(entry, dict):
+                        names.update(str(key) for key in entry)
+    return names
+
+
+def _reviewed_list_names(source_yaml: str) -> List[str]:
+    """Lists the file already treats as reviewable, in the order they appear.
+
+    A `table: plaintiffs.table` block, or a review entry pointing at
+    `plaintiffs.revisit`, is the interview saying "this is a list people edit
+    from the review screen" just as clearly as an `objects:` block does.
+    """
+    names: List[str] = []
+
+    def remember(name: Optional[str]) -> None:
+        if name and name not in names and not any(c in name for c in ".[]"):
+            names.append(name)
+
+    for document in _documents(source_yaml):
+        parsed = _parsed(document["text"])
+        if parsed is None:
+            continue
+        remember(_list_name(parsed.get("table"), ".table"))
+        remember(_list_name(parsed.get("continue button field"), ".revisit"))
+        review = parsed.get("review")
+        if isinstance(review, list):
+            for entry in review:
+                if isinstance(entry, dict):
+                    remember(_list_name(entry.get("Edit"), ".revisit"))
+    return names
+
+
+def inferred_objects_document(yaml_texts: Sequence[str]) -> Optional[str]:
+    """An `objects:` document for reviewable lists nothing in scope declares.
+
+    AssemblyLine declares `plaintiffs`, `defendants` and `courts` in its own
+    package, which the include walk deliberately does not follow -- an author
+    cannot edit those files from here. Without this, drafting over a
+    Weaver-generated interview silently drops the review entries for exactly
+    those lists, because the generator only knows about a list it has seen an
+    `objects:` block for.
+
+    The class name is a stand-in: it never reaches the file, and the generator
+    only asks whether the type looks like a list.
+    """
+    declared = _declared_object_names(yaml_texts)
+    reviewed: List[str] = []
+    for text in yaml_texts:
+        for name in _reviewed_list_names(str(text or "")):
+            if name not in reviewed:
+                reviewed.append(name)
+    missing = [name for name in reviewed if name not in declared]
+    if not missing:
+        return None
+    lines = ["objects:"]
+    lines.extend(f"  - {name}: DAList" for name in missing)
+    return "\n".join(lines) + "\n"
+
+
+def _round_trip_yaml():
+    from ruamel.yaml import YAML
+
+    yaml = YAML()
+    yaml.default_flow_style = False
+    yaml.indent(mapping=2, sequence=4, offset=2)
+    yaml.width = 4096
+    yaml.preserve_quotes = True
+    return yaml
+
+
+def carry_over_unmatched_entries(review_yaml: str, source_yaml: str) -> Tuple[str, int]:
+    """Keep review entries the draft has no opinion about.
+
+    Drafting reads the interview's YAML, so it only knows about variables this
+    project asks for. `docket_number` and the rest of AssemblyLine's built-in
+    questions live in a package the walk does not follow, and dropping their
+    entries would quietly shrink the review screen every time it is synced --
+    which is worse than carrying a stale entry the author can see in the diff
+    and delete.
+
+    Entries are matched by their "Edit" target. A `note:` separator is not
+    carried over: the draft regenerates the entries it labelled, so it would
+    arrive as a heading with nothing under it.
+
+    Returns the new draft and how many entries were kept.
+    """
+    from ruamel.yaml.compat import StringIO
+
+    yaml = _round_trip_yaml()
+    try:
+        draft_documents = list(yaml.load_all(review_yaml))
+        source_documents = list(yaml.load_all(source_yaml))
+    except Exception:
+        return review_yaml, 0
+
+    draft_review = None
+    for document in draft_documents:
+        if isinstance(document, dict) and isinstance(document.get("review"), list):
+            draft_review = document["review"]
+            break
+    if draft_review is None:
+        return review_yaml, 0
+
+    drafted_targets = {
+        str(entry.get("Edit"))
+        for entry in draft_review
+        if isinstance(entry, dict) and entry.get("Edit") is not None
+    }
+
+    kept = 0
+    for document in source_documents:
+        if not isinstance(document, dict) or not isinstance(
+            document.get("review"), list
+        ):
+            continue
+        for entry in document["review"]:
+            if not isinstance(entry, dict):
+                continue
+            target = entry.get("Edit")
+            if target is None or str(target) in drafted_targets:
+                continue
+            draft_review.append(entry)
+            drafted_targets.add(str(target))
+            kept += 1
+        break
+
+    if not kept:
+        return review_yaml, 0
+
+    stream = StringIO()
+    yaml.dump_all(draft_documents, stream)
+    return stream.getvalue(), kept
+
+
+_FALLBACK_TABLE = """table: {name}.table
+rows: {name}
+columns:
+  - Name: |
+      row_item
+edit: True
+confirm: True
+"""
+
+
+def ensure_revisit_tables(
+    review_yaml: str, existing_yaml: Union[str, Sequence[str]] = ""
+) -> str:
+    """Give every drafted revisit screen a table to show.
+
+    A revisit screen's whole body is `${{ <list>.table }}`, so one without a
+    matching `table:` block is a screen that errors the moment somebody opens
+    it. The generator omits the table when it never saw an indexed field for
+    that list, and the file being synced may not have one either.
+    """
+    if isinstance(existing_yaml, str):
+        existing_texts: Sequence[str] = [existing_yaml]
+    else:
+        existing_texts = list(existing_yaml)
+    revisits = _generated_revisits(review_yaml)
+    have = _generated_tables(review_yaml)
+    # Every file in scope counts: in a project that keeps its review screen in
+    # its own file, the table it displays is very often defined in another one,
+    # and adding a second definition here would shadow it.
+    for text in existing_texts:
+        have |= _generated_tables(str(text or ""))
+    missing = sorted(revisits - have)
+    if not missing:
+        return review_yaml
+    parts = [review_yaml.rstrip("\n")]
+    parts.extend(_FALLBACK_TABLE.format(name=name).rstrip("\n") for name in missing)
+    return "\n---\n".join(parts) + "\n"
+
+
 def sync_review_screen(source_yaml: str, review_yaml: str) -> Tuple[str, bool]:
     """Put ``review_yaml`` where the file's current review screen is.
 
     The review block is replaced in place, along with the revisit screens and
-    tables for the lists the new draft also covers -- those are regenerated, so
-    leaving the old copies behind would define the same table twice. A revisit
-    screen for a list the new draft says nothing about is left alone: the author
-    wrote it, not the Weaver.
+    tables the new draft actually regenerates -- leaving those behind would
+    define the same block twice. Anything the draft does not regenerate is left
+    alone: the author wrote it, not the Weaver, and a table the draft has no
+    replacement for is still the one its revisit screen displays.
 
     Returns the new source and whether an existing review screen was replaced;
     when there was none, the draft is appended.
     """
-    regenerated = _generated_list_names(review_yaml)
+    # Tracked apart on purpose. A draft can regenerate a list's revisit screen
+    # without regenerating its table, and dropping the table anyway leaves the
+    # new screen pointing at a `${ <list>.table }` that no longer exists.
+    regenerated_tables = _generated_tables(review_yaml)
+    regenerated_revisits = _generated_revisits(review_yaml)
     documents = _documents(source_yaml)
 
     review_index: Optional[int] = None
@@ -325,11 +529,11 @@ def sync_review_screen(source_yaml: str, review_yaml: str) -> Tuple[str, bool]:
             drop.add(index)
             continue
         name = _list_name(parsed.get("table"), ".table")
-        if name and name in regenerated:
+        if name and name in regenerated_tables:
             drop.add(index)
             continue
         name = _list_name(parsed.get("continue button field"), ".revisit")
-        if name and name in regenerated and "review" not in parsed:
+        if name and name in regenerated_revisits:
             drop.add(index)
 
     block = review_yaml.strip("\n")
@@ -371,9 +575,12 @@ def _apply_identity(
 
     from ruamel.yaml import YAML
     from ruamel.yaml.compat import StringIO
+    from ruamel.yaml.scalarstring import LiteralScalarString
 
     yaml = YAML()
     yaml.default_flow_style = False
+    yaml.indent(mapping=2, sequence=4, offset=2)
+    yaml.width = 4096
     documents = list(yaml.load_all(review_yaml))
     for document in documents:
         if not isinstance(document, dict) or "review" not in document:
@@ -383,7 +590,12 @@ def _apply_identity(
         if event_name:
             document["event"] = event_name
         if question_text:
-            document["question"] = question_text
+            # A literal block, not the quoted scalar with an escaped newline
+            # ruamel would otherwise write: this is going back into a file an
+            # author reads.
+            document["question"] = LiteralScalarString(
+                str(question_text).rstrip("\n") + "\n"
+            )
         break
     stream = StringIO()
     yaml.dump_all(documents, stream)

--- a/docassemble/ALWeaver/review_screen_sync.py
+++ b/docassemble/ALWeaver/review_screen_sync.py
@@ -1,0 +1,451 @@
+"""Regenerate an interview's review screen from the YAML it has today.
+
+A Weaver-drafted review screen is only correct on the day it is drafted. Authors
+add screens, rename variables and split files, and the review screen quietly
+falls behind, because nothing regenerates it
+(SuffolkLITLab/docassemble-ALWeaver#865, and the same complaint in #400).
+
+The generation itself is ALDashboard's ``review_screen_generator``, imported at
+runtime: it already reads finished YAML rather than the Weaver's in-memory field
+model, which is exactly what re-syncing needs, and keeping one implementation
+means the Dashboard's "Generate a review screen draft" tool and this one cannot
+drift. ALDashboard is an optional dependency here -- the Weaver's own linting
+integration treats it the same way -- so callers get a clear message rather than
+a traceback when it is not installed.
+
+What this module adds on top of the Dashboard's generator:
+
+* the whole interview, not one file: `include:` directives inside the project
+  are followed so variables asked in an included file are reviewed too;
+* the interview's own identity: the drafted block keeps the `id`, `event` and
+  `question` the interview already uses, so the download screen's "Edit answers"
+  button and the navigation still point at it;
+* a real sync: the old review block, revisit screens and tables are replaced in
+  place instead of a second review screen being appended.
+"""
+
+import re
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
+
+__all__ = [
+    "ALDashboardUnavailable",
+    "collect_interview_yaml_texts",
+    "generate_review_screen_yaml",
+    "interview_scope",
+    "project_include_chain",
+    "review_screen_identity",
+    "sync_review_screen",
+]
+
+# An interview that includes more than this many project files is either a
+# mistake or a cycle we failed to spot; either way, stop walking.
+MAX_INCLUDED_FILES = 40
+
+_DOCUMENT_SEPARATOR_RE = re.compile(r"(?m)^---[ \t]*(?:#[^\r\n]*)?(?:\r\n|\n|\r|$)")
+
+
+class ALDashboardUnavailable(RuntimeError):
+    """Raised when the ALDashboard package needed for generation is missing."""
+
+
+def _load_dashboard_generator():
+    try:
+        from docassemble.ALDashboard.review_screen_generator import (  # type: ignore
+            generate_review_screen_yaml as dashboard_generate,
+        )
+    except Exception as err:  # pragma: no cover - depends on the server's packages
+        raise ALDashboardUnavailable(
+            "Drafting a review screen needs the ALDashboard package. Install "
+            "docassemble.ALDashboard on this server and try again."
+        ) from err
+    return dashboard_generate
+
+
+# ---------------------------------------------------------------------------
+# Walking the interview's files
+# ---------------------------------------------------------------------------
+
+
+def _include_targets(yaml_text: str) -> List[str]:
+    """Project-local files named by `include:` blocks, in the order listed.
+
+    Only bare filenames count. `docassemble.AssemblyLine:assembly_line.yml`
+    names another package, whose questions the author cannot edit here and whose
+    review entries AssemblyLine supplies itself.
+    """
+    import yaml as pyyaml
+
+    targets: List[str] = []
+    try:
+        documents = list(pyyaml.safe_load_all(yaml_text))
+    except pyyaml.YAMLError:
+        return targets
+    for document in documents:
+        if not isinstance(document, dict):
+            continue
+        included = document.get("include")
+        if isinstance(included, str):
+            included = [included]
+        if not isinstance(included, list):
+            continue
+        for entry in included:
+            name = str(entry or "").strip()
+            if not name or ":" in name or "/" in name or "\\" in name:
+                continue
+            if not name.lower().endswith((".yml", ".yaml")):
+                continue
+            if name not in targets:
+                targets.append(name)
+    return targets
+
+
+def project_include_chain(
+    read_file, filename: str, *, max_files: int = MAX_INCLUDED_FILES
+) -> List[str]:
+    """Every project YAML file the interview pulls in, starting with itself.
+
+    ``read_file`` takes a filename and returns its text. Files that cannot be
+    read are skipped: an interview that includes a file from a package we cannot
+    see should still get a review screen for the parts we can.
+    """
+    ordered: List[str] = []
+    seen: Set[str] = set()
+    queue: List[str] = [filename]
+    while queue and len(ordered) < max_files:
+        current = queue.pop(0)
+        if current in seen:
+            continue
+        seen.add(current)
+        try:
+            text = read_file(current)
+        except Exception:
+            continue
+        ordered.append(current)
+        for target in _include_targets(text):
+            if target not in seen:
+                queue.append(target)
+    return ordered
+
+
+def interview_scope(
+    read_file,
+    filename: str,
+    project_filenames: Optional[Sequence[str]] = None,
+    *,
+    max_files: int = MAX_INCLUDED_FILES,
+) -> Tuple[List[str], List[str]]:
+    """Work out which files make up the interview a review screen belongs to.
+
+    Review screens are very often kept in a file of their own -- `review.yml`,
+    `review_page.yml`, `review_screens.yml` -- that includes nothing and is
+    included *by* the interviews that use it. Drafting from that file alone
+    finds no questions at all, so the walk has to go up the include graph as
+    well as down: the scope is every file reachable from the root interviews
+    that pull this one in.
+
+    A review screen shared by several interviews is scoped to all of them,
+    which is what its author has to cover anyway.
+
+    Returns ``(roots, filenames)``. ``roots`` is empty when the file is its own
+    interview, in which case the scope is just its own include chain.
+    """
+    own_chain = project_include_chain(read_file, filename, max_files=max_files)
+    candidates = [str(name) for name in (project_filenames or []) if name]
+    if not candidates:
+        return [], own_chain
+
+    # Every candidate's chain is walked, so each file is read once and kept.
+    texts: Dict[str, Any] = {}
+
+    def cached_read(name: str) -> str:
+        if name not in texts:
+            try:
+                texts[name] = read_file(name)
+            except Exception as err:
+                texts[name] = err
+        value = texts[name]
+        if isinstance(value, Exception):
+            raise value
+        return str(value)
+
+    cache: Dict[str, List[str]] = {}
+    for name in candidates:
+        cache[name] = project_include_chain(cached_read, name, max_files=max_files)
+    cache.setdefault(filename, own_chain)
+
+    included_by_something: Set[str] = set()
+    for name, chain in cache.items():
+        included_by_something.update(chain[1:])
+
+    roots = [
+        name
+        for name in candidates
+        if name not in included_by_something and filename in cache.get(name, [])
+    ]
+    if not roots:
+        return [], own_chain
+
+    ordered: List[str] = []
+    for root in roots:
+        for name in cache[root]:
+            if name not in ordered:
+                ordered.append(name)
+    return roots, ordered[:max_files]
+
+
+def collect_interview_yaml_texts(
+    read_file,
+    filename: str,
+    project_filenames: Optional[Sequence[str]] = None,
+    *,
+    max_files: int = MAX_INCLUDED_FILES,
+) -> Tuple[List[str], List[str]]:
+    """Return ``(filenames, yaml_texts)`` for the whole interview."""
+    _roots, filenames = interview_scope(
+        read_file, filename, project_filenames, max_files=max_files
+    )
+    texts: List[str] = []
+    kept: List[str] = []
+    for name in filenames:
+        try:
+            texts.append(read_file(name))
+            kept.append(name)
+        except Exception:
+            continue
+    return kept, texts
+
+
+# ---------------------------------------------------------------------------
+# Reading and splicing documents
+# ---------------------------------------------------------------------------
+
+
+def _documents(source: str) -> List[Dict[str, Any]]:
+    """Character ranges for each YAML document, including its `---` separator.
+
+    Concatenating ``source[doc["sep_start"]:doc["end"]]`` for every document
+    reproduces the file exactly, so dropping a document is a pure deletion and
+    everything else keeps its original formatting.
+    """
+    documents: List[Dict[str, Any]] = []
+    separator_start = 0
+    body_start = 0
+    for match in _DOCUMENT_SEPARATOR_RE.finditer(source):
+        documents.append(
+            {"sep_start": separator_start, "start": body_start, "end": match.start()}
+        )
+        separator_start = match.start()
+        body_start = match.end()
+    documents.append(
+        {"sep_start": separator_start, "start": body_start, "end": len(source)}
+    )
+    for document in documents:
+        document["text"] = source[document["start"] : document["end"]]
+    return documents
+
+
+def _parsed(document_text: str) -> Optional[Dict[str, Any]]:
+    import yaml as pyyaml
+
+    if not document_text.strip():
+        return None
+    try:
+        parsed = pyyaml.safe_load(document_text)
+    except pyyaml.YAMLError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _list_name(value: Any, suffix: str) -> Optional[str]:
+    text = str(value or "").strip()
+    if text.endswith(suffix):
+        name = text[: -len(suffix)]
+        return name or None
+    return None
+
+
+def review_screen_identity(source_yaml: str) -> Dict[str, Any]:
+    """The `id`, `event` and `question` of the review screen already in a file.
+
+    Returned empty when the file has no review block yet, in which case the
+    caller is drafting rather than syncing.
+    """
+    for document in _documents(source_yaml):
+        parsed = _parsed(document["text"])
+        if parsed is None or "review" not in parsed:
+            continue
+        return {
+            "id": parsed.get("id"),
+            "event": parsed.get("event"),
+            "question": parsed.get("question"),
+            "found": True,
+        }
+    return {"found": False}
+
+
+def _generated_list_names(review_yaml: str) -> Set[str]:
+    names: Set[str] = set()
+    for document in _documents(review_yaml):
+        parsed = _parsed(document["text"])
+        if parsed is None:
+            continue
+        name = _list_name(parsed.get("table"), ".table")
+        if name:
+            names.add(name)
+        name = _list_name(parsed.get("continue button field"), ".revisit")
+        if name:
+            names.add(name)
+    return names
+
+
+def sync_review_screen(source_yaml: str, review_yaml: str) -> Tuple[str, bool]:
+    """Put ``review_yaml`` where the file's current review screen is.
+
+    The review block is replaced in place, along with the revisit screens and
+    tables for the lists the new draft also covers -- those are regenerated, so
+    leaving the old copies behind would define the same table twice. A revisit
+    screen for a list the new draft says nothing about is left alone: the author
+    wrote it, not the Weaver.
+
+    Returns the new source and whether an existing review screen was replaced;
+    when there was none, the draft is appended.
+    """
+    regenerated = _generated_list_names(review_yaml)
+    documents = _documents(source_yaml)
+
+    review_index: Optional[int] = None
+    drop: Set[int] = set()
+    for index, document in enumerate(documents):
+        parsed = _parsed(document["text"])
+        if parsed is None:
+            continue
+        if "review" in parsed:
+            if review_index is None:
+                review_index = index
+            drop.add(index)
+            continue
+        name = _list_name(parsed.get("table"), ".table")
+        if name and name in regenerated:
+            drop.add(index)
+            continue
+        name = _list_name(parsed.get("continue button field"), ".revisit")
+        if name and name in regenerated and "review" not in parsed:
+            drop.add(index)
+
+    block = review_yaml.strip("\n")
+    if review_index is None:
+        joined = source_yaml.rstrip("\n")
+        return f"{joined}\n---\n{block}\n", False
+
+    parts: List[str] = []
+    for index, document in enumerate(documents):
+        if index in drop:
+            if index == review_index:
+                parts.append(f"\n---\n{block}\n")
+            continue
+        parts.append(source_yaml[document["sep_start"] : document["end"]])
+    return "".join(parts).lstrip("\n"), True
+
+
+# ---------------------------------------------------------------------------
+# Generation
+# ---------------------------------------------------------------------------
+
+
+def _apply_identity(
+    review_yaml: str,
+    *,
+    screen_id: Optional[str],
+    event_name: Optional[str],
+    question_text: Optional[str],
+) -> str:
+    """Give the drafted review block the interview's own id, event and heading.
+
+    ALDashboard's generator names its screen `review_form`, which is right for a
+    standalone draft and wrong for an interview whose download screen already
+    links to `review_<label>`. Newer Dashboard versions take these as arguments;
+    this rewrite keeps the feature working against the released ones.
+    """
+    if not any([screen_id, event_name, question_text]):
+        return review_yaml
+
+    from ruamel.yaml import YAML
+    from ruamel.yaml.compat import StringIO
+
+    yaml = YAML()
+    yaml.default_flow_style = False
+    documents = list(yaml.load_all(review_yaml))
+    for document in documents:
+        if not isinstance(document, dict) or "review" not in document:
+            continue
+        if screen_id:
+            document["id"] = screen_id
+        if event_name:
+            document["event"] = event_name
+        if question_text:
+            document["question"] = question_text
+        break
+    stream = StringIO()
+    yaml.dump_all(documents, stream)
+    return stream.getvalue()
+
+
+def generate_review_screen_yaml(
+    yaml_texts: Sequence[str],
+    *,
+    screen_id: Optional[str] = None,
+    event_name: Optional[str] = None,
+    question_text: Optional[str] = None,
+) -> str:
+    """Draft review-screen YAML for a whole interview.
+
+    Raises ``ALDashboardUnavailable`` when the Dashboard package is not
+    installed on this server.
+    """
+    dashboard_generate = _load_dashboard_generator()
+    texts = [str(text or "") for text in yaml_texts if str(text or "").strip()]
+    if not texts:
+        raise ValueError("There is no YAML to draft a review screen from.")
+
+    kwargs: Dict[str, Any] = {
+        "build_revisit_blocks": True,
+        # The Weaver's `sections:` are navigation headings, not events. Pointing
+        # each one at the review screen would replace the interview's navigation
+        # with a set of jumps to the recap.
+        "point_sections_to_review": False,
+    }
+    supported = _supported_dashboard_kwargs(dashboard_generate)
+    passthrough = {
+        "review_id": screen_id,
+        "review_event_name": event_name,
+        "review_question": question_text,
+    }
+    handled_locally = False
+    for name, value in passthrough.items():
+        if value is None:
+            continue
+        if name in supported:
+            kwargs[name] = value
+        else:
+            handled_locally = True
+
+    review_yaml = dashboard_generate(texts, **kwargs)
+    if handled_locally:
+        review_yaml = _apply_identity(
+            review_yaml,
+            screen_id=screen_id if "review_id" not in supported else None,
+            event_name=event_name if "review_event_name" not in supported else None,
+            question_text=(
+                question_text if "review_question" not in supported else None
+            ),
+        )
+    return review_yaml
+
+
+def _supported_dashboard_kwargs(dashboard_generate) -> Set[str]:
+    import inspect
+
+    try:
+        return set(inspect.signature(dashboard_generate).parameters)
+    except (TypeError, ValueError):  # pragma: no cover - builtins only
+        return set()

--- a/docassemble/ALWeaver/test_editor_api.py
+++ b/docassemble/ALWeaver/test_editor_api.py
@@ -2076,6 +2076,16 @@ class TestEditorReviewScreenAndTemplateApi(unittest.TestCase):
         self.assertNotIn("Edit: old_variable", data["full_yaml"])
         self.assertIn("id: download", data["full_yaml"])
 
+        # The drafted block alone does not show what the sync will do to the
+        # file, so the response carries the diff the confirmation reads from.
+        self.assertIn("- Edit: old_variable", data["diff"]["diff"])
+        self.assertIn("+  - Edit: rent_amount", data["diff"]["diff"])
+        self.assertFalse(data["diff"]["truncated"])
+        self.assertGreater(data["diff"]["added"], 0)
+        self.assertGreater(data["diff"]["removed"], 0)
+        self.assertFalse(data["unchanged"])
+        self.assertTrue(data["revision"])
+
     def test_a_missing_dashboard_is_a_503_with_something_to_do_about_it(self):
         files = self._files()
 

--- a/docassemble/ALWeaver/test_editor_api.py
+++ b/docassemble/ALWeaver/test_editor_api.py
@@ -2019,6 +2019,37 @@ class TestEditorBlockPayloadValidation(unittest.TestCase):
                     self.accepts(payload)
 
 
+class TestOrderBlockLookup(unittest.TestCase):
+    """`order_blocks` holds document indices, not positions in `blocks`."""
+
+    def test_an_order_block_in_the_last_document_is_found(self):
+        # Every file that opens with `---` has an empty first document, so the
+        # two numberings differ by one; reading an index as a position raised
+        # IndexError as soon as the order block was last.
+        model = {
+            "blocks": [
+                {"id": "meta", "index": 1, "data": {"metadata": {}}},
+                {"id": "inc", "index": 2, "data": {"include": ["questions.yml"]}},
+                {"id": "order", "index": 3, "data": {"code": "rent_amount\n"}},
+            ],
+            "order_blocks": [3],
+        }
+        order_step_map, _steps = api_editor._order_steps_from_model(model)
+        self.assertEqual(list(order_step_map), ["order"])
+
+    def test_the_right_block_is_read_when_documents_are_skipped(self):
+        model = {
+            "blocks": [
+                {"id": "meta", "index": 1, "data": {"metadata": {}}},
+                {"id": "order", "index": 2, "data": {"code": "rent_amount\n"}},
+                {"id": "q", "index": 3, "data": {"question": "Hi"}},
+            ],
+            "order_blocks": [2],
+        }
+        order_step_map, _steps = api_editor._order_steps_from_model(model)
+        self.assertEqual(list(order_step_map), ["order"])
+
+
 class TestEditorReviewScreenAndTemplateApi(unittest.TestCase):
     """The two endpoints that lean on ALDashboard at runtime."""
 
@@ -2073,16 +2104,19 @@ class TestEditorReviewScreenAndTemplateApi(unittest.TestCase):
         self.assertEqual(seen["screen_id"], "my review screen")
         self.assertTrue(data["replaced"])
         self.assertIn("Edit: rent_amount", data["full_yaml"])
-        self.assertNotIn("Edit: old_variable", data["full_yaml"])
         self.assertIn("id: download", data["full_yaml"])
+
+        # An entry the draft has no opinion about is carried over rather than
+        # dropped: AssemblyLine asks for plenty this generator cannot see, and
+        # a review screen that shrinks on every sync is the worse failure.
+        self.assertIn("Edit: old_variable", data["full_yaml"])
+        self.assertEqual(data["kept_entries"], 1)
 
         # The drafted block alone does not show what the sync will do to the
         # file, so the response carries the diff the confirmation reads from.
-        self.assertIn("- Edit: old_variable", data["diff"]["diff"])
         self.assertIn("+  - Edit: rent_amount", data["diff"]["diff"])
         self.assertFalse(data["diff"]["truncated"])
         self.assertGreater(data["diff"]["added"], 0)
-        self.assertGreater(data["diff"]["removed"], 0)
         self.assertFalse(data["unchanged"])
         self.assertTrue(data["revision"])
 

--- a/docassemble/ALWeaver/test_editor_api.py
+++ b/docassemble/ALWeaver/test_editor_api.py
@@ -7,8 +7,10 @@ import os
 import importlib
 import importlib.util
 import sys
+import tempfile
 import types
 import unittest
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from flask import Flask, jsonify
@@ -2015,6 +2017,183 @@ class TestEditorBlockPayloadValidation(unittest.TestCase):
             with self.subTest(payload=payload):
                 with self.assertRaises(ValueError):
                     self.accepts(payload)
+
+
+class TestEditorReviewScreenAndTemplateApi(unittest.TestCase):
+    """The two endpoints that lean on ALDashboard at runtime."""
+
+    INTERVIEW = (
+        "---\ninclude:\n  - questions.yml\n"
+        "---\nid: my review screen\nevent: review_my_form\n"
+        "question: |\n  Check your answers\nreview:\n  - Edit: old_variable\n"
+        "    button: |\n      **Old**\n"
+        "---\nid: download\nevent: my_form_download\nquestion: |\n  Done\n"
+    )
+    QUESTIONS = "---\nid: q\nquestion: |\n  Q\nfields:\n  - Rent: rent_amount\n"
+
+    def _files(self):
+        return {"main.yml": self.INTERVIEW, "questions.yml": self.QUESTIONS}
+
+    def test_sync_reads_the_whole_include_chain_and_replaces_in_place(self):
+        files = self._files()
+        seen = {}
+
+        def fake_generate(yaml_texts, **kwargs):
+            seen["count"] = len(yaml_texts)
+            seen.update(kwargs)
+            return (
+                "id: my review screen\nevent: review_my_form\n"
+                "question: |\n  Check your answers\nreview:\n"
+                "  - Edit: rent_amount\n    button: |\n      **Rent**\n"
+            )
+
+        with (
+            patch.object(api_editor, "_editor_auth_check", return_value=True),
+            patch.object(api_editor, "_current_user_id", return_value=7),
+            patch.object(
+                api_editor,
+                "playground_read_yaml",
+                side_effect=lambda uid, project, filename: files[filename],
+            ),
+            patch.object(api_editor, "generate_review_screen_yaml", fake_generate),
+        ):
+            with api_editor.app.test_request_context(
+                "/al/editor/api/draft-review-screen",
+                method="POST",
+                json={"project": "default", "filename": "main.yml", "mode": "sync"},
+            ):
+                response = api_editor.editor_api_draft_review_screen()
+
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()["data"]
+        self.assertEqual(data["sources"], ["main.yml", "questions.yml"])
+        self.assertEqual(seen["count"], 2)
+        # The drafted screen keeps the identity the interview already links to.
+        self.assertEqual(seen["event_name"], "review_my_form")
+        self.assertEqual(seen["screen_id"], "my review screen")
+        self.assertTrue(data["replaced"])
+        self.assertIn("Edit: rent_amount", data["full_yaml"])
+        self.assertNotIn("Edit: old_variable", data["full_yaml"])
+        self.assertIn("id: download", data["full_yaml"])
+
+    def test_a_missing_dashboard_is_a_503_with_something_to_do_about_it(self):
+        files = self._files()
+
+        def unavailable(*args, **kwargs):
+            raise api_editor.ALDashboardUnavailable("Install docassemble.ALDashboard")
+
+        with (
+            patch.object(api_editor, "_editor_auth_check", return_value=True),
+            patch.object(api_editor, "_current_user_id", return_value=7),
+            patch.object(
+                api_editor,
+                "playground_read_yaml",
+                side_effect=lambda uid, project, filename: files[filename],
+            ),
+            patch.object(api_editor, "generate_review_screen_yaml", unavailable),
+        ):
+            with api_editor.app.test_request_context(
+                "/al/editor/api/draft-review-screen",
+                method="POST",
+                json={"project": "default", "filename": "main.yml"},
+            ):
+                response = api_editor.editor_api_draft_review_screen()
+
+        self.assertEqual(response.status_code, 503)
+        self.assertIn("ALDashboard", response.get_json()["error"]["message"])
+
+    def test_a_variable_report_lands_in_the_projects_templates_folder(self):
+        files = self._files()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            written = {}
+
+            def fake_write(yaml_texts, output_path, **kwargs):
+                written["path"] = output_path
+                written["title"] = kwargs.get("report_title")
+                with open(output_path, "wb") as handle:
+                    handle.write(b"docx")
+                return {
+                    "variables_count": 4,
+                    "list_count": 1,
+                    "scalar_count": 3,
+                    "size": 4,
+                }
+
+            with (
+                patch.object(api_editor, "_editor_auth_check", return_value=True),
+                patch.object(api_editor, "_current_user_id", return_value=7),
+                patch.object(
+                    api_editor,
+                    "playground_read_yaml",
+                    side_effect=lambda uid, project, filename: files[filename],
+                ),
+                patch.object(
+                    api_editor,
+                    "suggested_report_names",
+                    return_value={
+                        "title": "Main Draft",
+                        "filename": "main_draft.docx",
+                    },
+                ),
+                patch.object(api_editor, "write_variable_report_docx", fake_write),
+                patch.object(
+                    api_editor,
+                    "_editor_storage_directory",
+                    return_value=(SimpleNamespace(finalize=lambda: None), tmpdir),
+                ),
+            ):
+                with api_editor.app.test_request_context(
+                    "/al/editor/api/template/variable-report",
+                    method="POST",
+                    json={"project": "default", "filename": "main.yml"},
+                ):
+                    response = api_editor.editor_api_template_variable_report()
+
+            self.assertEqual(response.status_code, 200)
+            data = response.get_json()["data"]
+            self.assertEqual(data["section"], "templates")
+            self.assertEqual(data["filename"], "main_draft.docx")
+            self.assertEqual(data["variables_count"], 4)
+            self.assertEqual(data["sources"], ["main.yml", "questions.yml"])
+            self.assertEqual(written["title"], "Main Draft")
+            self.assertTrue(os.path.exists(written["path"]))
+
+    def test_an_existing_template_is_not_silently_overwritten(self):
+        files = self._files()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with open(os.path.join(tmpdir, "main_draft.docx"), "wb") as handle:
+                handle.write(b"already here")
+            with (
+                patch.object(api_editor, "_editor_auth_check", return_value=True),
+                patch.object(api_editor, "_current_user_id", return_value=7),
+                patch.object(
+                    api_editor,
+                    "playground_read_yaml",
+                    side_effect=lambda uid, project, filename: files[filename],
+                ),
+                patch.object(
+                    api_editor,
+                    "suggested_report_names",
+                    return_value={
+                        "title": "Main Draft",
+                        "filename": "main_draft.docx",
+                    },
+                ),
+                patch.object(
+                    api_editor,
+                    "_editor_storage_directory",
+                    return_value=(SimpleNamespace(finalize=lambda: None), tmpdir),
+                ),
+            ):
+                with api_editor.app.test_request_context(
+                    "/al/editor/api/template/variable-report",
+                    method="POST",
+                    json={"project": "default", "filename": "main.yml"},
+                ):
+                    response = api_editor.editor_api_template_variable_report()
+
+            self.assertEqual(response.status_code, 400)
+            self.assertIn("already exists", response.get_json()["error"]["message"])
 
 
 if __name__ == "__main__":

--- a/docassemble/ALWeaver/test_editor_frontend.py
+++ b/docassemble/ALWeaver/test_editor_frontend.py
@@ -89,6 +89,33 @@ class TestEditorFrontend(unittest.TestCase):
         self.assertIn("hasUnsavedChanges()", editor)
         self.assertIn(".editor-project-search-context", css)
 
+    def test_new_template_offers_a_blank_file_or_a_drafted_document(self):
+        template = (self.package_dir / "data/templates/editor.html").read_text()
+        editor = (self.package_dir / "data/static/editor.js").read_text()
+        css = (self.package_dir / "data/static/editor.css").read_text()
+
+        self.assertIn('id="new-template-modal"', template)
+        self.assertIn('id="new-template-kind-blank"', template)
+        self.assertIn('id="new-template-kind-report"', template)
+        self.assertIn('id="new-template-report-filename"', template)
+        self.assertIn('id="new-template-report-sources"', template)
+        self.assertIn(".editor-choice-card", css)
+
+        # Both ways in: the file list's "+ New", and Document setup itself.
+        self.assertIn("function openNewTemplateModal()", editor)
+        self.assertIn("if (state.currentView === 'templates') {", editor)
+        self.assertIn('id="btn-new-template-setup"', editor)
+        self.assertIn("apiPost('/api/template/variable-report'", editor)
+        self.assertIn("/api/template/variable-report/suggestion?project=", editor)
+
+    def test_review_screen_is_re_synced_rather_than_appended(self):
+        editor = (self.package_dir / "data/static/editor.js").read_text()
+
+        self.assertIn("Sync from questions", editor)
+        self.assertIn("mode: 'sync'", editor)
+        self.assertIn("res.data.full_yaml", editor)
+        self.assertIn("markInterviewDirty('sync-review-screen')", editor)
+
     def test_github_publish_uses_a_main_menu_modal_and_reports_the_commit(self):
         template = (self.package_dir / "data/templates/editor.html").read_text()
         editor = (self.package_dir / "data/static/editor.js").read_text()

--- a/docassemble/ALWeaver/test_editor_frontend.py
+++ b/docassemble/ALWeaver/test_editor_frontend.py
@@ -114,7 +114,30 @@ class TestEditorFrontend(unittest.TestCase):
         self.assertIn("Sync from questions", editor)
         self.assertIn("mode: 'sync'", editor)
         self.assertIn("res.data.full_yaml", editor)
-        self.assertIn("markInterviewDirty('sync-review-screen')", editor)
+        # The draft is built from the file on disk.
+        self.assertIn("promptAndSaveUnsavedChanges('sync the review screen')", editor)
+
+    def test_a_synced_review_screen_is_reviewed_as_a_diff_not_as_the_whole_file(self):
+        template = (self.package_dir / "data/templates/editor.html").read_text()
+        editor = (self.package_dir / "data/static/editor.js").read_text()
+        css = (self.package_dir / "data/static/editor.css").read_text()
+
+        self.assertIn('id="review-sync-modal"', template)
+        self.assertIn('data-review-sync-tab="diff"', template)
+        self.assertIn('data-review-sync-tab="draft"', template)
+        self.assertIn('id="review-sync-apply"', template)
+        self.assertIn("function renderUnifiedDiffHtml(", editor)
+        self.assertIn("function openReviewSyncModal(", editor)
+        self.assertIn(".editor-diff-add", css)
+        self.assertIn(".editor-diff-del", css)
+
+        # Applying saves the file and comes back to the review block, rather
+        # than leaving the author in a source editor for the whole interview.
+        self.assertIn("function applyReviewSync(", editor)
+        self.assertIn("selectReviewBlockAfterSync()", editor)
+        # The full-YAML route stays available, as a deliberate choice.
+        self.assertIn('id="review-sync-full-yaml"', template)
+        self.assertIn("function openReviewSyncInFullYaml(", editor)
 
     def test_github_publish_uses_a_main_menu_modal_and_reports_the_commit(self):
         template = (self.package_dir / "data/templates/editor.html").read_text()

--- a/docassemble/ALWeaver/test_generate_from_path.py
+++ b/docassemble/ALWeaver/test_generate_from_path.py
@@ -394,6 +394,68 @@ question: |
         self.assertNotIn("- Edit: signature_date", yaml_text)
         self.assertIn("\n  signature_date\n", yaml_text)
 
+    def test_review_screen_groups_a_screens_fields_into_one_entry(self):
+        """One entry per question, not one per variable. See #865."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = generate_interview_from_path(
+                str(
+                    Path(__file__).parent
+                    / "test/test_petition_to_enforce_sanitary_code.pdf"
+                ),
+                output_dir=tmpdir,
+                create_package_zip=False,
+                include_next_steps=False,
+            )
+            yaml_text = Path(result.yaml_path).read_text(encoding="utf-8")
+
+        review = yaml_text.split("\nreview:", 1)[1].split("\n---", 1)[0]
+        entries = re.findall(r"(?m)^  - Edit: (\S+)$", review)
+        reviewed_values = re.findall(r"(?m)^      [^%*].*: \$\{ (.+) \}$", review)
+
+        # Several variables share one entry, which is the whole point of #865.
+        self.assertGreater(len(reviewed_values), len(entries))
+        # Every entry has a bold heading and at least one value or a list loop.
+        self.assertEqual(review.count("    button: |"), len(entries))
+        self.assertEqual(
+            len(re.findall(r"(?m)^      \*\*.+\*\*$", review)), len(entries)
+        )
+
+        # Nothing in the recap may send the user back into the interview just
+        # for reading it: every value is either showifdef() or guarded.
+        for value in reviewed_values:
+            self.assertTrue(
+                value.startswith("showifdef(") or " if defined(" in value,
+                f"{value!r} would force a variable to be defined",
+            )
+
+        # Lists keep their own revisit entry rather than being folded into a
+        # screen, because "Edit" has to reach the whole list.
+        self.assertIn("users.revisit", entries)
+        self.assertIn("plaintiffs.revisit", entries)
+
+    def test_a_review_table_never_forces_a_signature(self):
+        """Editing a row used to march the user through a signature pad. #482"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = generate_interview_from_path(
+                str(
+                    Path(__file__).parent
+                    / "test/test_petition_to_enforce_sanitary_code.pdf"
+                ),
+                output_dir=tmpdir,
+                create_package_zip=False,
+                include_next_steps=False,
+            )
+            yaml_text = Path(result.yaml_path).read_text(encoding="utf-8")
+
+        table = yaml_text.split("table: plaintiffs.table", 1)[1].split("\n---", 1)[0]
+        edits = table.split("edit:", 1)[1]
+        self.assertNotIn("- signature\n", edits)
+        # The attributes the interview really does ask about are still editable.
+        self.assertIn("- name.first\n", edits)
+        self.assertIn("- phone_number\n", edits)
+        # The signature is still shown in the table, just not demanded.
+        self.assertIn("row_item.signature", table)
+
     def test_generated_yaml_has_no_leading_or_trailing_blank_lines(self):
         """Mako's control-flow lines used to leave blank lines wrapping the file."""
         for source in (

--- a/docassemble/ALWeaver/test_review_screen.py
+++ b/docassemble/ALWeaver/test_review_screen.py
@@ -1,0 +1,221 @@
+# do not pre-load
+
+import unittest
+
+from .review_screen import (
+    ReviewEntry,
+    build_review_entries,
+    table_edit_attributes,
+)
+
+
+class _Field:
+    """The parts of a DAField the review-screen builder actually reads."""
+
+    def __init__(
+        self,
+        variable,
+        *,
+        label=None,
+        field_type="text",
+        group="custom",
+        settable=None,
+    ):
+        self.variable = variable
+        self.final_display_var = variable
+        self._settable = settable or variable
+        self.label = label or variable
+        self.has_label = label is not None
+        self.field_type = field_type
+        self.group = type("Group", (), {"value": group})()
+
+    def get_settable_var(self):
+        return self._settable
+
+
+class _Collection:
+    def __init__(self, var_name, var_type, fields, attribute_map=None):
+        self.var_name = var_name
+        self.var_type = var_type
+        self.fields = fields
+        self.attribute_map = attribute_map or {}
+
+
+class _Screen:
+    def __init__(self, question_text, field_list):
+        self.question_text = question_text
+        self.field_list = field_list
+
+
+class TestReviewEntries(unittest.TestCase):
+    def test_one_entry_per_screen_instead_of_one_per_variable(self):
+        """The old review screen listed every loose primitive on its own."""
+        rent = _Field("rent_amount", label="Rent amount", field_type="currency")
+        inspected = _Field("inspection_yesno", label="Inspected?", field_type="yesno")
+        notes = _Field("notes", label="Notes")
+        collections = [
+            _Collection("rent_amount", "primitive", [rent]),
+            _Collection("inspection_yesno", "primitive", [inspected]),
+            _Collection("notes", "primitive", [notes]),
+        ]
+        screens = [_Screen("About the apartment", [rent, inspected, notes])]
+
+        entries = build_review_entries(collections, screens)
+
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0].edit_var, "rent_amount")
+        self.assertEqual(entries[0].title, "About the apartment")
+        self.assertEqual(
+            [row.label for row in entries[0].rows],
+            ["Rent amount", "Inspected?", "Notes"],
+        )
+
+    def test_values_never_force_a_variable_to_be_defined(self):
+        """A review screen that asks a question is a review screen with a bug."""
+        rent = _Field("rent_amount", label="Rent", field_type="currency")
+        yes = _Field("served", label="Served?", field_type="yesno")
+        plain = _Field("nickname", label="Nickname")
+        collections = [
+            _Collection("rent_amount", "primitive", [rent]),
+            _Collection("served", "primitive", [yes]),
+            _Collection("nickname", "primitive", [plain]),
+        ]
+        entries = build_review_entries(
+            collections, [_Screen("Details", [rent, yes, plain])]
+        )
+        expressions = [row.expression for row in entries[0].rows]
+
+        self.assertEqual(
+            expressions,
+            [
+                "currency(rent_amount) if defined('rent_amount') else ''",
+                "word(yesno(served)) if defined('served') else ''",
+                "showifdef('nickname')",
+            ],
+        )
+
+    def test_a_list_gets_one_revisit_entry_wherever_its_fields_appear(self):
+        member = _Field("household[i].name.first", settable="household[i].name.first")
+        household = _Collection("household", "list", [member])
+        entries = build_review_entries(
+            [household], [_Screen("Who lives there?", [member])]
+        )
+
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0].edit_var, "household.revisit")
+        self.assertEqual(entries[0].list_var, "household")
+        self.assertEqual(entries[0].rows, [])
+
+    def test_signatures_are_left_to_the_signature_flow(self):
+        signature = _Field("user_signature", group="signature")
+        date = _Field("signature_date", field_type="date")
+        name = _Field("nickname", label="Nickname")
+        collections = [
+            _Collection("user_signature", "primitive", [signature]),
+            _Collection("signature_date", "primitive", [date]),
+            _Collection("nickname", "primitive", [name]),
+        ]
+        entries = build_review_entries(
+            collections, [_Screen("Sign here", [signature, date, name])]
+        )
+
+        self.assertEqual(len(entries), 1)
+        self.assertEqual([row.label for row in entries[0].rows], ["Nickname"])
+        self.assertEqual(entries[0].edit_var, "nickname")
+
+    def test_questions_asked_by_assemblyline_still_get_an_entry(self):
+        """`docket_number` is never on a Weaver screen but belongs on the recap."""
+        docket = _Field("docket_number", label="Docket number")
+        collection = _Collection("docket_number", "primitive", [docket])
+
+        entries = build_review_entries([collection], [docket])
+
+        self.assertEqual([entry.edit_var for entry in entries], ["docket_number"])
+        self.assertEqual(entries[0].rows[0].expression, "showifdef('docket_number')")
+
+    def test_entries_follow_the_order_the_interview_asks_for_them(self):
+        first = _Field("first_question", label="First")
+        second = _Field("second_question", label="Second")
+        collections = [
+            _Collection("second_question", "primitive", [second]),
+            _Collection("first_question", "primitive", [first]),
+        ]
+        entries = build_review_entries(
+            collections, [_Screen("One", [first]), _Screen("Two", [second])]
+        )
+
+        self.assertEqual([entry.title for entry in entries], ["One", "Two"])
+
+    def test_an_object_shows_its_name_and_address_as_single_lines(self):
+        court = _Collection(
+            "trial_court",
+            "object",
+            [_Field("trial_court.address.county")],
+            attribute_map={
+                "name": ("name_full()", "name.first"),
+                "address": ("address.block()", "address.county"),
+            },
+        )
+        entries = build_review_entries([court], [])
+
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0].edit_var, "trial_court")
+        self.assertEqual(
+            [(row.label, row.expression) for row in entries[0].rows],
+            [
+                (
+                    "Name",
+                    "trial_court.name_full() if defined('trial_court.name.first') else ''",
+                ),
+                (
+                    "Address",
+                    "trial_court.address.block() if defined('trial_court.address.county') else ''",
+                ),
+            ],
+        )
+
+    def test_code_and_skipped_fields_have_nothing_to_link_back_to(self):
+        code = _Field("computed_total", field_type="code")
+        skipped = _Field("ignored", field_type="skip this field")
+        collections = [
+            _Collection("computed_total", "primitive", [code]),
+            _Collection("ignored", "primitive", [skipped]),
+        ]
+        self.assertEqual(
+            build_review_entries(collections, [_Screen("X", [code, skipped])]), []
+        )
+
+
+class TestTableEditAttributes(unittest.TestCase):
+    def test_a_signature_is_never_forced_from_a_review_table(self):
+        collection = _Collection(
+            "plaintiffs",
+            "list",
+            [],
+            attribute_map={
+                "name": ("name_full()", "name.first"),
+                "address": ("address.block()", "address.zip"),
+                "signature": ("signature", "signature"),
+                "phone_number": ("phone_number", "phone_number"),
+            },
+        )
+        self.assertEqual(
+            table_edit_attributes(collection),
+            ["name.first", "address.zip", "phone_number"],
+        )
+
+    def test_an_attribute_is_only_followed_up_once(self):
+        collection = _Collection(
+            "witnesses",
+            "list",
+            [],
+            attribute_map={
+                "name": ("name_full()", "name.first"),
+                "given_name": ("name_full()", "name.first"),
+            },
+        )
+        self.assertEqual(table_edit_attributes(collection), ["name.first"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docassemble/ALWeaver/test_review_screen_sync.py
+++ b/docassemble/ALWeaver/test_review_screen_sync.py
@@ -1,0 +1,270 @@
+# do not pre-load
+
+import unittest
+from unittest import mock
+
+from . import review_screen_sync
+from .review_screen_sync import (
+    ALDashboardUnavailable,
+    collect_interview_yaml_texts,
+    interview_scope,
+    generate_review_screen_yaml,
+    project_include_chain,
+    review_screen_identity,
+    sync_review_screen,
+)
+
+MAIN_YAML = """---
+include:
+  - docassemble.AssemblyLine:assembly_line.yml
+  - questions.yml
+---
+id: intro
+question: |
+  Hello
+---
+id: my review screen
+event: review_my_form
+question: |
+  Check your answers
+review:
+  - Edit: rent_amount
+    button: |
+      **Rent**
+---
+id: edit tenants
+continue button field: tenants.revisit
+question: |
+  Edit tenants
+---
+table: tenants.table
+rows: tenants
+columns:
+  - Name: |
+      row_item
+edit:
+  - name.first
+---
+id: download
+event: my_form_download
+question: |
+  All done
+"""
+
+
+class TestIncludeChain(unittest.TestCase):
+    def setUp(self):
+        self.files = {
+            "main.yml": MAIN_YAML,
+            "questions.yml": "---\ninclude:\n  - shared.yml\n---\nid: q\nquestion: |\n  Q\n",
+            "shared.yml": "---\nid: s\nquestion: |\n  S\n",
+        }
+
+    def read(self, name):
+        return self.files[name]
+
+    def test_it_follows_project_includes_but_not_other_packages(self):
+        self.assertEqual(
+            project_include_chain(self.read, "main.yml"),
+            ["main.yml", "questions.yml", "shared.yml"],
+        )
+
+    def test_a_cycle_does_not_loop_forever(self):
+        self.files["shared.yml"] = "---\ninclude:\n  - main.yml\n---\nid: s\n"
+        self.assertEqual(
+            project_include_chain(self.read, "main.yml"),
+            ["main.yml", "questions.yml", "shared.yml"],
+        )
+
+    def test_an_unreadable_include_does_not_stop_the_rest(self):
+        self.files["questions.yml"] = "---\ninclude:\n  - missing.yml\n  - shared.yml\n"
+        names, texts = collect_interview_yaml_texts(self.read, "main.yml")
+        self.assertEqual(names, ["main.yml", "questions.yml", "shared.yml"])
+        self.assertEqual(len(texts), 3)
+
+
+class TestInterviewScope(unittest.TestCase):
+    """Review screens usually live in a file the interviews include."""
+
+    def setUp(self):
+        self.files = {
+            "main.yml": "---\ninclude:\n  - questions.yml\n  - review.yml\n",
+            "questions.yml": "---\nid: q\nquestion: |\n  Q\n",
+            "review.yml": "---\nid: r\nreview:\n  - Edit: x\n",
+        }
+
+    def read(self, name):
+        return self.files[name]
+
+    def test_a_review_only_file_is_scoped_to_the_interview_that_includes_it(self):
+        roots, files = interview_scope(self.read, "review.yml", list(self.files))
+        self.assertEqual(roots, ["main.yml"])
+        self.assertEqual(files, ["main.yml", "questions.yml", "review.yml"])
+
+    def test_a_shared_review_screen_covers_every_interview_that_uses_it(self):
+        self.files["other.yml"] = "---\ninclude:\n  - review.yml\n  - extra.yml\n"
+        self.files["extra.yml"] = "---\nid: e\nquestion: |\n  E\n"
+        roots, files = interview_scope(self.read, "review.yml", list(self.files))
+        self.assertEqual(sorted(roots), ["main.yml", "other.yml"])
+        self.assertEqual(
+            sorted(files),
+            ["extra.yml", "main.yml", "other.yml", "questions.yml", "review.yml"],
+        )
+
+    def test_an_interview_of_its_own_keeps_its_own_chain(self):
+        roots, files = interview_scope(self.read, "main.yml", list(self.files))
+        self.assertEqual(roots, ["main.yml"])
+        self.assertEqual(files, ["main.yml", "questions.yml", "review.yml"])
+
+    def test_without_a_project_listing_it_falls_back_to_the_files_own_chain(self):
+        roots, files = interview_scope(self.read, "review.yml", [])
+        self.assertEqual(roots, [])
+        self.assertEqual(files, ["review.yml"])
+
+
+class TestReviewScreenIdentity(unittest.TestCase):
+    def test_it_reads_the_screen_the_interview_already_uses(self):
+        identity = review_screen_identity(MAIN_YAML)
+        self.assertTrue(identity["found"])
+        self.assertEqual(identity["id"], "my review screen")
+        self.assertEqual(identity["event"], "review_my_form")
+        self.assertEqual(identity["question"].strip(), "Check your answers")
+
+    def test_a_file_without_one_is_reported_as_a_first_draft(self):
+        self.assertEqual(review_screen_identity("---\nid: x\n"), {"found": False})
+
+
+NEW_REVIEW = """id: my review screen
+event: review_my_form
+question: |
+  Check your answers
+review:
+  - Edit: tenants.revisit
+    button: |
+      **Tenants**
+---
+id: revisit tenants
+continue button field: tenants.revisit
+question: |
+  Edit your answers about tenants
+---
+table: tenants.table
+rows: tenants
+columns:
+  - Name: |
+      row_item
+edit:
+  - name.first
+"""
+
+
+class TestSync(unittest.TestCase):
+    def test_the_old_review_screen_is_replaced_where_it_stood(self):
+        result, replaced = sync_review_screen(MAIN_YAML, NEW_REVIEW)
+
+        self.assertTrue(replaced)
+        self.assertEqual(result.count("review:"), 1)
+        self.assertIn("Edit: tenants.revisit", result)
+        self.assertNotIn("Edit: rent_amount", result)
+        # Everything around it survives, in place.
+        self.assertLess(result.index("id: intro"), result.index("review:"))
+        self.assertLess(result.index("review:"), result.index("id: download"))
+        self.assertIn("id: download", result)
+
+    def test_regenerated_tables_are_not_left_behind_in_duplicate(self):
+        result, _replaced = sync_review_screen(MAIN_YAML, NEW_REVIEW)
+        self.assertEqual(result.count("table: tenants.table"), 1)
+        self.assertEqual(result.count("continue button field: tenants.revisit"), 1)
+        self.assertIn("Edit your answers about tenants", result)
+
+    def test_a_table_the_draft_says_nothing_about_is_the_authors_own(self):
+        source = MAIN_YAML + "\n---\ntable: exhibits.table\nrows: exhibits\n"
+        result, _replaced = sync_review_screen(source, NEW_REVIEW)
+        self.assertIn("table: exhibits.table", result)
+
+    def test_a_file_with_no_review_screen_gets_the_draft_appended(self):
+        source = "---\nid: intro\nquestion: |\n  Hi\n"
+        result, replaced = sync_review_screen(source, NEW_REVIEW)
+        self.assertFalse(replaced)
+        self.assertIn("id: intro", result)
+        self.assertTrue(result.rstrip().endswith("- name.first"))
+
+
+class TestGeneration(unittest.TestCase):
+    def test_a_missing_dashboard_is_reported_not_raised_as_an_import_error(self):
+        with mock.patch.object(
+            review_screen_sync,
+            "_load_dashboard_generator",
+            side_effect=ALDashboardUnavailable("nope"),
+        ):
+            with self.assertRaises(ALDashboardUnavailable):
+                generate_review_screen_yaml(["---\nid: x\n"])
+
+    def test_the_interviews_own_event_and_id_survive_an_older_dashboard(self):
+        def old_dashboard(
+            yaml_texts, build_revisit_blocks=True, point_sections_to_review=True
+        ):
+            return (
+                "id: review screen\n"
+                "event: review_form\n"
+                "question: |\n  Review your answers\n"
+                "review:\n"
+                "  - Edit: rent_amount\n"
+                "    button: |\n      **Rent**\n"
+            )
+
+        with mock.patch.object(
+            review_screen_sync, "_load_dashboard_generator", return_value=old_dashboard
+        ):
+            result = generate_review_screen_yaml(
+                ["---\nid: x\n"],
+                screen_id="my review screen",
+                event_name="review_my_form",
+                question_text="Check your answers\n",
+            )
+
+        self.assertIn("review_my_form", result)
+        self.assertNotIn("review_form\n", result.replace("review_my_form", ""))
+        self.assertIn("my review screen", result)
+        self.assertIn("Check your answers", result)
+
+    def test_a_newer_dashboard_is_asked_for_the_names_directly(self):
+        seen = {}
+
+        def new_dashboard(
+            yaml_texts,
+            build_revisit_blocks=True,
+            point_sections_to_review=True,
+            review_id=None,
+            review_event_name=None,
+            review_question=None,
+        ):
+            seen.update(
+                {
+                    "review_id": review_id,
+                    "review_event_name": review_event_name,
+                    "review_question": review_question,
+                    "point_sections_to_review": point_sections_to_review,
+                }
+            )
+            return "id: review screen\nreview: []\n"
+
+        with mock.patch.object(
+            review_screen_sync, "_load_dashboard_generator", return_value=new_dashboard
+        ):
+            generate_review_screen_yaml(
+                ["---\nid: x\n"],
+                screen_id="my review screen",
+                event_name="review_my_form",
+                question_text="Check your answers",
+            )
+
+        self.assertEqual(seen["review_id"], "my review screen")
+        self.assertEqual(seen["review_event_name"], "review_my_form")
+        self.assertEqual(seen["review_question"], "Check your answers")
+        # The Weaver's `sections:` are navigation headings, not events.
+        self.assertFalse(seen["point_sections_to_review"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docassemble/ALWeaver/test_review_screen_sync.py
+++ b/docassemble/ALWeaver/test_review_screen_sync.py
@@ -6,7 +6,10 @@ from unittest import mock
 from . import review_screen_sync
 from .review_screen_sync import (
     ALDashboardUnavailable,
+    carry_over_unmatched_entries,
     collect_interview_yaml_texts,
+    ensure_revisit_tables,
+    inferred_objects_document,
     interview_scope,
     generate_review_screen_yaml,
     project_include_chain,
@@ -188,6 +191,143 @@ class TestSync(unittest.TestCase):
         self.assertFalse(replaced)
         self.assertIn("id: intro", result)
         self.assertTrue(result.rstrip().endswith("- name.first"))
+
+
+class TestKeepingWhatTheDraftCannotSee(unittest.TestCase):
+    """A generated interview reviews lists AssemblyLine declares, not this file."""
+
+    WEAVER_FILE = """---
+objects:
+  - users: ALPeopleList
+---
+id: review screen
+event: review_form
+review:
+  - Edit: users.revisit
+    button: |
+      **Users**
+  - Edit: plaintiffs.revisit
+    button: |
+      **Plaintiffs**
+  - Edit: docket_number
+    button: |
+      **Docket number**
+---
+id: edit plaintiffs
+continue button field: plaintiffs.revisit
+question: |
+  Edit plaintiffs
+---
+table: plaintiffs.table
+rows: plaintiffs
+columns:
+  - Name: |
+      row_item
+edit:
+  - name.first
+---
+table: users.table
+rows: users
+columns:
+  - Name: |
+      row_item
+edit:
+  - name.first
+"""
+
+    def test_lists_only_assemblyline_declares_are_still_offered(self):
+        document = inferred_objects_document([self.WEAVER_FILE])
+        self.assertIsNotNone(document)
+        # `users` has its own objects: block, so it needs no help.
+        self.assertNotIn("users:", document)
+        self.assertIn("plaintiffs:", document)
+
+    def test_nothing_is_inferred_when_every_list_is_declared(self):
+        source = "---\nobjects:\n  - users: ALPeopleList\n---\ntable: users.table\nrows: users\n"
+        self.assertIsNone(inferred_objects_document([source]))
+
+    def test_a_regenerated_revisit_screen_never_loses_its_table(self):
+        """The draft can rebuild the screen without rebuilding the table."""
+        draft = (
+            "id: review screen\nevent: review_form\nreview:\n"
+            "  - Edit: users.revisit\n    button: |\n      **Users**\n"
+            "---\nid: revisit users\ncontinue button field: users.revisit\n"
+            "question: |\n  Edit users\nsubquestion: |\n  ${users.table}\n"
+        )
+        result, replaced = sync_review_screen(self.WEAVER_FILE, draft)
+
+        self.assertTrue(replaced)
+        # The screen that displays it was regenerated; the table it displays
+        # was not, so the author's table has to survive.
+        self.assertIn("table: users.table", result)
+        self.assertIn("table: plaintiffs.table", result)
+        self.assertEqual(result.count("continue button field: users.revisit"), 1)
+
+    def test_a_revisit_screen_with_no_table_anywhere_gets_one(self):
+        draft = (
+            "id: review screen\nevent: review_form\nreview: []\n"
+            "---\nid: revisit witnesses\ncontinue button field: witnesses.revisit\n"
+            "question: |\n  Edit witnesses\nsubquestion: |\n  ${witnesses.table}\n"
+        )
+        result = ensure_revisit_tables(draft, "---\nid: x\n")
+
+        self.assertIn("table: witnesses.table", result)
+        self.assertIn("rows: witnesses", result)
+        self.assertIn("edit: True", result)
+
+    def test_an_existing_table_is_not_duplicated_by_the_safety_net(self):
+        draft = (
+            "id: review screen\nevent: review_form\nreview: []\n"
+            "---\nid: revisit users\ncontinue button field: users.revisit\n"
+            "question: |\n  Edit users\n"
+        )
+        self.assertNotIn("rows: users", ensure_revisit_tables(draft, self.WEAVER_FILE))
+        # ...including when the table lives in another file of the same
+        # interview, which is where a split-out review screen usually finds it.
+        self.assertNotIn(
+            "rows: users",
+            ensure_revisit_tables(draft, ["---\nid: r\n", self.WEAVER_FILE]),
+        )
+
+    def test_lists_are_inferred_from_any_file_in_the_interview(self):
+        """The tables can sit in one file and the review screen in another."""
+        review_file = "---\nid: review screen\nreview:\n  - Edit: rent\n"
+        main_file = "---\ntable: plaintiffs.table\nrows: plaintiffs\n"
+        document = inferred_objects_document([review_file, main_file])
+        self.assertIsNotNone(document)
+        self.assertIn("plaintiffs:", document)
+
+    def test_entries_the_draft_cannot_see_are_carried_over(self):
+        draft = (
+            "id: review screen\nevent: review_form\nreview:\n"
+            "  - Edit: users.revisit\n    button: |\n      **Users**\n"
+        )
+        result, kept = carry_over_unmatched_entries(draft, self.WEAVER_FILE)
+
+        self.assertEqual(kept, 2)
+        self.assertIn("Edit: plaintiffs.revisit", result)
+        self.assertIn("Edit: docket_number", result)
+        # The draft's own version of an entry wins; it is not duplicated.
+        self.assertEqual(result.count("Edit: users.revisit"), 1)
+
+    def test_carrying_over_preserves_the_literal_block_style(self):
+        draft = (
+            "id: review screen\nevent: review_form\nreview:\n"
+            "  - Edit: rent\n    button: |\n      **Rent**\n"
+        )
+        result, kept = carry_over_unmatched_entries(draft, self.WEAVER_FILE)
+        self.assertEqual(kept, 3)
+        self.assertNotIn("\\n", result)
+        self.assertIn("button: |", result)
+
+    def test_a_file_without_a_review_screen_carries_nothing(self):
+        draft = (
+            "id: review screen\nevent: review_form\nreview:\n"
+            "  - Edit: rent\n    button: |\n      **Rent**\n"
+        )
+        result, kept = carry_over_unmatched_entries(draft, "---\nid: x\n")
+        self.assertEqual(kept, 0)
+        self.assertEqual(result, draft)
 
 
 class TestGeneration(unittest.TestCase):

--- a/docassemble/ALWeaver/variable_report.py
+++ b/docassemble/ALWeaver/variable_report.py
@@ -1,0 +1,86 @@
+"""Draft a starter DOCX template from an interview's own questions.
+
+Authors are told to build the output document first and automate it second,
+which is backwards for an intake: the questions are the point, and the document
+is just a record of the answers (SuffolkLITLab/docassemble-ALWeaver#819, and the
+generic-template request in #498).
+
+ALDashboard already does this under "Generate variable report" / its Interview
+Intake Document Generator, walking the YAML and writing a DOCX whose Jinja
+fields line up with the variables the interview gathers. This module imports
+that at runtime -- the Dashboard is an optional dependency, as it is for the
+review screen generator and the linter -- and drops the result straight into the
+project's templates folder, where the Weaver's document setup can pick it up.
+"""
+
+import os
+from typing import Any, Dict, List, Optional, Sequence
+
+from .review_screen_sync import ALDashboardUnavailable
+
+__all__ = [
+    "ALDashboardUnavailable",
+    "suggested_report_names",
+    "write_variable_report_docx",
+]
+
+
+def _load_dashboard_report():
+    try:
+        from docassemble.ALDashboard.variable_report_generator import (  # type: ignore
+            extract_interview_metadata_info,
+            generate_variable_report,
+        )
+    except Exception as err:  # pragma: no cover - depends on the server's packages
+        raise ALDashboardUnavailable(
+            "Drafting a variable report needs the ALDashboard package. Install "
+            "docassemble.ALDashboard on this server and try again."
+        ) from err
+    return extract_interview_metadata_info, generate_variable_report
+
+
+def suggested_report_names(
+    yaml_texts: Sequence[str], *, primary_filename: Optional[str] = None
+) -> Dict[str, str]:
+    """The title and filename ALDashboard would give this interview's report."""
+    extract_interview_metadata_info, _generate = _load_dashboard_report()
+    info = extract_interview_metadata_info(
+        [str(text or "") for text in yaml_texts], primary_filename=primary_filename
+    )
+    return {
+        "title": str(info.get("display_title") or "Interview Document Draft"),
+        "filename": str(info.get("docx_filename") or "interview_document_draft.docx"),
+    }
+
+
+def write_variable_report_docx(
+    yaml_texts: Sequence[str],
+    output_path: str,
+    *,
+    report_title: Optional[str] = None,
+    show_variable_names: bool = False,
+) -> Dict[str, Any]:
+    """Write the report to ``output_path`` and describe what went into it.
+
+    Raises ``ALDashboardUnavailable`` when the Dashboard package is not
+    installed on this server.
+    """
+    _extract, generate_variable_report = _load_dashboard_report()
+    texts: List[str] = [
+        str(text or "") for text in yaml_texts if str(text or "").strip()
+    ]
+    if not texts:
+        raise ValueError("There is no YAML to draft a template from.")
+
+    result = generate_variable_report(
+        texts,
+        report_title=report_title,
+        show_variable_names=show_variable_names,
+        output_docx_path=output_path,
+    )
+    return {
+        "variables_count": int(result.get("variables_count") or 0),
+        "list_count": int(result.get("list_count") or 0),
+        "scalar_count": int(result.get("scalar_count") or 0),
+        "size": os.path.getsize(output_path) if os.path.exists(output_path) else 0,
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,10 @@ ignore_missing_imports = true
 module = "docassemble.ALDashboard.review_screen_generator"
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = "docassemble.ALDashboard.variable_report_generator"
+ignore_missing_imports = true
+
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
Fixes #865. Fixes #482.

### One entry per question, not one per variable (#865)

The review screen the Weaver drafted listed one entry per parent collection, which for an interview made mostly of loose primitives meant one "Edit" link per variable. `review_screen.py` now makes the same grouping decision ALDashboard's generator makes, from the Weaver's own field model: one entry per question screen, in asking order, holding every value that screen asked for, under the question's own text. Lists keep a `.revisit` entry of their own, because "Edit" there has to reach the whole list, and a name or an address stays one line via the display map rather than becoming six — the "better handling of common attributes" half of the issue.

Before and after, from `test_petition_to_enforce_sanitary_code.pdf`:

```yaml
  - Edit: rent_amount              |    - Edit: rent_amount
    button: |                      |      button: |
      **Rent amount**:             |        **Rent amount**
      ${ currency(rent_amount) }   |
  - Edit: inspection_yesno         |        Rent amount: ${ currency(rent_amount) if defined('rent_amount') else '' }
    button: |                      |
      **Inspection yesno**:        |        Inspection yesno: ${ word(yesno(inspection_yesno)) if defined('inspection_yesno') else '' }
      ${ word(yesno(...)) }        |
  - Edit: future_inspection_yesno  |        Future inspection yesno: ${ ... }
      ... eleven more entries      |        ... five more values, same entry
```

Measured over the 50 interviews in the SuffolkLITLab packages that have a review screen, grouping puts **2.3 to 5.1 values behind each "Edit" link**, where the hand-written screens sit at roughly one.

### The review screen never forces a variable to be defined (#482)

Looking at your answers should not send you back into the interview, and `${ rent_amount }` did exactly that for anything asked conditionally. Plain values now use `showifdef()`; `currency()` and `yesno()` are guarded, since `yesno('')` would report a confident "No" for a question nobody was asked.

That principle is most of #482. The rest is `edit:` on a revisit table, which Docassemble turns into a follow-up list and seeks every variable in — so editing a plaintiff's name walked the user through a signature pad that `basic_questions_signature_flow` overwrites moments later. Signatures are now left out of `edit:`, though still shown as a table column.

**What this deliberately does not change:** a list whose attributes are gathered on several screens still opens several screens when you click Edit. That matches AssemblyLine's own `ql_baseline.yml` tables, and Docassemble has no way to make `edit:` conditional. If the team wants one screen per row instead, that is a separate design (a per-object "edit everything" question), and worth its own issue.

### Re-syncing a review screen that has drifted

A drafted review screen is only right on the day it is drafted, which is the complaint behind #865 and the closed #400. The review block's button now re-syncs instead of appending a second screen. `review_screen_sync.py` calls ALDashboard's generator at runtime — one implementation, so the Dashboard's "Generate a review screen draft" tool and this one cannot drift — and adds what re-syncing a real interview needs:

* **It works out what "the interview" means.** Review screens usually live in a `review.yml` / `review_page.yml` / `review_screens.yml` that the interviews include, rather than the other way round. Drafting from such a file alone found *no questions at all* in 4 of the packages I checked, so the include graph is walked in both directions.
* **It keeps the interview's identity** — `id`, `event` and question text — so the download screen's "Edit answers" button still resolves.
* **It replaces in place**: the old review block, revisit screens and regenerated tables, rather than leaving a stale copy beside a new one. The result opens in the full-YAML view to be read before saving, and the banner names the files it read.

ALDashboard stays an optional dependency, as it already is for the linter, so a server without it gets a 503 saying what to install. SuffolkLITLab/docassemble-ALDashboard#270 brings its generator to the same standard — guarded values, no signature in `edit:`, collapsed name and address, AssemblyLine's output style — and the Weaver passes the new naming arguments when they are present, falling back to a local rewrite against released versions.

### A template drafted from the questions

Separately, "+ New" under Templates is now a picker rather than a filename prompt, reachable from Document setup as well: a blank file, or a **variable report** — the DOCX ALDashboard's interview intake document generator drafts from the questions an interview already asks, with a Jinja field per variable. That is for the intakes in #819, where the answers *are* the output and there is no form to start from, and a starting point for #498. It writes into the project's templates folder, so Document setup can import it like any uploaded file.

### Checking

748 tests pass, including new unit tests for the grouping rules, the include-graph scope resolution, the splice, and both endpoints, plus generation-level tests asserting that no review value can force a definition and that no table `edit:` names a signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)