### PR TITLE
Add axe accessibility check for /al/editor

### DIFF
--- a/.github/fixtures/editor_a11y/editor_accessibility.js
+++ b/.github/fixtures/editor_a11y/editor_accessibility.js
@@ -1,0 +1,1 @@
+window.editorAccessibilityFixture = true;

--- a/.github/fixtures/editor_a11y/editor_accessibility.md
+++ b/.github/fixtures/editor_a11y/editor_accessibility.md
@@ -1,0 +1,3 @@
+# Accessibility fixture template
+
+This editable Markdown file gives the Templates view a real source editor.

--- a/.github/fixtures/editor_a11y/editor_accessibility.py
+++ b/.github/fixtures/editor_a11y/editor_accessibility.py
@@ -1,0 +1,1 @@
+EDITOR_FIXTURE_VALUE = "ready"

--- a/.github/fixtures/editor_a11y/editor_accessibility.txt
+++ b/.github/fixtures/editor_a11y/editor_accessibility.txt
@@ -1,0 +1,1 @@
+Accessibility fixture source data.

--- a/.github/fixtures/editor_a11y/editor_accessibility.yml
+++ b/.github/fixtures/editor_a11y/editor_accessibility.yml
@@ -9,12 +9,14 @@ code: |
 question: What is your name?
 subquestion: This screen gives the graphical editor a real field to edit.
 fields:
-  - First name: editor_fixture_name
+  - label: First name
+    field: editor_fixture_name
     datatype: text
 ---
 question: Choose a color
 fields:
-  - Color: editor_fixture_color
+  - label: Color
+    field: editor_fixture_color
     datatype: radio
     choices:
       - Blue

--- a/.github/fixtures/editor_a11y/editor_accessibility.yml
+++ b/.github/fixtures/editor_a11y/editor_accessibility.yml
@@ -1,0 +1,25 @@
+metadata:
+  title: Accessibility editor fixture
+  short title: Accessibility fixture
+  description: A small interview used to exercise the Weaver editor in CI.
+---
+code: |
+  editor_fixture_value = "ready"
+---
+question: What is your name?
+subquestion: This screen gives the graphical editor a real field to edit.
+fields:
+  - First name: editor_fixture_name
+    datatype: text
+---
+question: Choose a color
+fields:
+  - Color: editor_fixture_color
+    datatype: radio
+    choices:
+      - Blue
+      - Green
+---
+question: Fixture complete
+subquestion: |
+  Hello ${ editor_fixture_name }.

--- a/.github/scripts/editor_a11y.js
+++ b/.github/scripts/editor_a11y.js
@@ -109,8 +109,17 @@ async function closeModal(page, selector) {
 }
 
 async function openMoreMenu(page) {
-  await page.locator("#topbar-more-menu").click();
-  await page.locator("#topbar-more-menu").getAttribute("aria-expanded");
+  const button = page.locator("#topbar-more-menu");
+  const menu = page.locator('ul[aria-labelledby="topbar-more-menu"]');
+  if ((await button.getAttribute("aria-expanded")) !== "true") {
+    await button.click();
+  }
+  await page.waitForFunction(
+    () => document.querySelector("#topbar-more-menu")?.getAttribute("aria-expanded") === "true",
+    undefined,
+    { timeout: 10_000 }
+  );
+  await menu.waitFor({ state: "visible", timeout: 10_000 });
 }
 
 async function main() {

--- a/.github/scripts/editor_a11y.js
+++ b/.github/scripts/editor_a11y.js
@@ -176,7 +176,7 @@ async function main() {
       )
     );
     await page.locator("#cancel-new-project").click();
-    await page.locator('[data-project-card="default"]').click();
+    await page.locator('[data-project-card="default"]').last().click();
     await page.locator("#outline-list .editor-outline-item").first().waitFor();
 
     // Project-wide search dialog and its result state.

--- a/.github/scripts/editor_a11y.js
+++ b/.github/scripts/editor_a11y.js
@@ -15,9 +15,7 @@ const pageErrors = [];
 async function signInIfNeeded(page) {
   await page.goto(`${serverUrl}/al/editor`, { waitUntil: "domcontentloaded" });
 
-  if (new URL(page.url()).pathname.endsWith("/al/editor")) {
-    return;
-  }
+  if (new URL(page.url()).pathname.endsWith("/al/editor")) return;
 
   const emailInput = page
     .locator('input[type="email"], input[name="email"], input[name="username"]')
@@ -56,8 +54,44 @@ async function audit(page, label) {
       })
     );
   }
-
   return blocking;
+}
+
+async function auditAfter(page, label, locator, action) {
+  await action();
+  await locator.waitFor({ state: "visible", timeout: 30_000 });
+  await page.waitForTimeout(250);
+  return audit(page, label);
+}
+
+async function selectOption(page, selector, value, description) {
+  const control = page.locator(selector);
+  await control.waitFor({ state: "visible", timeout: 30_000 });
+  const options = await control.locator("option").evaluateAll((items) =>
+    items.map((item) => ({ value: item.value, label: item.textContent.trim() }))
+  );
+  const option = options.find((item) => item.value === value || item.label === value);
+  if (!option) {
+    throw new Error(
+      `Could not find ${description} ${value}; available options: ${JSON.stringify(options)}`
+    );
+  }
+  await control.selectOption(option.value);
+}
+
+async function closeModal(page, selector) {
+  const modal = page.locator(selector);
+  if (await modal.locator(".btn-close").count()) {
+    await modal.locator(".btn-close").first().click();
+  } else {
+    await modal.locator('[data-bs-dismiss="modal"]').first().click();
+  }
+  await modal.waitFor({ state: "hidden", timeout: 10_000 });
+}
+
+async function openMoreMenu(page) {
+  await page.locator("#topbar-more-menu").click();
+  await page.locator("#topbar-more-menu").getAttribute("aria-expanded");
 }
 
 async function main() {
@@ -68,17 +102,166 @@ async function main() {
   const page = await context.newPage();
   page.on("pageerror", (error) => pageErrors.push(String(error)));
 
+  let blockingViolations = [];
   try {
     await signInIfNeeded(page);
     await page.locator("#editor-app").waitFor({ state: "visible", timeout: 30_000 });
 
-    let blockingViolations = await audit(page, "interview");
+    // Open a real Playground interview and its file-backed editing areas.
+    await selectOption(page, "#project-select", "default", "project");
+    await page.locator('#file-select option[value="editor_accessibility.yml"]').waitFor({
+      state: "attached",
+      timeout: 30_000,
+    });
+    await selectOption(page, "#file-select", "editor_accessibility.yml", "interview file");
+    await page.locator("#outline-list .editor-outline-item").first().waitFor({
+      state: "visible",
+      timeout: 30_000,
+    });
+    blockingViolations = blockingViolations.concat(
+      await audit(page, "interview editor")
+    );
+
+    // Visit every file-backed secondary editor, not only the empty shell.
     for (const view of ["templates", "modules", "static", "data"]) {
       const tab = page.locator(`.editor-top-tab[data-view="${view}"]`).first();
-      await tab.click();
-      await page.waitForTimeout(500);
-      blockingViolations = blockingViolations.concat(await audit(page, view));
+      blockingViolations = blockingViolations.concat(
+        await auditAfter(
+          page,
+          `${view} source editor`,
+          page.locator("#section-file-source-editor"),
+          () => tab.click()
+        )
+      );
     }
+    await page.locator('.editor-top-tab[data-view="interview"]').click();
+    await page.locator("#outline-list .editor-outline-item").first().waitFor();
+
+    // Project selector and the new-project editing form.
+    blockingViolations = blockingViolations.concat(
+      await auditAfter(
+        page,
+        "project selector",
+        page.locator("#project-search-input"),
+        () => page.locator('[data-action="open-project-selector"]').first().click()
+      )
+    );
+    blockingViolations = blockingViolations.concat(
+      await auditAfter(
+        page,
+        "new project form",
+        page.locator("#new-project-name"),
+        () => page.locator("#open-new-project-card").click()
+      )
+    );
+    await page.locator("#cancel-new-project").click();
+    await page.locator('[data-project-card="default"]').click();
+    await page.locator("#outline-list .editor-outline-item").first().waitFor();
+
+    // Project-wide search dialog and its result state.
+    await page.locator("#btn-project-search").click();
+    blockingViolations = blockingViolations.concat(
+      await audit(page, "project search dialog")
+    );
+    await page.locator("#project-search-query").fill("editor_fixture");
+    await page.locator("#project-search-submit").click();
+    await page.locator("#project-search-status").waitFor({ state: "visible" });
+    blockingViolations = blockingViolations.concat(
+      await audit(page, "project search results")
+    );
+    await closeModal(page, "#project-search-modal");
+
+    // Validation actions and the open results drawer.
+    await page.locator('[data-action="check-errors"]').click();
+    await page.waitForTimeout(1_000);
+    blockingViolations = blockingViolations.concat(
+      await audit(page, "validation drawer")
+    );
+    await page.locator('[aria-label="Validation actions"]').click();
+    blockingViolations = blockingViolations.concat(
+      await audit(page, "validation actions menu")
+    );
+    await page.locator("#btn-style-check").click();
+    await page.waitForTimeout(1_000);
+    blockingViolations = blockingViolations.concat(
+      await audit(page, "style-check results")
+    );
+
+    // Full YAML, metadata, and interview-order source editors.
+    await openMoreMenu(page);
+    await page.locator('[data-action="open-full-yaml"]').click();
+    await page.locator("#full-source-editor").waitFor({ state: "visible" });
+    blockingViolations = blockingViolations.concat(
+      await audit(page, "full YAML editor")
+    );
+    for (const tabName of ["metadata", "order"]) {
+      await page.locator(`[data-yaml-tab="${tabName}"]`).click();
+      await page.waitForTimeout(250);
+      blockingViolations = blockingViolations.concat(
+        await audit(page, `${tabName} YAML editor`)
+      );
+    }
+    await page.locator("#back-to-question").click();
+    await page.locator("#outline-list .editor-outline-item").first().waitFor();
+
+    // AssemblyLine settings, including its explanatory popover.
+    await openMoreMenu(page);
+    await page.locator('[data-action="open-assemblyline-settings"]').click();
+    await page.locator("#assemblyline-settings-filter").waitFor({ state: "visible" });
+    blockingViolations = blockingViolations.concat(
+      await audit(page, "AssemblyLine settings")
+    );
+    await page.locator("[data-al-settings-explainer]").click();
+    await page.locator(".popover").waitFor({ state: "visible", timeout: 10_000 });
+    blockingViolations = blockingViolations.concat(
+      await audit(page, "AssemblyLine settings explainer")
+    );
+    await page.locator("#close-assemblyline-settings").click();
+    await page.locator("#outline-list .editor-outline-item").first().waitFor();
+
+    // Graphical question editing, field settings, YAML editing, and preview.
+    const question = page.locator('.editor-outline-item[data-block-id]').filter({
+      hasText: "What is your name?",
+    });
+    await question.first().click();
+    await page.locator("#q-title").waitFor({ state: "visible" });
+    blockingViolations = blockingViolations.concat(
+      await audit(page, "graphical question editor")
+    );
+    await page.locator('[data-question-tab="options"]').click();
+    await page.waitForTimeout(250);
+    blockingViolations = blockingViolations.concat(
+      await audit(page, "question options editor")
+    );
+    await page.locator(".editor-field-kebab-btn").first().click();
+    await page.waitForTimeout(250);
+    blockingViolations = blockingViolations.concat(
+      await audit(page, "field settings editor")
+    );
+    await page.locator(".editor-field-kebab-btn").first().click();
+    await page.locator("#toggle-edit-mode-tab").click();
+    await page.locator("#block-source-editor").waitFor({ state: "visible" });
+    blockingViolations = blockingViolations.concat(
+      await audit(page, "question YAML editor")
+    );
+    await page.locator('[data-question-mode="preview"]').first().click();
+    await page.locator("#q-title").waitFor({ state: "visible" });
+    await page.locator("#question-preview-tab").click();
+    await page.locator("#screen-preview-modal").waitFor({ state: "visible" });
+    await page.locator("#screen-preview-frame").waitFor({ state: "visible" });
+    await page.waitForTimeout(250);
+    blockingViolations = blockingViolations.concat(
+      await audit(page, "screen preview dialog")
+    );
+    await closeModal(page, "#screen-preview-modal");
+
+    // The insert-block dialog is the main entry point for authoring new work.
+    await page.locator(".editor-outline-insert-btn").first().click();
+    await page.locator("#insert-modal").waitFor({ state: "visible" });
+    blockingViolations = blockingViolations.concat(
+      await audit(page, "insert-block dialog")
+    );
+    await closeModal(page, "#insert-modal");
 
     if (pageErrors.length) {
       console.error("Browser page errors:");

--- a/.github/scripts/editor_a11y.js
+++ b/.github/scripts/editor_a11y.js
@@ -237,6 +237,7 @@ async function main() {
     blockingViolations = blockingViolations.concat(
       await audit(page, "AssemblyLine settings explainer")
     );
+    await page.keyboard.press("Escape");
     await page.locator("#close-assemblyline-settings").click();
     await page.locator("#outline-list .editor-outline-item").first().waitFor();
 
@@ -245,6 +246,7 @@ async function main() {
       hasText: "What is your name?",
     });
     await question.first().click();
+    await page.locator('[data-question-tab="screen"]').click();
     await page.locator("#q-title").waitFor({ state: "visible" });
     blockingViolations = blockingViolations.concat(
       await audit(page, "graphical question editor")

--- a/.github/scripts/editor_a11y.js
+++ b/.github/scripts/editor_a11y.js
@@ -64,6 +64,25 @@ async function auditAfter(page, label, locator, action) {
   return audit(page, label);
 }
 
+async function auditSecondaryView(page, view, filename, blockingViolations) {
+  await page.locator(`.editor-top-tab[data-view="${view}"]`).click();
+  await page
+    .locator(".editor-full-yaml-header h2")
+    .filter({ hasText: filename })
+    .waitFor({ state: "visible", timeout: 30_000 });
+  await page.locator("#section-file-source-editor").waitFor({
+    state: "visible",
+    timeout: 30_000,
+  });
+  const apiError = page.locator("#editor-api-error");
+  if (await apiError.isVisible()) {
+    throw new Error(`Editor API error while opening ${view}: ${await apiError.innerText()}`);
+  }
+  return blockingViolations.concat(
+    await audit(page, `${view} source editor`)
+  );
+}
+
 async function selectOption(page, selector, value, description) {
   const control = page.locator(selector);
   await control.waitFor({ state: "visible", timeout: 30_000 });
@@ -123,15 +142,17 @@ async function main() {
     );
 
     // Visit every file-backed secondary editor, not only the empty shell.
-    for (const view of ["templates", "modules", "static", "data"]) {
-      const tab = page.locator(`.editor-top-tab[data-view="${view}"]`).first();
-      blockingViolations = blockingViolations.concat(
-        await auditAfter(
-          page,
-          `${view} source editor`,
-          page.locator("#section-file-source-editor"),
-          () => tab.click()
-        )
+    for (const [view, filename] of [
+      ["templates", "editor_accessibility.md"],
+      ["modules", "editor_accessibility.py"],
+      ["static", "editor_accessibility.js"],
+      ["data", "editor_accessibility.txt"],
+    ]) {
+      blockingViolations = await auditSecondaryView(
+        page,
+        view,
+        filename,
+        blockingViolations
       );
     }
     await page.locator('.editor-top-tab[data-view="interview"]').click();

--- a/.github/scripts/editor_a11y.js
+++ b/.github/scripts/editor_a11y.js
@@ -1,0 +1,98 @@
+const { chromium } = require("playwright");
+const AxeBuilder = require("@axe-core/playwright").default;
+
+const serverUrl = String(process.env.SERVER_URL || "").replace(/\/$/, "");
+const email = process.env.EDITOR_EMAIL;
+const password = process.env.EDITOR_PASSWORD;
+
+if (!serverUrl || !email || !password) {
+  throw new Error("SERVER_URL, EDITOR_EMAIL, and EDITOR_PASSWORD are required");
+}
+
+const blockingImpacts = new Set(["critical", "serious"]);
+const pageErrors = [];
+
+async function signInIfNeeded(page) {
+  await page.goto(`${serverUrl}/al/editor`, { waitUntil: "domcontentloaded" });
+
+  if (new URL(page.url()).pathname.endsWith("/al/editor")) {
+    return;
+  }
+
+  const emailInput = page
+    .locator('input[type="email"], input[name="email"], input[name="username"]')
+    .first();
+  await emailInput.fill(email);
+  await page.locator('input[type="password"]').first().fill(password);
+  await page
+    .getByRole("button", { name: /sign in|log in/i })
+    .first()
+    .click();
+  await page.waitForURL((url) => url.pathname.endsWith("/al/editor"), {
+    timeout: 30_000,
+  });
+}
+
+async function audit(page, label) {
+  const result = await new AxeBuilder({ page })
+    .withTags(["wcag2a", "wcag2aa"])
+    .analyze();
+  const blocking = result.violations.filter((violation) =>
+    blockingImpacts.has(violation.impact)
+  );
+
+  console.log(
+    `${label}: ${result.violations.length} total violation(s), ` +
+      `${blocking.length} blocking violation(s)`
+  );
+  for (const violation of result.violations) {
+    console.log(
+      JSON.stringify({
+        id: violation.id,
+        impact: violation.impact,
+        help: violation.help,
+        helpUrl: violation.helpUrl,
+        targets: violation.nodes.map((node) => node.target),
+      })
+    );
+  }
+
+  return blocking;
+}
+
+async function main() {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({
+    viewport: { width: 1440, height: 1200 },
+  });
+  const page = await context.newPage();
+  page.on("pageerror", (error) => pageErrors.push(String(error)));
+
+  try {
+    await signInIfNeeded(page);
+    await page.locator("#editor-app").waitFor({ state: "visible", timeout: 30_000 });
+
+    let blockingViolations = await audit(page, "interview");
+    for (const view of ["templates", "modules", "static", "data"]) {
+      const tab = page.locator(`.editor-top-tab[data-view="${view}"]`).first();
+      await tab.click();
+      await page.waitForTimeout(500);
+      blockingViolations = blockingViolations.concat(await audit(page, view));
+    }
+
+    if (pageErrors.length) {
+      console.error("Browser page errors:");
+      for (const error of pageErrors) console.error(error);
+      process.exitCode = 1;
+    }
+    if (blockingViolations.length) process.exitCode = 1;
+  } finally {
+    await context.close();
+    await browser.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/.github/scripts/editor_a11y.js
+++ b/.github/scripts/editor_a11y.js
@@ -251,12 +251,17 @@ async function main() {
     blockingViolations = blockingViolations.concat(
       await audit(page, "graphical question editor")
     );
-    await page.locator(".editor-field-kebab-btn").first().click();
-    await page.waitForTimeout(250);
-    blockingViolations = blockingViolations.concat(
-      await audit(page, "field settings editor")
-    );
-    await page.locator(".editor-field-kebab-btn").first().click();
+    const fieldSettingsButton = page.locator(".editor-field-kebab-btn").first();
+    if (await fieldSettingsButton.count()) {
+      await fieldSettingsButton.click();
+      await page.waitForTimeout(250);
+      blockingViolations = blockingViolations.concat(
+        await audit(page, "field settings editor")
+      );
+      await fieldSettingsButton.click();
+    } else {
+      console.log("field settings editor: fixture field has no settings control");
+    }
     await page.locator('[data-question-tab="options"]').click();
     await page.waitForTimeout(250);
     blockingViolations = blockingViolations.concat(

--- a/.github/scripts/editor_a11y.js
+++ b/.github/scripts/editor_a11y.js
@@ -249,17 +249,17 @@ async function main() {
     blockingViolations = blockingViolations.concat(
       await audit(page, "graphical question editor")
     );
-    await page.locator('[data-question-tab="options"]').click();
-    await page.waitForTimeout(250);
-    blockingViolations = blockingViolations.concat(
-      await audit(page, "question options editor")
-    );
     await page.locator(".editor-field-kebab-btn").first().click();
     await page.waitForTimeout(250);
     blockingViolations = blockingViolations.concat(
       await audit(page, "field settings editor")
     );
     await page.locator(".editor-field-kebab-btn").first().click();
+    await page.locator('[data-question-tab="options"]').click();
+    await page.waitForTimeout(250);
+    blockingViolations = blockingViolations.concat(
+      await audit(page, "question options editor")
+    );
     await page.locator("#toggle-edit-mode-tab").click();
     await page.locator("#block-source-editor").waitFor({ state: "visible" });
     blockingViolations = blockingViolations.concat(

--- a/.github/scripts/editor_a11y.js
+++ b/.github/scripts/editor_a11y.js
@@ -294,7 +294,13 @@ async function main() {
 
     // The insert-block dialog is the main entry point for authoring new work.
     await page.locator(".editor-outline-insert-btn").first().click();
-    await page.locator("#insert-modal").waitFor({ state: "visible" });
+    const insertModal = page.locator("#insert-modal");
+    await insertModal.waitFor({ state: "visible" });
+    await page.locator("#insert-modal.show").waitFor({
+      state: "attached",
+      timeout: 10_000,
+    });
+    await page.waitForTimeout(250);
     blockingViolations = blockingViolations.concat(
       await audit(page, "insert-block dialog")
     );

--- a/.github/workflows/alkiln_tests.yml
+++ b/.github/workflows/alkiln_tests.yml
@@ -42,6 +42,22 @@ jobs:
           INSTALL_METHOD: "server"
           # To learn more, see https://assemblyline.suffolklitlab.org/docs/alkiln/writing/#optional-inputs
           ALKILN_TAG_EXPRESSION: "${{ env.ALKILN_TAG_EXPRESSION }}"
+      - name: Install accessibility test dependencies
+        if: ${{ !cancelled() }}
+        run: |
+          mkdir -p /tmp/alweaver-a11y
+          cd /tmp/alweaver-a11y
+          npm init -y
+          npm install playwright @axe-core/playwright
+          npx playwright install --with-deps chromium
+      - name: Check /al/editor accessibility
+        if: ${{ !cancelled() }}
+        env:
+          SERVER_URL: "${{ steps.github_server.outputs.SERVER_URL }}"
+          EDITOR_EMAIL: "${{ steps.github_server.outputs.DA_ADMIN_EMAIL }}"
+          EDITOR_PASSWORD: "${{ steps.github_server.outputs.DA_ADMIN_PASSWORD }}"
+          NODE_PATH: /tmp/alweaver-a11y/node_modules
+        run: node .github/scripts/editor_a11y.js
       - run: echo "Finished running ALKiln end-to-end tests"
       
       ## To make a new issue in your repository when a test fails,

--- a/.github/workflows/alkiln_tests.yml
+++ b/.github/workflows/alkiln_tests.yml
@@ -32,6 +32,17 @@ jobs:
           SHOW_DOCKER_OUTPUT: "${{ github.event.inputs.show_docker_output }}"
           DOCASSEMBLECLI_VERSION: "0.0.25"
       - run: echo "ALKiln finished starting the isolated GitHub docassemble server"
+      - name: Mask temporary server credentials
+        env:
+          ADMIN_EMAIL: "${{ steps.github_server.outputs.DA_ADMIN_EMAIL }}"
+          ADMIN_PASSWORD: "${{ steps.github_server.outputs.DA_ADMIN_PASSWORD }}"
+          ADMIN_API_KEY: "${{ steps.github_server.outputs.DA_ADMIN_API_KEY }}"
+          DEVELOPER_API_KEY: "${{ steps.github_server.outputs.DOCASSEMBLE_DEVELOPER_API_KEY }}"
+        run: |
+          echo "::add-mask::$ADMIN_EMAIL"
+          echo "::add-mask::$ADMIN_PASSWORD"
+          echo "::add-mask::$ADMIN_API_KEY"
+          echo "::add-mask::$DEVELOPER_API_KEY"
       - name: Use ALKiln to run tests
         uses: SuffolkLITLab/ALKiln@v5
         env:

--- a/.github/workflows/alkiln_tests.yml
+++ b/.github/workflows/alkiln_tests.yml
@@ -53,6 +53,37 @@ jobs:
           INSTALL_METHOD: "server"
           # To learn more, see https://assemblyline.suffolklitlab.org/docs/alkiln/writing/#optional-inputs
           ALKILN_TAG_EXPRESSION: "${{ env.ALKILN_TAG_EXPRESSION }}"
+      - name: Seed editor accessibility fixture
+        if: ${{ !cancelled() }}
+        env:
+          SERVER_URL: "${{ steps.github_server.outputs.SERVER_URL }}"
+          ADMIN_API_KEY: "${{ steps.github_server.outputs.DA_ADMIN_API_KEY }}"
+        run: |
+          curl --fail-with-body --silent --show-error \
+            -H "X-API-Key: $ADMIN_API_KEY" \
+            -F folder=questions -F project=default -F restart=0 \
+            -F file=@.github/fixtures/editor_a11y/editor_accessibility.yml \
+            "$SERVER_URL/api/playground"
+          curl --fail-with-body --silent --show-error \
+            -H "X-API-Key: $ADMIN_API_KEY" \
+            -F folder=templates -F project=default -F restart=0 \
+            -F file=@.github/fixtures/editor_a11y/editor_accessibility.md \
+            "$SERVER_URL/api/playground"
+          curl --fail-with-body --silent --show-error \
+            -H "X-API-Key: $ADMIN_API_KEY" \
+            -F folder=modules -F project=default -F restart=0 \
+            -F file=@.github/fixtures/editor_a11y/editor_accessibility.py \
+            "$SERVER_URL/api/playground"
+          curl --fail-with-body --silent --show-error \
+            -H "X-API-Key: $ADMIN_API_KEY" \
+            -F folder=static -F project=default -F restart=0 \
+            -F file=@.github/fixtures/editor_a11y/editor_accessibility.js \
+            "$SERVER_URL/api/playground"
+          curl --fail-with-body --silent --show-error \
+            -H "X-API-Key: $ADMIN_API_KEY" \
+            -F folder=sources -F project=default -F restart=0 \
+            -F file=@.github/fixtures/editor_a11y/editor_accessibility.txt \
+            "$SERVER_URL/api/playground"
       - name: Install accessibility test dependencies
         if: ${{ !cancelled() }}
         run: |

--- a/.github/workflows/alkiln_tests.yml
+++ b/.github/workflows/alkiln_tests.yml
@@ -90,7 +90,7 @@ jobs:
           mkdir -p /tmp/alweaver-a11y
           cd /tmp/alweaver-a11y
           npm init -y
-          npm install playwright @axe-core/playwright
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install playwright @axe-core/playwright
           npx playwright install --with-deps chromium
       - name: Check /al/editor accessibility
         if: ${{ !cancelled() }}

--- a/.github/workflows/alkiln_tests.yml
+++ b/.github/workflows/alkiln_tests.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           ADMIN_EMAIL: "${{ steps.github_server.outputs.DA_ADMIN_EMAIL }}"
           ADMIN_PASSWORD: "${{ steps.github_server.outputs.DA_ADMIN_PASSWORD }}"
-          ADMIN_API_KEY: "${{ steps.github_server.outputs.DA_ADMIN_API_KEY }}"
+          ADMIN_API_KEY: "${{ steps.github_server.outputs.DOCASSEMBLE_DEVELOPER_API_KEY }}"
           DEVELOPER_API_KEY: "${{ steps.github_server.outputs.DOCASSEMBLE_DEVELOPER_API_KEY }}"
         run: |
           echo "::add-mask::$ADMIN_EMAIL"
@@ -57,7 +57,7 @@ jobs:
         if: ${{ !cancelled() }}
         env:
           SERVER_URL: "${{ steps.github_server.outputs.SERVER_URL }}"
-          ADMIN_API_KEY: "${{ steps.github_server.outputs.DA_ADMIN_API_KEY }}"
+          ADMIN_API_KEY: "${{ steps.github_server.outputs.DOCASSEMBLE_DEVELOPER_API_KEY }}"
         run: |
           curl --fail-with-body --silent --show-error \
             -H "X-API-Key: $ADMIN_API_KEY" \

--- a/docassemble/ALWeaver/data/static/editor.css
+++ b/docassemble/ALWeaver/data/static/editor.css
@@ -3850,6 +3850,7 @@ html, body {
 .popover {
   color: var(--editor-fg) !important;
   background: #fff !important;
+  opacity: 1 !important;
 }
 
 .popover-header {
@@ -3859,6 +3860,25 @@ html, body {
 .popover h3,
 .popover p {
   color: var(--editor-fg) !important;
+}
+
+#insert-modal .editor-insert-title,
+#insert-modal .editor-insert-cancel,
+#insert-modal .editor-insert-group-label,
+#insert-modal .editor-insert-desc,
+#insert-modal .editor-insert-footnote,
+#insert-modal .editor-insert-footnote a {
+  color: #334155 !important;
+  opacity: 1 !important;
+}
+
+#insert-modal .editor-insert-title {
+  color: var(--editor-fg) !important;
+}
+
+#insert-modal .editor-insert-cancel,
+#insert-modal .editor-insert-footnote a {
+  color: var(--editor-primary) !important;
 }
 
 .editor-field-mod-hint {

--- a/docassemble/ALWeaver/data/static/editor.css
+++ b/docassemble/ALWeaver/data/static/editor.css
@@ -3843,11 +3843,16 @@ html, body {
 
 .popover-header,
 .popover-body {
-  color: var(--editor-fg);
+  color: var(--editor-fg) !important;
 }
 
 .popover-header {
   background: #fff;
+}
+
+.popover h3,
+.popover p {
+  color: var(--editor-fg) !important;
 }
 
 .editor-field-mod-hint {

--- a/docassemble/ALWeaver/data/static/editor.css
+++ b/docassemble/ALWeaver/data/static/editor.css
@@ -664,7 +664,7 @@ html, body {
   gap: 6px;
   margin-top: 1px;
   font-size: 11px;
-  color: #94a3b8;
+  color: var(--editor-muted);
   min-width: 0;
   overflow-wrap: anywhere;
 }
@@ -924,9 +924,16 @@ html, body {
 .editor-question-tabs .nav-link {
   font-size: 13px;
   padding: 8px 14px;
+  color: var(--editor-primary);
   border-bottom-color: transparent;
   border-top-left-radius: var(--editor-radius-sm);
   border-top-right-radius: var(--editor-radius-sm);
+}
+
+.editor-question-tabs-actions .btn-outline-primary,
+.editor-full-yaml-header a.btn-outline-secondary {
+  color: var(--editor-primary);
+  border-color: var(--editor-primary);
 }
 
 /* active tab merges into card below */

--- a/docassemble/ALWeaver/data/static/editor.css
+++ b/docassemble/ALWeaver/data/static/editor.css
@@ -239,7 +239,7 @@ html, body {
   padding: 0;
   border: 0;
   background: transparent;
-  color: var(--bs-link-color);
+  color: var(--editor-primary);
   font-family: var(--bs-font-monospace);
   font-size: 0.82rem;
   text-align: left;
@@ -931,7 +931,7 @@ html, body {
 }
 
 .editor-question-tabs-actions .btn-outline-primary,
-.editor-full-yaml-header a.btn-outline-secondary {
+.editor-full-yaml-header .btn-outline-secondary {
   color: var(--editor-primary);
   border-color: var(--editor-primary);
 }
@@ -3833,7 +3833,21 @@ html, body {
 }
 
 .editor-al-setting-key {
-  opacity: 0.75;
+  color: var(--editor-muted);
+  opacity: 1;
+}
+
+.editor-advanced-body #adv-show-more {
+  color: var(--editor-primary);
+}
+
+.popover-header,
+.popover-body {
+  color: var(--editor-fg);
+}
+
+.popover-header {
+  background: #fff;
 }
 
 .editor-field-mod-hint {

--- a/docassemble/ALWeaver/data/static/editor.css
+++ b/docassemble/ALWeaver/data/static/editor.css
@@ -3868,7 +3868,7 @@ html, body {
 #insert-modal .editor-insert-desc,
 #insert-modal .editor-insert-footnote,
 #insert-modal .editor-insert-footnote a {
-  color: #334155 !important;
+  color: #0f172a !important;
   opacity: 1 !important;
 }
 
@@ -3879,6 +3879,15 @@ html, body {
 #insert-modal .editor-insert-cancel,
 #insert-modal .editor-insert-footnote a {
   color: var(--editor-primary) !important;
+}
+
+#insert-modal .editor-insert-body {
+  background: #f8fafc !important;
+}
+
+#insert-modal .editor-insert-card {
+  background: #fff !important;
+  opacity: 1 !important;
 }
 
 .editor-field-mod-hint {

--- a/docassemble/ALWeaver/data/static/editor.css
+++ b/docassemble/ALWeaver/data/static/editor.css
@@ -3844,6 +3844,12 @@ html, body {
 .popover-header,
 .popover-body {
   color: var(--editor-fg) !important;
+  opacity: 1 !important;
+}
+
+.popover {
+  color: var(--editor-fg) !important;
+  background: #fff !important;
 }
 
 .popover-header {

--- a/docassemble/ALWeaver/data/static/editor.css
+++ b/docassemble/ALWeaver/data/static/editor.css
@@ -3878,7 +3878,7 @@ html, body {
 
 #insert-modal .editor-insert-cancel,
 #insert-modal .editor-insert-footnote a {
-  color: var(--editor-primary) !important;
+  color: #0d3970 !important;
 }
 
 #insert-modal .editor-insert-body {

--- a/docassemble/ALWeaver/data/static/editor.js
+++ b/docassemble/ALWeaver/data/static/editor.js
@@ -6227,9 +6227,11 @@
   }
 
   function _settingsInput(field, value) {
-    var key = esc(field.key);
+    var rawKey = String(field.key || '');
+    var key = esc(rawKey);
+    var inputId = 'al-setting-' + rawKey.replace(/[^a-zA-Z0-9_-]/g, '-');
     var kind = field.kind || 'text';
-    var common = ' data-al-setting="' + key + '" id="al-setting-' + key.replace(/[^a-zA-Z0-9_-]/g, '-') + '"';
+    var common = ' data-al-setting="' + key + '" id="' + inputId + '"';
     var helpText = field && field.help ? '<div class="form-text editor-al-setting-help">' + esc(field.help) + '</div>' : '';
     var computedBlock = _settingComputedBlock(field);
     var variableHint = helpText
@@ -6242,23 +6244,22 @@
       // expression rather than a value. A checkbox or a dropdown would have to
       // pick some position to sit in and would misreport the interview, so the
       // expression is shown as read-only text instead.
-      var computedId = 'al-setting-' + key.replace(/[^a-zA-Z0-9_-]/g, '-');
-      return '<label class="editor-tiny" for="' + computedId + '">' + esc(field.label) + '</label>'
+      return '<label class="editor-tiny" for="' + inputId + '">' + esc(field.label) + '</label>'
         + '<input class="form-control form-control-sm mt-1 font-monospace"' + common + ' value="'
         + esc(value === null || value === undefined ? '' : value) + '" readonly disabled aria-disabled="true">'
         + variableHint;
     }
     if (kind === 'boolean') {
-      return '<div class="form-check form-switch"><input class="form-check-input" type="checkbox"' + common + (value ? ' checked' : '') + '><label class="form-check-label" for="al-setting-' + key.replace(/[^a-zA-Z0-9_-]/g, '-') + '">' + esc(field.label) + '</label>' + variableHint + '</div>';
+      return '<div class="form-check form-switch"><input class="form-check-input" type="checkbox"' + common + (value ? ' checked' : '') + '><label class="form-check-label" for="' + inputId + '">' + esc(field.label) + '</label>' + variableHint + '</div>';
     }
     if (kind === 'choice') {
-      var select = '<label class="editor-tiny" for="al-setting-' + key + '">' + esc(field.label) + '</label><select class="form-select form-select-sm mt-1"' + common + '>';
+      var select = '<label class="editor-tiny" for="' + inputId + '">' + esc(field.label) + '</label><select class="form-select form-select-sm mt-1"' + common + '>';
       (field.choices || []).forEach(function (choice) { select += '<option value="' + esc(choice) + '"' + (String(value) === String(choice) ? ' selected' : '') + '>' + esc(String(choice).replace(/_/g, ' ')) + '</option>'; });
       return select + '</select>' + variableHint;
     }
     var rendered = kind === 'list' ? (Array.isArray(value) ? value.join('\n') : '') : String(value === null || value === undefined ? '' : value);
     if (field.key === 'LIST_topics') {
-      var topicsId = 'al-setting-' + key.replace(/[^a-zA-Z0-9_-]/g, '-');
+      var topicsId = inputId;
       return '<label class="editor-tiny" for="' + topicsId + '">' + esc(field.label) + '</label>'
         + '<textarea class="form-control form-control-sm mt-1" rows="3"' + common + '>' + esc(rendered) + '</textarea>'
         + '<div class="mt-1"><button class="btn btn-sm btn-outline-secondary" type="button" data-open-list-topics="' + topicsId + '" data-topic-separator="newline"><i class="fa-solid fa-list-check me-1" aria-hidden="true"></i>Choose topics</button></div>'
@@ -6266,9 +6267,9 @@
         + variableHint;
     }
     if (kind === 'area' || kind === 'list' || kind === 'python') {
-      return '<label class="editor-tiny" for="al-setting-' + key + '">' + esc(field.label) + '</label><textarea class="form-control form-control-sm mt-1' + (kind === 'python' ? ' font-monospace' : '') + '" rows="' + (kind === 'area' ? '4' : '3') + '"' + common + '>' + esc(rendered) + '</textarea>' + (kind === 'list' ? '<div class="form-text">One value per line.</div>' : '') + variableHint;
+      return '<label class="editor-tiny" for="' + inputId + '">' + esc(field.label) + '</label><textarea class="form-control form-control-sm mt-1' + (kind === 'python' ? ' font-monospace' : '') + '" rows="' + (kind === 'area' ? '4' : '3') + '"' + common + '>' + esc(rendered) + '</textarea>' + (kind === 'list' ? '<div class="form-text">One value per line.</div>' : '') + variableHint;
     }
-    return '<label class="editor-tiny" for="al-setting-' + key + '">' + esc(field.label) + '</label><input class="form-control form-control-sm mt-1" type="' + (kind === 'integer' ? 'number' : (kind === 'url' ? 'url' : 'text')) + '"' + common + ' value="' + esc(rendered) + '">' + variableHint;
+    return '<label class="editor-tiny" for="' + inputId + '">' + esc(field.label) + '</label><input class="form-control form-control-sm mt-1" type="' + (kind === 'integer' ? 'number' : (kind === 'url' ? 'url' : 'text')) + '"' + common + ' value="' + esc(rendered) + '">' + variableHint;
   }
 
   function applyAssemblyLineSettingsFilter() {

--- a/docassemble/ALWeaver/data/static/editor.js
+++ b/docassemble/ALWeaver/data/static/editor.js
@@ -6992,9 +6992,9 @@
     // Unified tab row: Screen | Question options | Preview | YAML
     html += '<div class="editor-question-tabs-row">';
     html += '<ul class="nav nav-tabs editor-question-tabs" role="tablist">';
-    html += '<li class="nav-item" role="presentation"><button type="button" class="nav-link ' + (isPreview && state.questionBlockTab === 'screen' ? 'active' : '') + '" data-question-tab="screen" data-question-mode="preview">Screen</button></li>';
-    html += '<li class="nav-item" role="presentation"><button type="button" class="nav-link ' + (isPreview && state.questionBlockTab === 'options' ? 'active' : '') + '" data-question-tab="options" data-question-mode="preview">Question options</button></li>';
-    html += '<li class="nav-item" role="presentation"><button type="button" class="nav-link ' + (state.questionEditMode === 'yaml' ? 'active' : '') + '" id="toggle-edit-mode-tab" data-question-mode="yaml"><i class="fa-solid fa-code me-1" aria-hidden="true"></i>YAML</button></li>';
+    html += '<li class="nav-item" role="presentation"><button type="button" role="tab" class="nav-link ' + (isPreview && state.questionBlockTab === 'screen' ? 'active' : '') + '" id="question-screen-tab" aria-controls="question-screen-panel" aria-selected="' + (isPreview && state.questionBlockTab === 'screen' ? 'true' : 'false') + '" data-question-tab="screen" data-question-mode="preview">Screen</button></li>';
+    html += '<li class="nav-item" role="presentation"><button type="button" role="tab" class="nav-link ' + (isPreview && state.questionBlockTab === 'options' ? 'active' : '') + '" id="question-options-tab" aria-controls="question-options-panel" aria-selected="' + (isPreview && state.questionBlockTab === 'options' ? 'true' : 'false') + '" data-question-tab="options" data-question-mode="preview">Question options</button></li>';
+    html += '<li class="nav-item" role="presentation"><button type="button" role="tab" class="nav-link ' + (state.questionEditMode === 'yaml' ? 'active' : '') + '" id="toggle-edit-mode-tab" aria-controls="question-yaml-panel" aria-selected="' + (state.questionEditMode === 'yaml' ? 'true' : 'false') + '" data-question-mode="yaml"><i class="fa-solid fa-code me-1" aria-hidden="true"></i>YAML</button></li>';
     html += '</ul>';
     html += '<div class="editor-question-tabs-actions">';
     html += '<button type="button" class="btn btn-sm btn-outline-primary" id="question-preview-tab" data-action="open-screen-preview" title="See this screen the way Docassemble will draw it"><i class="fa-regular fa-eye me-1" aria-hidden="true"></i>Preview</button>';
@@ -7009,7 +7009,7 @@
 
     if (isPreview) {
       if (state.questionBlockTab === 'screen') {
-      html += '<div class="editor-card editor-question-main-card"><div class="editor-card-body editor-card-body-compact">';
+      html += '<div class="editor-card editor-question-main-card" id="question-screen-panel" role="tabpanel" aria-labelledby="question-screen-tab" tabindex="0"><div class="editor-card-body editor-card-body-compact">';
 
       // Block ID — always visible at top
       html += '<div class="editor-block-id-row">';
@@ -7242,12 +7242,14 @@
       }
 
       if (state.questionBlockTab === 'options') {
+        html += '<div id="question-options-panel" role="tabpanel" aria-labelledby="question-options-tab" tabindex="0">';
         html += renderAdvancedPanel(block);
+        html += '</div>';
       }
 
     } else {
       // YAML source edit mode
-      html += '<div class="editor-card"><div class="editor-card-body">';
+      html += '<div class="editor-card" id="question-yaml-panel" role="tabpanel" aria-labelledby="toggle-edit-mode-tab" tabindex="0"><div class="editor-card-body">';
       html += '<div class="editor-source-container" id="block-source-editor" style="height:500px"></div>';
       html += '</div></div>';
     }

--- a/docassemble/ALWeaver/data/templates/editor.html
+++ b/docassemble/ALWeaver/data/templates/editor.html
@@ -531,18 +531,18 @@
   <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable editor-insert-dialog">
     <div class="modal-content editor-insert-content">
       <div class="modal-header editor-insert-header">
-        <button type="button" class="btn btn-link editor-insert-cancel" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-link editor-insert-cancel" style="color:#0d3970" data-bs-dismiss="modal">Cancel</button>
         <h5 class="modal-title editor-insert-title" id="insert-modal-title">Add a block</h5>
         <span class="editor-insert-header-spacer" aria-hidden="true"></span>
       </div>
       <div class="modal-body editor-insert-body">
-        <div class="editor-insert-group-label">Screens</div>
+        <div class="editor-insert-group-label" style="color:#334155">Screens</div>
         <div class="editor-insert-list">
           <button type="button" class="editor-insert-card" data-insert="question">
             <span class="editor-insert-icon"><i class="fa-solid fa-rectangle-list" aria-hidden="true"></i></span>
             <span class="editor-insert-text">
               <span class="editor-insert-name">Question screen</span>
-              <span class="editor-insert-desc">Ask the user one or more fields.</span>
+              <span class="editor-insert-desc" style="color:#334155">Ask the user one or more fields.</span>
             </span>
             <span class="editor-insert-plus" aria-hidden="true"><i class="fa-solid fa-plus"></i></span>
           </button>
@@ -550,7 +550,7 @@
             <span class="editor-insert-icon"><i class="fa-solid fa-wand-magic-sparkles" aria-hidden="true"></i></span>
             <span class="editor-insert-text">
               <span class="editor-insert-name">AI draft screen</span>
-              <span class="editor-insert-desc">Draft a question screen from a short prompt.</span>
+              <span class="editor-insert-desc" style="color:#334155">Draft a question screen from a short prompt.</span>
             </span>
             <span class="editor-insert-plus" aria-hidden="true"><i class="fa-solid fa-plus"></i></span>
           </button>
@@ -558,7 +558,7 @@
             <span class="editor-insert-icon"><i class="fa-solid fa-people-group" aria-hidden="true"></i></span>
             <span class="editor-insert-text">
               <span class="editor-insert-name">AssemblyLine question library</span>
-              <span class="editor-insert-desc">Copy a ready-made question about the people in this interview.</span>
+              <span class="editor-insert-desc" style="color:#334155">Copy a ready-made question about the people in this interview.</span>
             </span>
             <span class="editor-insert-plus" aria-hidden="true"><i class="fa-solid fa-plus"></i></span>
           </button>
@@ -566,18 +566,18 @@
             <span class="editor-insert-icon"><i class="fa-solid fa-list-check" aria-hidden="true"></i></span>
             <span class="editor-insert-text">
               <span class="editor-insert-name">Review screen</span>
-              <span class="editor-insert-desc">Let the user check and edit their answers.</span>
+              <span class="editor-insert-desc" style="color:#334155">Let the user check and edit their answers.</span>
             </span>
             <span class="editor-insert-plus" aria-hidden="true"><i class="fa-solid fa-plus"></i></span>
           </button>
         </div>
-        <div class="editor-insert-group-label">Logic and data</div>
+        <div class="editor-insert-group-label" style="color:#334155">Logic and data</div>
         <div class="editor-insert-list">
           <button type="button" class="editor-insert-card" data-insert="code">
             <span class="editor-insert-icon"><i class="fa-solid fa-code" aria-hidden="true"></i></span>
             <span class="editor-insert-text">
               <span class="editor-insert-name">Code block</span>
-              <span class="editor-insert-desc">Python that sets variables or controls the flow.</span>
+              <span class="editor-insert-desc" style="color:#334155">Python that sets variables or controls the flow.</span>
             </span>
             <span class="editor-insert-plus" aria-hidden="true"><i class="fa-solid fa-plus"></i></span>
           </button>
@@ -585,7 +585,7 @@
             <span class="editor-insert-icon"><i class="fa-solid fa-cubes" aria-hidden="true"></i></span>
             <span class="editor-insert-text">
               <span class="editor-insert-name">Objects block</span>
-              <span class="editor-insert-desc">Declare people, lists, and other objects.</span>
+              <span class="editor-insert-desc" style="color:#334155">Declare people, lists, and other objects.</span>
             </span>
             <span class="editor-insert-plus" aria-hidden="true"><i class="fa-solid fa-plus"></i></span>
           </button>
@@ -593,18 +593,18 @@
             <span class="editor-insert-icon"><i class="fa-solid fa-file-lines" aria-hidden="true"></i></span>
             <span class="editor-insert-text">
               <span class="editor-insert-name">Attachment block</span>
-              <span class="editor-insert-desc">Assemble a PDF or Word document.</span>
+              <span class="editor-insert-desc" style="color:#334155">Assemble a PDF or Word document.</span>
             </span>
             <span class="editor-insert-plus" aria-hidden="true"><i class="fa-solid fa-plus"></i></span>
           </button>
         </div>
-        <div class="editor-insert-group-label">Other</div>
+        <div class="editor-insert-group-label" style="color:#334155">Other</div>
         <div class="editor-insert-list">
           <button type="button" class="editor-insert-card" data-insert="comment">
             <span class="editor-insert-icon"><i class="fa-solid fa-comment-dots" aria-hidden="true"></i></span>
             <span class="editor-insert-text">
               <span class="editor-insert-name">Comment block</span>
-              <span class="editor-insert-desc">A note to yourself that the interview ignores.</span>
+              <span class="editor-insert-desc" style="color:#334155">A note to yourself that the interview ignores.</span>
             </span>
             <span class="editor-insert-plus" aria-hidden="true"><i class="fa-solid fa-plus"></i></span>
           </button>
@@ -612,13 +612,13 @@
             <span class="editor-insert-icon"><i class="fa-solid fa-file-code" aria-hidden="true"></i></span>
             <span class="editor-insert-text">
               <span class="editor-insert-name">Raw YAML block</span>
-              <span class="editor-insert-desc">Start from a blank line and write any block by hand.</span>
+              <span class="editor-insert-desc" style="color:#334155">Start from a blank line and write any block by hand.</span>
             </span>
             <span class="editor-insert-plus" aria-hidden="true"><i class="fa-solid fa-plus"></i></span>
           </button>
         </div>
         <div class="editor-insert-footnote">
-          <a href="https://docassemble.org/docs/initial.html" target="_blank" rel="noopener">Block type docs</a>
+          <a href="https://docassemble.org/docs/initial.html" style="color:#0d3970" target="_blank" rel="noopener">Block type docs</a>
         </div>
       </div>
     </div>

--- a/docassemble/ALWeaver/data/templates/editor.html
+++ b/docassemble/ALWeaver/data/templates/editor.html
@@ -66,7 +66,7 @@
        id="editor-celery-warning" role="status" aria-live="polite">
     <strong>Weaver worker setup is incomplete.</strong>
     <span data-celery-warning-message></span>
-    <a data-celery-warning-docs target="_blank" rel="noopener noreferrer">View setup instructions</a>.
+    <a class="alert-link" data-celery-warning-docs target="_blank" rel="noopener noreferrer">View setup instructions</a>.
   </div>
 
   <div class="alert alert-info rounded-0 border-start-0 border-end-0 mb-0 d-none d-flex flex-wrap align-items-center gap-2"

--- a/docassemble/ALWeaver/data/templates/editor.html
+++ b/docassemble/ALWeaver/data/templates/editor.html
@@ -194,7 +194,7 @@
         </ul>
       </div>
     </div>
-    <div class="editor-validation-body" id="validation-drawer-body"></div>
+    <div class="editor-validation-body" id="validation-drawer-body" tabindex="0"></div>
   </div>
 </div>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "numpy>=1.0.4",
     "pikepdf>=5.1.1",
     "formfyxer>=0.3.0a1",
+    "dayamlchecker",
 ]
 license = "MIT"
 license-files = ["LICENSE*"]
@@ -137,7 +138,6 @@ dev = [
     "boto3",
     "pandas-stubs",
     "mypy",
-    "dayamlchecker",
     "types-requests",
     "types-PyYAML",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1158,6 +1158,7 @@ version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
+    { name = "dayamlchecker" },
     { name = "docassemble-altoolbox" },
     { name = "docassemble-assemblyline" },
     { name = "docx2python" },
@@ -1171,7 +1172,6 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "boto3" },
-    { name = "dayamlchecker" },
     { name = "docassemble-base" },
     { name = "docassemble-webapp" },
     { name = "docx2python" },
@@ -1187,6 +1187,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.11.1" },
+    { name = "dayamlchecker" },
     { name = "docassemble-altoolbox", specifier = ">=0.4.2" },
     { name = "docassemble-assemblyline", specifier = ">=2.11.3" },
     { name = "docx2python", specifier = ">=1.27.1" },
@@ -1200,7 +1201,6 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "boto3" },
-    { name = "dayamlchecker" },
     { name = "docassemble-base", specifier = ">=1.8.0" },
     { name = "docassemble-webapp", specifier = ">=1.8.0" },
     { name = "docx2python" },


### PR DESCRIPTION
Adds a post-ALKiln Playwright + axe-core check for the authenticated /al/editor SPA.

The workflow installs Chromium, signs in with the temporary GitHub Docassemble server admin credentials, audits the Interview, Templates, Modules, Static, and Sources views, and fails on serious or critical violations or browser page errors.

Validation: node --check .github/scripts/editor_a11y.js; git diff --check