### PR TITLE
Offer ALDashboard's court form shapes when drafting from an interview

### DIFF
--- a/docassemble/ALWeaver/api_editor.py
+++ b/docassemble/ALWeaver/api_editor.py
@@ -194,6 +194,7 @@ except Exception as _editor_utils_import_err:
     raise
 
 from .variable_report import (
+    court_form_options,
     suggested_report_names,
     write_variable_report_docx,
 )
@@ -2689,6 +2690,9 @@ def editor_api_template_variable_report_suggestion() -> Response:
             read_project_file, filename, _project_yaml_filenames(uid, project)
         )
         suggested = suggested_report_names(yaml_texts, primary_filename=filename)
+        # Which shapes this server can draft depends on the ALDashboard it has
+        # installed, so the editor asks rather than assuming.
+        options = court_form_options()
         return jsonify(
             {
                 "success": True,
@@ -2697,6 +2701,9 @@ def editor_api_template_variable_report_suggestion() -> Response:
                     "title": suggested["title"],
                     "filename": suggested["filename"],
                     "sources": sources,
+                    "court_forms_supported": bool(options.get("supported")),
+                    "shapes": options.get("shapes", []),
+                    "court_profiles": options.get("profiles", []),
                 },
             }
         )
@@ -2748,6 +2755,13 @@ def editor_api_template_variable_report() -> Response:
         project = _normalize_project(post_data.get("project"))
         filename = _normalize_filename(post_data.get("filename"))
         show_variable_names = bool(post_data.get("show_variable_names"))
+        shape = str(post_data.get("shape") or "intake").strip().lower() or "intake"
+        court_profile = str(post_data.get("court_profile") or "").strip() or None
+        include_certificate_of_service = (
+            bool(post_data.get("include_certificate_of_service"))
+            if post_data.get("include_certificate_of_service") is not None
+            else None
+        )
 
         raw_yaml = playground_read_yaml(uid, project, filename)
 
@@ -2780,6 +2794,9 @@ def editor_api_template_variable_report() -> Response:
             path,
             report_title=report_title or None,
             show_variable_names=show_variable_names,
+            shape=shape,
+            court_profile=court_profile,
+            include_certificate_of_service=include_certificate_of_service,
         )
         area.finalize()
 

--- a/docassemble/ALWeaver/data/static/editor.js
+++ b/docassemble/ALWeaver/data/static/editor.js
@@ -8880,6 +8880,7 @@
     }
     if (reportName) reportName.value = '';
     if (reportTitle) reportTitle.value = '';
+    resetVariableReportShapes();
     if (sources) {
       sources.textContent = haveInterview
         ? 'Reading ' + state.filename + '\u2026'
@@ -8891,6 +8892,60 @@
     if (haveInterview) loadVariableReportSuggestion();
   }
 
+  // Which shapes and courts are on offer depends on the ALDashboard installed
+  // on this server, so the suggestion response tells us rather than the editor
+  // hard-coding a list that might not work when used.
+  function resetVariableReportShapes() {
+    var shapeWrap = document.getElementById('new-template-report-shape-wrap');
+    var courtWrap = document.getElementById('new-template-report-court-wrap');
+    var shape = document.getElementById('new-template-report-shape');
+    var profile = document.getElementById('new-template-report-profile');
+    var cos = document.getElementById('new-template-report-cos');
+    if (shapeWrap) shapeWrap.classList.add('d-none');
+    if (courtWrap) courtWrap.classList.add('d-none');
+    if (shape) shape.innerHTML = '';
+    if (profile) profile.innerHTML = '';
+    if (cos) cos.checked = false;
+  }
+
+  function fillSelect(select, items, selectedValue) {
+    if (!select) return;
+    select.innerHTML = '';
+    items.forEach(function (item) {
+      var option = document.createElement('option');
+      option.value = item.value;
+      option.textContent = item.label;
+      if (item.value === selectedValue) option.selected = true;
+      select.appendChild(option);
+    });
+  }
+
+  function syncVariableReportShapeFields() {
+    var shape = document.getElementById('new-template-report-shape');
+    var courtWrap = document.getElementById('new-template-report-court-wrap');
+    if (!courtWrap) return;
+    var isCourt = Boolean(shape && shape.value && shape.value !== 'intake');
+    courtWrap.classList.toggle('d-none', !isCourt);
+  }
+
+  function applyVariableReportOptions(data) {
+    var shapeWrap = document.getElementById('new-template-report-shape-wrap');
+    var shape = document.getElementById('new-template-report-shape');
+    var profile = document.getElementById('new-template-report-profile');
+    var shapes = (data && data.shapes) || [];
+    var profiles = (data && data.court_profiles) || [];
+    // An older ALDashboard offers the intake report only; showing a shape
+    // picker with one entry would just be noise.
+    if (!data || !data.court_forms_supported || shapes.length < 2) {
+      resetVariableReportShapes();
+      return;
+    }
+    fillSelect(shape, shapes, 'intake');
+    fillSelect(profile, profiles, 'generic');
+    if (shapeWrap) shapeWrap.classList.remove('d-none');
+    syncVariableReportShapeFields();
+  }
+
   function loadVariableReportSuggestion() {
     apiGet('/api/template/variable-report/suggestion?project=' + encodeURIComponent(state.project) + '&filename=' + encodeURIComponent(state.filename))
       .then(function (res) {
@@ -8900,6 +8955,7 @@
         var sources = document.getElementById('new-template-report-sources');
         if (reportName && !reportName.value) reportName.value = res.data.filename || '';
         if (reportTitle && !reportTitle.value) reportTitle.value = res.data.title || '';
+        applyVariableReportOptions(res.data);
         if (sources) {
           var names = res.data.sources || [];
           sources.textContent = names.length > 1
@@ -8956,13 +9012,23 @@
     var titleInput = document.getElementById('new-template-report-title');
     var reportNameInput = document.getElementById('new-template-report-filename');
     var varNames = document.getElementById('new-template-report-varnames');
-    apiPost('/api/template/variable-report', {
+    var shapeInput = document.getElementById('new-template-report-shape');
+    var profileInput = document.getElementById('new-template-report-profile');
+    var cosInput = document.getElementById('new-template-report-cos');
+    var shape = shapeInput && shapeInput.value ? shapeInput.value : 'intake';
+    var payload = {
       project: state.project,
       filename: state.filename,
       title: titleInput ? titleInput.value.trim() : '',
       output_filename: reportNameInput ? reportNameInput.value.trim() : '',
       show_variable_names: Boolean(varNames && varNames.checked),
-    }).then(function (res) {
+      shape: shape,
+    };
+    if (shape !== 'intake') {
+      payload.court_profile = profileInput ? profileInput.value : '';
+      payload.include_certificate_of_service = Boolean(cosInput && cosInput.checked);
+    }
+    apiPost('/api/template/variable-report', payload).then(function (res) {
       finish();
       if (!res.success) {
         setNewTemplateError((res.error && res.error.message) || 'Unable to draft the document.');
@@ -8972,7 +9038,11 @@
       state.sectionSelectedFile.templates = res.data.filename;
       state.sectionDirty = false;
       loadSectionFiles('templates');
-      _showSuccessBanner('Drafted ' + esc(res.data.filename) + ' from ' + res.data.variables_count + ' variables. Import it under Document setup to assemble it.');
+      var drafted = 'Drafted ' + esc(res.data.filename) + ' from ' + res.data.variables_count + ' variables.';
+      if (res.data.profile_name) {
+        drafted += ' Caption and signature block from ' + esc(res.data.profile_name) + '.';
+      }
+      _showSuccessBanner(drafted + ' Import it under Document setup to assemble it.');
     }).catch(function (error) {
       finish();
       setNewTemplateError(error.message || 'Unable to draft the document.');
@@ -11759,6 +11829,10 @@
     if (target.name === 'new-template-kind') {
       setNewTemplateError('');
       syncNewTemplateFields();
+      return;
+    }
+    if (target.id === 'new-template-report-shape') {
+      syncVariableReportShapeFields();
       return;
     }
     if (target.matches('[data-enabled-mode]')) {

--- a/docassemble/ALWeaver/data/templates/editor.html
+++ b/docassemble/ALWeaver/data/templates/editor.html
@@ -473,12 +473,14 @@
         <div class="form-check editor-choice-card mt-2">
           <input class="form-check-input" type="radio" name="new-template-kind" id="new-template-kind-report" value="variable-report">
           <label class="form-check-label" for="new-template-kind-report">
-            <span class="fw-semibold">Variable report</span>
+            <span class="fw-semibold">Draft from this interview&#39;s questions</span>
             <span class="d-block editor-tiny text-muted">
               A DOCX drafted from the questions this interview already asks, with a
-              Jinja field for every variable. The same document ALDashboard's
+              Jinja field for every variable. The same document ALDashboard&#39;s
               interview intake document generator produces. Useful when the answers
-              <em>are</em> the output, so there is no form to start from.
+              <em>are</em> the output, so there is no form to start from &mdash; or
+              when you want a court filing whose caption and signature block come
+              from a jurisdiction template.
             </span>
           </label>
         </div>
@@ -491,6 +493,23 @@
           <input class="form-control form-control-sm mt-1" id="new-template-report-title" autocomplete="off">
           <label class="editor-tiny mt-2" for="new-template-report-filename">Filename</label>
           <input class="form-control form-control-sm mt-1" id="new-template-report-filename" autocomplete="off">
+          <div class="d-none" id="new-template-report-shape-wrap">
+            <label class="editor-tiny mt-2" for="new-template-report-shape">Shape</label>
+            <select class="form-select form-select-sm mt-1" id="new-template-report-shape"></select>
+          </div>
+          <div class="d-none" id="new-template-report-court-wrap">
+            <label class="editor-tiny mt-2" for="new-template-report-profile">Court / jurisdiction</label>
+            <select class="form-select form-select-sm mt-1" id="new-template-report-profile"></select>
+            <div class="editor-tiny text-muted mt-1">
+              Supplies the caption, running footer and signature block. Fonts are
+              Word styles, so a court that wants a different one is a small edit
+              to the template in ALDashboard rather than a rebuild here.
+            </div>
+            <div class="form-check mt-2">
+              <input class="form-check-input" type="checkbox" id="new-template-report-cos">
+              <label class="form-check-label editor-tiny" for="new-template-report-cos">Include a certificate of service</label>
+            </div>
+          </div>
           <div class="form-check mt-2">
             <input class="form-check-input" type="checkbox" id="new-template-report-varnames">
             <label class="form-check-label editor-tiny" for="new-template-report-varnames">Show variable names beside each label</label>

--- a/docassemble/ALWeaver/test_editor_api.py
+++ b/docassemble/ALWeaver/test_editor_api.py
@@ -2202,6 +2202,192 @@ class TestEditorReviewScreenAndTemplateApi(unittest.TestCase):
             self.assertEqual(written["title"], "Main Draft")
             self.assertTrue(os.path.exists(written["path"]))
 
+    def test_the_suggestion_reports_the_shapes_this_server_can_draft(self):
+        files = self._files()
+        with (
+            patch.object(api_editor, "_editor_auth_check", return_value=True),
+            patch.object(api_editor, "_current_user_id", return_value=7),
+            patch.object(
+                api_editor,
+                "playground_read_yaml",
+                side_effect=lambda uid, project, filename: files[filename],
+            ),
+            patch.object(
+                api_editor,
+                "suggested_report_names",
+                return_value={"title": "Main Draft", "filename": "main_draft.docx"},
+            ),
+            patch.object(
+                api_editor,
+                "court_form_options",
+                return_value={
+                    "supported": True,
+                    "shapes": [
+                        {"value": "intake", "label": "Intake summary"},
+                        {"value": "motion", "label": "Motion"},
+                    ],
+                    "profiles": [{"value": "ma_trial_court", "label": "Massachusetts"}],
+                },
+            ),
+        ):
+            with api_editor.app.test_request_context(
+                "/al/editor/api/template/variable-report/suggestion"
+                "?project=default&filename=main.yml",
+                method="GET",
+            ):
+                response = api_editor.editor_api_template_variable_report_suggestion()
+
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()["data"]
+        self.assertTrue(data["court_forms_supported"])
+        self.assertIn("motion", {shape["value"] for shape in data["shapes"]})
+        self.assertEqual(data["court_profiles"][0]["value"], "ma_trial_court")
+
+    def test_the_suggestion_still_works_against_an_older_dashboard(self):
+        files = self._files()
+        with (
+            patch.object(api_editor, "_editor_auth_check", return_value=True),
+            patch.object(api_editor, "_current_user_id", return_value=7),
+            patch.object(
+                api_editor,
+                "playground_read_yaml",
+                side_effect=lambda uid, project, filename: files[filename],
+            ),
+            patch.object(
+                api_editor,
+                "suggested_report_names",
+                return_value={"title": "Main Draft", "filename": "main_draft.docx"},
+            ),
+            patch.object(
+                api_editor,
+                "court_form_options",
+                return_value={"supported": False, "shapes": [], "profiles": []},
+            ),
+        ):
+            with api_editor.app.test_request_context(
+                "/al/editor/api/template/variable-report/suggestion"
+                "?project=default&filename=main.yml",
+                method="GET",
+            ):
+                response = api_editor.editor_api_template_variable_report_suggestion()
+
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()["data"]
+        self.assertFalse(data["court_forms_supported"])
+        self.assertEqual(data["shapes"], [])
+        self.assertEqual(data["title"], "Main Draft")
+
+    def test_a_court_shape_reaches_the_dashboard_and_comes_back_named(self):
+        files = self._files()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            written = {}
+
+            def fake_write(yaml_texts, output_path, **kwargs):
+                written.update(kwargs)
+                with open(output_path, "wb") as handle:
+                    handle.write(b"docx")
+                return {
+                    "variables_count": 4,
+                    "list_count": 1,
+                    "scalar_count": 3,
+                    "size": 4,
+                    "shape": kwargs.get("shape"),
+                    "profile_id": kwargs.get("court_profile"),
+                    "profile_name": "Massachusetts Trial Court",
+                    "sections": {"caption": "yaml"},
+                }
+
+            with (
+                patch.object(api_editor, "_editor_auth_check", return_value=True),
+                patch.object(api_editor, "_current_user_id", return_value=7),
+                patch.object(
+                    api_editor,
+                    "playground_read_yaml",
+                    side_effect=lambda uid, project, filename: files[filename],
+                ),
+                patch.object(
+                    api_editor,
+                    "suggested_report_names",
+                    return_value={
+                        "title": "Main Draft",
+                        "filename": "main_draft.docx",
+                    },
+                ),
+                patch.object(api_editor, "write_variable_report_docx", fake_write),
+                patch.object(
+                    api_editor,
+                    "_editor_storage_directory",
+                    return_value=(SimpleNamespace(finalize=lambda: None), tmpdir),
+                ),
+            ):
+                with api_editor.app.test_request_context(
+                    "/al/editor/api/template/variable-report",
+                    method="POST",
+                    json={
+                        "project": "default",
+                        "filename": "main.yml",
+                        "shape": "motion",
+                        "court_profile": "ma_trial_court",
+                        "include_certificate_of_service": True,
+                    },
+                ):
+                    response = api_editor.editor_api_template_variable_report()
+
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(written["shape"], "motion")
+            self.assertEqual(written["court_profile"], "ma_trial_court")
+            self.assertIs(written["include_certificate_of_service"], True)
+            data = response.get_json()["data"]
+            self.assertEqual(data["profile_name"], "Massachusetts Trial Court")
+            self.assertEqual(data["sections"]["caption"], "yaml")
+
+    def test_omitting_the_shape_still_drafts_the_intake_report(self):
+        """The editor drafted intake reports before shapes existed."""
+        files = self._files()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            written = {}
+
+            def fake_write(yaml_texts, output_path, **kwargs):
+                written.update(kwargs)
+                with open(output_path, "wb") as handle:
+                    handle.write(b"docx")
+                return {"variables_count": 4, "list_count": 1, "scalar_count": 3}
+
+            with (
+                patch.object(api_editor, "_editor_auth_check", return_value=True),
+                patch.object(api_editor, "_current_user_id", return_value=7),
+                patch.object(
+                    api_editor,
+                    "playground_read_yaml",
+                    side_effect=lambda uid, project, filename: files[filename],
+                ),
+                patch.object(
+                    api_editor,
+                    "suggested_report_names",
+                    return_value={
+                        "title": "Main Draft",
+                        "filename": "main_draft.docx",
+                    },
+                ),
+                patch.object(api_editor, "write_variable_report_docx", fake_write),
+                patch.object(
+                    api_editor,
+                    "_editor_storage_directory",
+                    return_value=(SimpleNamespace(finalize=lambda: None), tmpdir),
+                ),
+            ):
+                with api_editor.app.test_request_context(
+                    "/al/editor/api/template/variable-report",
+                    method="POST",
+                    json={"project": "default", "filename": "main.yml"},
+                ):
+                    response = api_editor.editor_api_template_variable_report()
+
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(written["shape"], "intake")
+            self.assertIsNone(written["court_profile"])
+            self.assertIsNone(written["include_certificate_of_service"])
+
     def test_an_existing_template_is_not_silently_overwritten(self):
         files = self._files()
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/docassemble/ALWeaver/test_editor_frontend.py
+++ b/docassemble/ALWeaver/test_editor_frontend.py
@@ -99,6 +99,9 @@ class TestEditorFrontend(unittest.TestCase):
         self.assertIn('id="new-template-kind-blank"', template)
         self.assertIn('id="new-template-kind-report"', template)
         self.assertIn('id="new-template-report-filename"', template)
+        self.assertIn('id="new-template-report-shape"', template)
+        self.assertIn('id="new-template-report-profile"', template)
+        self.assertIn('id="new-template-report-cos"', template)
         self.assertIn('id="new-template-report-sources"', template)
         self.assertIn(".editor-choice-card", css)
 
@@ -108,6 +111,9 @@ class TestEditorFrontend(unittest.TestCase):
         self.assertIn('id="btn-new-template-setup"', editor)
         self.assertIn("apiPost('/api/template/variable-report'", editor)
         self.assertIn("/api/template/variable-report/suggestion?project=", editor)
+        self.assertIn("applyVariableReportOptions(res.data)", editor)
+        self.assertIn("payload.court_profile", editor)
+        self.assertIn("payload.include_certificate_of_service", editor)
 
     def test_review_screen_is_re_synced_rather_than_appended(self):
         editor = (self.package_dir / "data/static/editor.js").read_text()

--- a/docassemble/ALWeaver/test_variable_report.py
+++ b/docassemble/ALWeaver/test_variable_report.py
@@ -1,0 +1,186 @@
+# do not pre-load
+
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from . import variable_report
+from .variable_report import (
+    ALDashboardUnavailable,
+    court_form_options,
+    supports_court_form_shapes,
+    write_variable_report_docx,
+)
+
+SAMPLE_YAML = """---
+id: intro
+question: |
+  Tell us about your case
+fields:
+  - Docket number: docket_number
+"""
+
+
+class _FakeDashboard:
+    """Stands in for ALDashboard's generator, recording how it was called.
+
+    ALDashboard is an optional dependency and is not installed in the Weaver's
+    test environment, which is exactly the condition these tests care about.
+    """
+
+    def __init__(self, court_shapes: bool = True):
+        self.court_shapes = court_shapes
+        self.calls = []
+
+    def generate(self, texts, **kwargs):
+        self.calls.append((texts, kwargs))
+        output_path = kwargs.get("output_docx_path")
+        if output_path:
+            with open(output_path, "wb") as handle:
+                handle.write(b"docx bytes")
+        result = {
+            "variables_count": 4,
+            "list_count": 1,
+            "scalar_count": 3,
+            "shape": kwargs.get("shape", "intake"),
+        }
+        if kwargs.get("shape") and kwargs["shape"] != "intake":
+            result.update(
+                {
+                    "profile_id": kwargs.get("court_profile") or "generic",
+                    "profile_name": "Massachusetts Trial Court",
+                    "sections": {"caption": "yaml", "signature": "yaml"},
+                }
+            )
+        return result
+
+    def shapes(self):
+        return [
+            {"value": "intake", "label": "Intake summary"},
+            {"value": "motion", "label": "Motion"},
+        ]
+
+    def profiles(self):
+        return [
+            {"value": "generic", "label": "Generic court form"},
+            {"value": "ma_trial_court", "label": "Massachusetts Trial Court"},
+        ]
+
+    def install(self, test_case):
+        test_case.enterContext(
+            mock.patch.object(
+                variable_report,
+                "_load_dashboard_report",
+                return_value=(None, self.generate),
+            )
+        )
+        loaded = (self.shapes, self.profiles) if self.court_shapes else None
+        test_case.enterContext(
+            mock.patch.object(
+                variable_report, "_load_dashboard_court_forms", return_value=loaded
+            )
+        )
+
+
+class TestCourtFormOptions(unittest.TestCase):
+    def test_options_come_from_the_installed_dashboard(self):
+        _FakeDashboard().install(self)
+        options = court_form_options()
+        self.assertTrue(options["supported"])
+        self.assertIn("motion", {shape["value"] for shape in options["shapes"]})
+        self.assertIn("ma_trial_court", {item["value"] for item in options["profiles"]})
+        self.assertTrue(supports_court_form_shapes())
+
+    def test_an_older_dashboard_reports_no_court_shapes(self):
+        _FakeDashboard(court_shapes=False).install(self)
+        options = court_form_options()
+        self.assertFalse(options["supported"])
+        self.assertEqual(options["shapes"], [])
+        self.assertEqual(options["profiles"], [])
+        self.assertFalse(supports_court_form_shapes())
+
+    def test_a_broken_profile_on_the_server_is_not_fatal(self):
+        def explode():
+            raise RuntimeError("malformed profile")
+
+        with mock.patch.object(
+            variable_report,
+            "_load_dashboard_court_forms",
+            return_value=(explode, explode),
+        ):
+            self.assertFalse(court_form_options()["supported"])
+
+
+class TestWriteVariableReportDocx(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp(prefix="weaver_variable_report_")
+
+    def _path(self, name="draft.docx"):
+        return os.path.join(self.tempdir, name)
+
+    def test_intake_is_the_default_and_asks_for_no_shape(self):
+        """The original behavior has to survive: the Dashboard's own default."""
+        fake = _FakeDashboard()
+        fake.install(self)
+        summary = write_variable_report_docx(
+            [SAMPLE_YAML], self._path(), report_title="Main Draft"
+        )
+        _texts, kwargs = fake.calls[0]
+        self.assertNotIn("shape", kwargs)
+        self.assertNotIn("court_profile", kwargs)
+        self.assertEqual(summary["shape"], "intake")
+        self.assertEqual(summary["variables_count"], 4)
+        self.assertNotIn("profile_id", summary)
+
+    def test_a_court_shape_passes_the_profile_through(self):
+        fake = _FakeDashboard()
+        fake.install(self)
+        summary = write_variable_report_docx(
+            [SAMPLE_YAML],
+            self._path(),
+            report_title="Motion to Vacate",
+            shape="motion",
+            court_profile="ma_trial_court",
+            include_certificate_of_service=True,
+        )
+        _texts, kwargs = fake.calls[0]
+        self.assertEqual(kwargs["shape"], "motion")
+        self.assertEqual(kwargs["court_profile"], "ma_trial_court")
+        self.assertIs(kwargs["include_certificate_of_service"], True)
+        self.assertEqual(summary["profile_id"], "ma_trial_court")
+        self.assertEqual(summary["profile_name"], "Massachusetts Trial Court")
+        self.assertEqual(summary["sections"]["caption"], "yaml")
+
+    def test_certificate_of_service_is_omitted_when_not_chosen(self):
+        fake = _FakeDashboard()
+        fake.install(self)
+        write_variable_report_docx(
+            [SAMPLE_YAML], self._path(), shape="motion", court_profile="generic"
+        )
+        _texts, kwargs = fake.calls[0]
+        self.assertNotIn("include_certificate_of_service", kwargs)
+
+    def test_a_court_shape_against_an_older_dashboard_explains_itself(self):
+        _FakeDashboard(court_shapes=False).install(self)
+        with self.assertRaises(ALDashboardUnavailable) as caught:
+            write_variable_report_docx([SAMPLE_YAML], self._path(), shape="motion")
+        self.assertIn("newer ALDashboard", str(caught.exception))
+
+    def test_the_intake_report_still_works_against_an_older_dashboard(self):
+        fake = _FakeDashboard(court_shapes=False)
+        fake.install(self)
+        summary = write_variable_report_docx([SAMPLE_YAML], self._path())
+        self.assertEqual(summary["variables_count"], 4)
+        self.assertGreater(summary["size"], 0)
+
+    def test_empty_yaml_is_rejected_before_the_dashboard_is_called(self):
+        fake = _FakeDashboard()
+        fake.install(self)
+        with self.assertRaises(ValueError):
+            write_variable_report_docx(["", "   "], self._path())
+        self.assertEqual(fake.calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docassemble/ALWeaver/test_variable_report.py
+++ b/docassemble/ALWeaver/test_variable_report.py
@@ -115,7 +115,9 @@ class TestCourtFormOptions(unittest.TestCase):
 
 class TestWriteVariableReportDocx(unittest.TestCase):
     def setUp(self):
-        self.tempdir = tempfile.mkdtemp(prefix="weaver_variable_report_")
+        self._tempdir = tempfile.TemporaryDirectory(prefix="weaver_variable_report_")
+        self.addCleanup(self._tempdir.cleanup)
+        self.tempdir = self._tempdir.name
 
     def _path(self, name="draft.docx"):
         return os.path.join(self.tempdir, name)

--- a/docassemble/ALWeaver/test_variable_report.py
+++ b/docassemble/ALWeaver/test_variable_report.py
@@ -3,6 +3,7 @@
 import os
 import tempfile
 import unittest
+from typing import Any, Dict, List, Tuple
 from unittest import mock
 
 from . import variable_report
@@ -31,7 +32,7 @@ class _FakeDashboard:
 
     def __init__(self, court_shapes: bool = True):
         self.court_shapes = court_shapes
-        self.calls = []
+        self.calls: List[Tuple[List[str], Dict[str, Any]]] = []
 
     def generate(self, texts, **kwargs):
         self.calls.append((texts, kwargs))

--- a/docassemble/ALWeaver/variable_report.py
+++ b/docassemble/ALWeaver/variable_report.py
@@ -11,6 +11,16 @@ fields line up with the variables the interview gathers. This module imports
 that at runtime -- the Dashboard is an optional dependency, as it is for the
 review screen generator and the linter -- and drops the result straight into the
 project's templates folder, where the Weaver's document setup can pick it up.
+
+The Dashboard can also arrange those same variables into a court filing rather
+than a list of fields (ALDashboard#272, and the "generic court form output
+document" ask in #498). A jurisdiction profile there supplies the caption,
+running footer, signature block and certificate of service; the interview's
+screens become the middle of the document. This module exposes that as the
+``shape`` argument and asks the Dashboard which shapes and profiles a given
+server actually has, because the answer depends on which ALDashboard is
+installed -- an older one has none of this, and the Weaver has to keep working
+against it.
 """
 
 import os
@@ -20,9 +30,15 @@ from .review_screen_sync import ALDashboardUnavailable
 
 __all__ = [
     "ALDashboardUnavailable",
+    "DEFAULT_SHAPE",
+    "court_form_options",
     "suggested_report_names",
+    "supports_court_form_shapes",
     "write_variable_report_docx",
 ]
+
+# The shape that behaves exactly as this module always has.
+DEFAULT_SHAPE = "intake"
 
 
 def _load_dashboard_report():
@@ -37,6 +53,53 @@ def _load_dashboard_report():
             "docassemble.ALDashboard on this server and try again."
         ) from err
     return extract_interview_metadata_info, generate_variable_report
+
+
+def _load_dashboard_court_forms():
+    """The Dashboard's court form listing helpers, or ``None`` if it predates them.
+
+    Returning ``None`` rather than raising is deliberate: a server running an
+    older ALDashboard should still be offered the intake report, just without
+    the court shapes.
+    """
+    try:
+        from docassemble.ALDashboard.variable_report_generator import (  # type: ignore
+            list_court_form_profile_choices,
+            list_court_form_shapes,
+        )
+    except Exception:  # pragma: no cover - depends on the server's packages
+        return None
+    return list_court_form_shapes, list_court_form_profile_choices
+
+
+def supports_court_form_shapes() -> bool:
+    """Whether the installed ALDashboard can draft court shapes at all."""
+    return _load_dashboard_court_forms() is not None
+
+
+def court_form_options() -> Dict[str, Any]:
+    """The shapes and jurisdiction profiles this server can offer.
+
+    ``supported`` is false against an ALDashboard that predates court shapes; the
+    caller should then offer the intake report alone rather than a dropdown of
+    choices that would fail on use.
+    """
+    loaded = _load_dashboard_court_forms()
+    if loaded is None:
+        return {"supported": False, "shapes": [], "profiles": []}
+    list_shapes, list_profiles = loaded
+    try:
+        shapes = [
+            {"value": str(item["value"]), "label": str(item["label"])}
+            for item in list_shapes()
+        ]
+        profiles = [
+            {"value": str(item["value"]), "label": str(item["label"])}
+            for item in list_profiles()
+        ]
+    except Exception:  # pragma: no cover - a malformed profile on the server
+        return {"supported": False, "shapes": [], "profiles": []}
+    return {"supported": True, "shapes": shapes, "profiles": profiles}
 
 
 def suggested_report_names(
@@ -59,11 +122,20 @@ def write_variable_report_docx(
     *,
     report_title: Optional[str] = None,
     show_variable_names: bool = False,
+    shape: str = DEFAULT_SHAPE,
+    court_profile: Optional[str] = None,
+    include_certificate_of_service: Optional[bool] = None,
 ) -> Dict[str, Any]:
     """Write the report to ``output_path`` and describe what went into it.
 
+    ``shape`` defaults to the intake summary this has always produced. Any other
+    shape -- ``court_form``, ``motion``, ``affidavit``, ``letter`` -- drafts a
+    court document using the jurisdiction profile named by ``court_profile``,
+    and the returned summary then also carries which profile was used and which
+    template each fixed section came from.
+
     Raises ``ALDashboardUnavailable`` when the Dashboard package is not
-    installed on this server.
+    installed, or when it is too old to draft the requested shape.
     """
     _extract, generate_variable_report = _load_dashboard_report()
     texts: List[str] = [
@@ -72,15 +144,41 @@ def write_variable_report_docx(
     if not texts:
         raise ValueError("There is no YAML to draft a template from.")
 
-    result = generate_variable_report(
-        texts,
-        report_title=report_title,
-        show_variable_names=show_variable_names,
-        output_docx_path=output_path,
-    )
-    return {
+    shape_name = str(shape or DEFAULT_SHAPE).strip().lower() or DEFAULT_SHAPE
+
+    options: Dict[str, Any] = {
+        "report_title": report_title,
+        "show_variable_names": show_variable_names,
+        "output_docx_path": output_path,
+    }
+    if shape_name != DEFAULT_SHAPE:
+        if not supports_court_form_shapes():
+            raise ALDashboardUnavailable(
+                f"Drafting a {shape_name.replace('_', ' ')} needs a newer "
+                "ALDashboard. Update docassemble.ALDashboard on this server, or "
+                "draft the intake report instead."
+            )
+        options["shape"] = shape_name
+        if court_profile:
+            options["court_profile"] = str(court_profile)
+        if include_certificate_of_service is not None:
+            options["include_certificate_of_service"] = bool(
+                include_certificate_of_service
+            )
+
+    result = generate_variable_report(texts, **options)
+
+    summary: Dict[str, Any] = {
         "variables_count": int(result.get("variables_count") or 0),
         "list_count": int(result.get("list_count") or 0),
         "scalar_count": int(result.get("scalar_count") or 0),
         "size": os.path.getsize(output_path) if os.path.exists(output_path) else 0,
+        "shape": str(result.get("shape") or shape_name),
     }
+    # Only a court shape has these, and only a Dashboard new enough to report
+    # them. Passing them through lets the editor say which caption it drew and
+    # whether a Word-authored override replaced it.
+    for key in ("profile_id", "profile_name", "sections"):
+        if result.get(key):
+            summary[key] = result[key]
+    return summary


### PR DESCRIPTION
Addresses the Weaver's half of #498 — a generic "court form" output document — by exposing the court form shapes that [ALDashboard#272](https://github.com/SuffolkLITLab/docassemble-ALDashboard/issues/272) adds.

## What changes

The Weaver can already draft a starter DOCX from the questions an interview asks. ALDashboard can now arrange those same variables into a court filing instead of a list of fields: a jurisdiction profile supplies the caption, running footer, signature block and certificate of service, and the interview's screens become the numbered middle of the document.

`write_variable_report_docx()` grows `shape`, `court_profile` and `include_certificate_of_service`. Shapes are `intake` (unchanged, still the default), `court_form`, `motion`, `affidavit` and `letter`.

In the editor's "+ New" template picker, choosing to draft from the interview's questions now offers a **Shape** dropdown, and — for anything other than the intake report — a **Court / jurisdiction** dropdown and a certificate-of-service checkbox. The success banner names the caption that was drawn.

## Version tolerance

ALDashboard is an optional dependency here and its version is not ours to assume, so the Weaver asks what it can do rather than hard-coding a list of shapes that might fail on use. A new `court_form_options()` reports what the installed Dashboard supports, and the suggestion endpoint passes that to the editor.

Against an older ALDashboard:

- `court_form_options()` reports `supported: false`;
- the editor hides the shape picker entirely rather than showing choices that would fail;
- the intake report keeps working exactly as before;
- asking for a court shape anyway raises `ALDashboardUnavailable` telling the author to update ALDashboard, instead of a `TypeError` about an unexpected keyword argument.

There are tests for each of those.

## Backward compatibility

`shape` defaults to `intake`, so every existing caller and the editor's existing flow behave as they did. A POST that omits `shape` still drafts the intake report — asserted by `test_omitting_the_shape_still_drafts_the_intake_report`.

## Where a court's layout lives

Nothing about a court's layout is in this repo. Profiles are editable YAML in ALDashboard, any section can be replaced with a Word-authored `.docx` fragment, and fonts and spacing are Word styles — so a court that wants a different font is a one-line edit there, not a change here.

## Depends on

The ALDashboard side (`court_form_profiles.py`, `court_form_generator.py`, the profiles, and the `shape`/`court_profile` arguments on `generate_variable_report`). Until that ships, this branch is inert rather than broken: `court_form_options()` reports no support and the editor offers the intake report alone.

## Testing

- New `test_variable_report.py` (9 tests) covering the pass-through, the older-Dashboard fallbacks, and a malformed profile on the server.
- 4 new endpoint tests in `test_editor_api.py`.
- Full suite: 778 passed, 737 subtests passed. `black` and `mypy` clean; `node --check` on `editor.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)