### PR TITLE
Add static checks for editor endpoint clients

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -eu
+
+files=$(git diff --cached --name-only --diff-filter=ACMR -- '*.js')
+if [ -n "$files" ]; then
+  npx --no-install prettier --write $files
+  printf '%s\n' "$files" | xargs git add --
+fi
+
+npm run check

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,10 +2,14 @@
 
 set -eu
 
-files=$(git diff --cached --name-only --diff-filter=ACMR -- '*.js')
-if [ -n "$files" ]; then
-  npx --no-install prettier --write $files
-  printf '%s\n' "$files" | xargs git add --
+tmp=$(mktemp)
+git diff --cached --name-only --diff-filter=ACMR -- '*.js' > "$tmp"
+if [ -s "$tmp" ]; then
+  while IFS= read -r file; do
+    npx --no-install prettier --write "$file"
+    git add -- "$file"
+  done < "$tmp"
 fi
+rm -f "$tmp"
 
 npm run check

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -1,0 +1,25 @@
+name: JavaScript static checks
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  javascript-checks:
+    name: Prettier, ESLint, and checkJs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install JavaScript tooling
+        run: npm ci
+
+      - name: Run JavaScript checks
+        run: npm run check

--- a/.gitignore
+++ b/.gitignore
@@ -22,9 +22,8 @@ _al_test_project_name*
 alkiln-*
 cucumber-report.txt
 runtime_config.json
-# package.json is for local development only
-package.json
-package-lock.json
+# JavaScript tooling dependencies
+node_modules/
 .mypy_cache/
 .creds
 .codex

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 80
+}

--- a/docassemble/ALWeaver/data/static/editor_agent_chat.js
+++ b/docassemble/ALWeaver/data/static/editor_agent_chat.js
@@ -5,7 +5,7 @@
  * handed to editor.js, which folds it into the current unsaved buffer. No
  * intermediate agent step touches the editor or the Playground.
  */
-(function (root, factory) {
+(function (/** @type {any} */ root, factory) {
   'use strict';
   var api = factory();
   if (typeof module === 'object' && module.exports) module.exports = api;
@@ -30,18 +30,25 @@
   };
 
   var STOP_REASON_NOTES = {
-    step_limit: 'This one request needed more steps than the assistant is ' +
+    step_limit:
+      'This one request needed more steps than the assistant is ' +
       'allowed to take at once. Apply what it managed, then ask for the rest ' +
       'as a smaller, separate request.',
-    mutating_tool_limit: 'This one request needed more edits than the ' +
+    mutating_tool_limit:
+      'This one request needed more edits than the ' +
       'assistant makes at once. Apply what it managed, then ask for the rest.',
-    runtime_operation_limit: 'The assistant reached its runtime-inspection limit.',
-    validation_repair_limit: 'The assistant could not repair the validation errors.',
+    runtime_operation_limit:
+      'The assistant reached its runtime-inspection limit.',
+    validation_repair_limit:
+      'The assistant could not repair the validation errors.',
     repeated_blocking_diagnostic: 'The same validation error kept coming back.',
-    malformed_model_responses: 'The assistant kept returning an unusable response.',
+    malformed_model_responses:
+      'The assistant kept returning an unusable response.',
     repeated_invalid_arguments: 'The assistant kept sending invalid arguments.',
-    unavailable_capability: 'The assistant asked for a capability it does not have.',
-    unsupported_source: 'The change would need to rewrite source Weaver cannot edit safely.',
+    unavailable_capability:
+      'The assistant asked for a capability it does not have.',
+    unsupported_source:
+      'The change would need to rewrite source Weaver cannot edit safely.',
     stale_candidate: 'The candidate changed mid-request.',
     model_call_failed: 'The language model could not be reached.',
     cancelled: 'You stopped the request.',
@@ -68,7 +75,11 @@
   function createAgentChat(options) {
     options = options || {};
     var api = options.api;
-    var getContext = options.getContext || function () { return {}; };
+    var getContext =
+      options.getContext ||
+      function () {
+        return {};
+      };
     var getWorkingSource = options.getWorkingSource;
     var onApply = options.onApply || function () {};
     var onStateChange = options.onStateChange || function () {};
@@ -120,7 +131,8 @@
         var missedPolls = 0;
         pollTimer = setInterval(function () {
           if (!busy || !session) return;
-          api.get(sessionPath('/progress'), { preventStale: false })
+          api
+            .get(sessionPath('/progress'), { preventStale: false })
             .then(function (response) {
               missedPolls = 0;
               var data = (response && response.data) || {};
@@ -131,8 +143,12 @@
               }
               stopProgressWatch();
               if (data.error) {
-                var failure = new Error(data.error.message || 'The assistant request failed.');
-                failure.code = data.error.code;
+                var failure = Object.assign(
+                  new Error(
+                    data.error.message || 'The assistant request failed.',
+                  ),
+                  { code: data.error.code },
+                );
                 reject(failure);
                 return;
               }
@@ -141,9 +157,11 @@
                 return;
               }
               // Not running, no result, no error: the worker went away.
-              reject(new Error(
-                'The assistant stopped unexpectedly. Nothing was applied — try again.'
-              ));
+              reject(
+                new Error(
+                  'The assistant stopped unexpectedly. Nothing was applied — try again.',
+                ),
+              );
             })
             .catch(function (pollError) {
               missedPolls += 1;
@@ -165,7 +183,10 @@
     }
 
     function elapsedLabel() {
-      var seconds = Math.max(0, Math.round((Date.now() - liveStartedAt) / 1000));
+      var seconds = Math.max(
+        0,
+        Math.round((Date.now() - liveStartedAt) / 1000),
+      );
       if (seconds < 60) return seconds + 's';
       return Math.floor(seconds / 60) + 'm ' + (seconds % 60) + 's';
     }
@@ -196,12 +217,12 @@
     function buildWorkingBanner(host) {
       var head = element('div', 'editor-agent-working-head');
       head.appendChild(element('span', 'editor-agent-spinner'));
-      head.appendChild(element(
-        'span',
-        'editor-agent-working-label',
-        currentActivity() + '…'
-      ));
-      head.appendChild(element('span', 'editor-agent-working-time', elapsedLabel()));
+      head.appendChild(
+        element('span', 'editor-agent-working-label', currentActivity() + '…'),
+      );
+      head.appendChild(
+        element('span', 'editor-agent-working-time', elapsedLabel()),
+      );
       host.appendChild(head);
       host.appendChild(element('div', 'editor-agent-working-bar'));
 
@@ -213,10 +234,14 @@
       done.slice(-6).forEach(function (event) {
         var item = element(
           'li',
-          'editor-agent-step editor-agent-step-' + (event.status || 'info')
+          'editor-agent-step editor-agent-step-' + (event.status || 'info'),
         );
-        item.appendChild(element('span', 'editor-agent-step-icon', statusIcon(event.status)));
-        item.appendChild(element('span', 'editor-agent-step-label', event.label || event.tool));
+        item.appendChild(
+          element('span', 'editor-agent-step-icon', statusIcon(event.status)),
+        );
+        item.appendChild(
+          element('span', 'editor-agent-step-label', event.label || event.tool),
+        );
         list.appendChild(item);
       });
       host.appendChild(list);
@@ -232,12 +257,16 @@
     function fail(error) {
       stopProgressWatch();
       var code = error && error.code;
-      if (code === 'agent_session_stale' || code === 'agent_base_revision_stale') {
+      if (
+        code === 'agent_session_stale' ||
+        code === 'agent_base_revision_stale'
+      ) {
         setState('stale');
         errorMessage = error.message;
       } else {
         setState('error');
-        errorMessage = (error && error.message) || 'The assistant request failed.';
+        errorMessage =
+          (error && error.message) || 'The assistant request failed.';
       }
       busy = false;
       render();
@@ -247,8 +276,11 @@
       if (!session || !session.agent_session_id) {
         throw new Error('The assistant session has not started yet.');
       }
-      return '/api/agent/sessions/' + encodeURIComponent(session.agent_session_id) +
-        (suffix || '');
+      return (
+        '/api/agent/sessions/' +
+        encodeURIComponent(session.agent_session_id) +
+        (suffix || '')
+      );
     }
 
     function ensureSession(autoHeal) {
@@ -262,66 +294,79 @@
       }
       setState('starting');
       render();
-      return api.post('/api/agent/sessions', {
-        project: context.project,
-        filename: context.filename,
-        raw_yaml: snapshot.raw_yaml,
-        base_revision: snapshot.base_revision,
-        auto_heal: Boolean(autoHeal),
-      }, { preventStale: false }).then(function (response) {
-        session = clone(response.data);
-        repairOffer = null;
-        if (session.repairs && session.repairs.length) {
-          transcript.push({
-            role: 'assistant',
-            content: 'I fixed ' + session.repairs.length +
-              (session.repairs.length === 1 ? ' problem' : ' problems') +
-              ' with block ids before starting. These are part of the change you ' +
-              'will review before saving.',
-            status: 'ready',
-            repairs: session.repairs,
-            events: [],
-          });
-        }
-        return session;
-      }).catch(function (error) {
-        // A file the validator rejects is not a dead end when every problem is
-        // mechanical: offer the fix rather than making the developer hand-edit.
-        var details = (error && error.details) || {};
-        if (error && error.code === 'invalid_working_source') {
-          repairOffer = {
-            canAutoHeal: Boolean(details.can_auto_heal),
-            repairs: details.repairs || [],
-            repairableCount: Number(details.repairable_count || 0),
-            unrepairableCount: Number(details.unrepairable_count || 0),
-            diagnostics: details.diagnostics || [],
-          };
-        }
-        throw error;
-      });
+      return api
+        .post(
+          '/api/agent/sessions',
+          {
+            project: context.project,
+            filename: context.filename,
+            raw_yaml: snapshot.raw_yaml,
+            base_revision: snapshot.base_revision,
+            auto_heal: Boolean(autoHeal),
+          },
+          { preventStale: false },
+        )
+        .then(function (response) {
+          session = clone(response.data);
+          repairOffer = null;
+          if (session.repairs && session.repairs.length) {
+            transcript.push({
+              role: 'assistant',
+              content:
+                'I fixed ' +
+                session.repairs.length +
+                (session.repairs.length === 1 ? ' problem' : ' problems') +
+                ' with block ids before starting. These are part of the change you ' +
+                'will review before saving.',
+              status: 'ready',
+              repairs: session.repairs,
+              events: [],
+            });
+          }
+          return session;
+        })
+        .catch(function (error) {
+          // A file the validator rejects is not a dead end when every problem is
+          // mechanical: offer the fix rather than making the developer hand-edit.
+          var details = (error && error.details) || {};
+          if (error && error.code === 'invalid_working_source') {
+            repairOffer = {
+              canAutoHeal: Boolean(details.can_auto_heal),
+              repairs: details.repairs || [],
+              repairableCount: Number(details.repairable_count || 0),
+              unrepairableCount: Number(details.unrepairable_count || 0),
+              diagnostics: details.diagnostics || [],
+            };
+          }
+          throw error;
+        });
     }
 
     function healAndRetry() {
-      if (!repairOffer || !repairOffer.canAutoHeal || busy) return Promise.resolve();
+      if (!repairOffer || !repairOffer.canAutoHeal || busy)
+        return Promise.resolve();
       var pending = lastRequest;
       repairOffer = null;
       busy = true;
       setState('starting');
       render();
-      return ensureSession(true).then(function () {
-        busy = false;
-        setState('idle');
-        render();
-        if (pending) return send(pending);
-        return undefined;
-      }).catch(function (error) {
-        fail(error);
-      });
+      return ensureSession(true)
+        .then(function () {
+          busy = false;
+          setState('idle');
+          render();
+          if (pending) return send(pending);
+          return undefined;
+        })
+        .catch(function (error) {
+          fail(error);
+        });
     }
 
     function send(message) {
       var text = String(message || '').trim();
-      if (!text || busy || !isAvailable() || isExhausted()) return Promise.resolve();
+      if (!text || busy || !isAvailable() || isExhausted())
+        return Promise.resolve();
       busy = true;
       draft = '';
       lastRequest = text;
@@ -333,48 +378,61 @@
       liveStartedAt = Date.now();
       render();
 
-      return ensureSession().then(function () {
-        var context = getContext();
-        // Kicking the turn off is the only thing this request does; the work
-        // itself outlives it.
-        var started = api.post(sessionPath('/turn'), {
-          message: text,
-          selected_block_id: context.selectedBlockId || null,
-        }, { preventStale: false });
-        var watching = watchTurn();
-        return started.then(function () { return watching; });
-      }).then(function (data) {
-        latest = clone(data);
-        if (data.session) session = clone(data.session);
-        transcript.push({
-          role: 'assistant',
-          content: data.summary,
-          status: data.status,
-          stopReason: data.stop_reason,
-          events: data.turn && data.turn.events ? data.turn.events : [],
-          diagnostics: data.diagnostics || [],
-          diff: data.diff || null,
+      return ensureSession()
+        .then(function () {
+          var context = getContext();
+          // Kicking the turn off is the only thing this request does; the work
+          // itself outlives it.
+          var started = api.post(
+            sessionPath('/turn'),
+            {
+              message: text,
+              selected_block_id: context.selectedBlockId || null,
+            },
+            { preventStale: false },
+          );
+          var watching = watchTurn();
+          return started.then(function () {
+            return watching;
+          });
+        })
+        .then(function (data) {
+          latest = clone(data);
+          if (data.session) session = clone(data.session);
+          transcript.push({
+            role: 'assistant',
+            content: data.summary,
+            status: data.status,
+            stopReason: data.stop_reason,
+            events: data.turn && data.turn.events ? data.turn.events : [],
+            diagnostics: data.diagnostics || [],
+            diff: data.diff || null,
+          });
+          setState(data.status === 'ready' ? 'ready' : data.status);
+          busy = false;
+          stopProgressWatch();
+          render();
+        })
+        .catch(function (error) {
+          stopProgressWatch();
+          transcript.push({
+            role: 'error',
+            content:
+              (error && error.message) || 'The assistant request failed.',
+          });
+          fail(error);
         });
-        setState(data.status === 'ready' ? 'ready' : data.status);
-        busy = false;
-        stopProgressWatch();
-        render();
-      }).catch(function (error) {
-        stopProgressWatch();
-        transcript.push({
-          role: 'error',
-          content: (error && error.message) || 'The assistant request failed.',
-        });
-        fail(error);
-      });
     }
 
     function stop() {
       if (!session || !busy) return Promise.resolve();
       // Cancelling is safe because the loop never writes: at worst it leaves a
       // valid intermediate candidate that is not presented as finished.
-      return api.post(sessionPath('/cancel'), {}, { preventStale: false })
-        .catch(function () { /* the turn may already have finished */ });
+      return api
+        .post(sessionPath('/cancel'), {}, { preventStale: false })
+        .catch(function () {
+          /* the turn may already have finished */
+        });
     }
 
     function reset() {
@@ -387,15 +445,20 @@
       }
       busy = true;
       render();
-      return api.post(sessionPath('/reset'), {}, { preventStale: false })
+      return api
+        .post(sessionPath('/reset'), {}, { preventStale: false })
         .then(function (response) {
           session = clone(response.data);
           transcript = [];
           latest = null;
           busy = false;
-          setState('idle', 'Conversation reset to the source the assistant started from.');
+          setState(
+            'idle',
+            'Conversation reset to the source the assistant started from.',
+          );
           render();
-        }).catch(fail);
+        })
+        .catch(fail);
     }
 
     function apply() {
@@ -403,13 +466,18 @@
       busy = true;
       setState('validating');
       render();
-      return api.post(sessionPath('/apply'), {}, { preventStale: false })
+      return api
+        .post(sessionPath('/apply'), {}, { preventStale: false })
         .then(function (response) {
           busy = false;
           onApply(clone(response.data));
-          setState('idle', 'Applied to the editor. Use Save to write it to the Playground.');
+          setState(
+            'idle',
+            'Applied to the editor. Use Save to write it to the Playground.',
+          );
           render();
-        }).catch(fail);
+        })
+        .catch(fail);
     }
 
     // Distinct from Reset: Reset rewinds the candidate inside this chat, while
@@ -418,7 +486,10 @@
     function startFreshChat() {
       if (busy) return Promise.resolve();
       var finished = endSession();
-      setState('idle', 'Started a new chat. The assistant works from your current editor state.');
+      setState(
+        'idle',
+        'Started a new chat. The assistant works from your current editor state.',
+      );
       render();
       return finished;
     }
@@ -430,7 +501,9 @@
       transcript = [];
       latest = null;
       setState('idle');
-      return api.delete(path).catch(function () { /* expiry is fine */ });
+      return api.delete(path).catch(function () {
+        /* expiry is fine */
+      });
     }
 
     // -----------------------------------------------------------------------
@@ -444,8 +517,13 @@
       if (!interesting.length) return;
       var list = element('ul', 'editor-agent-steps');
       interesting.forEach(function (event) {
-        var item = element('li', 'editor-agent-step editor-agent-step-' + (event.status || 'info'));
-        item.appendChild(element('span', 'editor-agent-step-icon', statusIcon(event.status)));
+        var item = element(
+          'li',
+          'editor-agent-step editor-agent-step-' + (event.status || 'info'),
+        );
+        item.appendChild(
+          element('span', 'editor-agent-step-icon', statusIcon(event.status)),
+        );
         var label = event.label || event.tool;
         if (event.status === 'rejected') {
           label = 'Attempted change failed; trying a corrected edit — ' + label;
@@ -458,14 +536,21 @@
 
     function renderDiagnostics(target, diagnostics) {
       var problems = (diagnostics || []).filter(function (item) {
-        var level = String((item && (item.level || item.severity)) || '').toLowerCase();
+        var level = String(
+          (item && (item.level || item.severity)) || '',
+        ).toLowerCase();
         return level === 'error' || level === 'warning';
       });
       if (!problems.length) return;
       var list = element('ul', 'editor-agent-diagnostics');
       problems.slice(0, 12).forEach(function (item) {
-        var level = String(item.level || item.severity || 'error').toLowerCase();
-        var row = element('li', 'editor-agent-diagnostic editor-agent-diagnostic-' + level);
+        var level = String(
+          item.level || item.severity || 'error',
+        ).toLowerCase();
+        var row = element(
+          'li',
+          'editor-agent-diagnostic editor-agent-diagnostic-' + level,
+        );
         var where = item.block_id ? item.block_id + ': ' : '';
         row.textContent = where + (item.message || 'Unknown issue');
         list.appendChild(row);
@@ -489,34 +574,43 @@
       var fixable = repairOffer.repairableCount;
       var blocked = repairOffer.unrepairableCount;
       if (repairOffer.canAutoHeal) {
-        box.appendChild(element(
-          'p',
-          'editor-agent-repair-offer-text',
-          'This interview has ' + fixable +
-          (fixable === 1 ? ' problem' : ' problems') +
-          ' with block ids. I can fix ' +
-          (fixable === 1 ? 'it' : 'them') +
-          ' automatically — the change will appear in the diff for you to review ' +
-          'before you save.'
-        ));
+        box.appendChild(
+          element(
+            'p',
+            'editor-agent-repair-offer-text',
+            'This interview has ' +
+              fixable +
+              (fixable === 1 ? ' problem' : ' problems') +
+              ' with block ids. I can fix ' +
+              (fixable === 1 ? 'it' : 'them') +
+              ' automatically — the change will appear in the diff for you to review ' +
+              'before you save.',
+          ),
+        );
         renderRepairs(box, repairOffer.repairs);
         var fixButton = element(
           'button',
           'btn btn-primary btn-sm',
-          'Fix ' + fixable + (fixable === 1 ? ' problem' : ' problems') + ' and continue'
+          'Fix ' +
+            fixable +
+            (fixable === 1 ? ' problem' : ' problems') +
+            ' and continue',
         );
         fixButton.type = 'button';
         fixButton.disabled = busy;
         fixButton.addEventListener('click', healAndRetry);
         box.appendChild(fixButton);
       } else {
-        box.appendChild(element(
-          'p',
-          'editor-agent-repair-offer-text',
-          blocked === 1
-            ? 'One problem here needs a human decision, so the assistant cannot start yet.'
-            : blocked + ' problems here need a human decision, so the assistant cannot start yet.'
-        ));
+        box.appendChild(
+          element(
+            'p',
+            'editor-agent-repair-offer-text',
+            blocked === 1
+              ? 'One problem here needs a human decision, so the assistant cannot start yet.'
+              : blocked +
+                  ' problems here need a human decision, so the assistant cannot start yet.',
+          ),
+        );
         renderDiagnostics(box, repairOffer.diagnostics);
       }
       target.appendChild(box);
@@ -529,47 +623,65 @@
       var summary = element(
         'summary',
         null,
-        'Assistant changed ' + blocks + (blocks === 1 ? ' block' : ' blocks') +
-        ' · +' + Number(diff.added || 0) + ' −' + Number(diff.removed || 0) + ' lines'
+        'Assistant changed ' +
+          blocks +
+          (blocks === 1 ? ' block' : ' blocks') +
+          ' · +' +
+          Number(diff.added || 0) +
+          ' −' +
+          Number(diff.removed || 0) +
+          ' lines',
       );
       details.appendChild(summary);
       var pre = element('pre', 'editor-agent-diff-body', diff.diff);
       details.appendChild(pre);
       if (diff.truncated) {
-        details.appendChild(element(
-          'p',
-          'editor-agent-diff-note',
-          'This diff is too large to show in full. Apply and review it in the editor.'
-        ));
+        details.appendChild(
+          element(
+            'p',
+            'editor-agent-diff-note',
+            'This diff is too large to show in full. Apply and review it in the editor.',
+          ),
+        );
       }
       target.appendChild(details);
     }
 
     function renderTranscript(target) {
       if (!transcript.length) {
-        target.appendChild(element(
-          'p',
-          'editor-agent-empty',
-          'Describe the change you want. For example: “Add a screen asking ' +
-          'whether the client has children, before the address questions.”'
-        ));
+        target.appendChild(
+          element(
+            'p',
+            'editor-agent-empty',
+            'Describe the change you want. For example: “Add a screen asking ' +
+              'whether the client has children, before the address questions.”',
+          ),
+        );
         return;
       }
       transcript.forEach(function (entry) {
-        var row = element('article', 'editor-agent-message editor-agent-message-' + entry.role);
-        var who = entry.role === 'user' ? 'You' :
-          (entry.role === 'error' ? 'Error' : 'Assistant');
+        var row = element(
+          'article',
+          'editor-agent-message editor-agent-message-' + entry.role,
+        );
+        var who = 'Assistant';
+        if (entry.role === 'user') who = 'You';
+        if (entry.role === 'error') who = 'Error';
         row.appendChild(element('h4', 'editor-agent-message-role', who));
-        row.appendChild(element('div', 'editor-agent-message-body', entry.content));
+        row.appendChild(
+          element('div', 'editor-agent-message-body', entry.content),
+        );
         if (entry.role === 'assistant') {
           renderRepairs(row, entry.repairs);
           renderEvents(row, entry.events);
           if (entry.stopReason && STOP_REASON_NOTES[entry.stopReason]) {
-            row.appendChild(element(
-              'p',
-              'editor-agent-stop-reason',
-              STOP_REASON_NOTES[entry.stopReason]
-            ));
+            row.appendChild(
+              element(
+                'p',
+                'editor-agent-stop-reason',
+                STOP_REASON_NOTES[entry.stopReason],
+              ),
+            );
           }
           renderDiagnostics(row, entry.diagnostics);
           renderDiff(row, entry.diff);
@@ -584,7 +696,7 @@
         latest.status === 'ready' &&
         latest.has_candidate_changes &&
         !busy &&
-        uiState !== 'stale'
+        uiState !== 'stale',
       );
     }
 
@@ -600,15 +712,24 @@
       applyButton.addEventListener('click', apply);
       target.appendChild(applyButton);
 
-      var resetButton = element('button', 'btn btn-outline-secondary btn-sm', 'Reset');
+      var resetButton = element(
+        'button',
+        'btn btn-outline-secondary btn-sm',
+        'Reset',
+      );
       resetButton.type = 'button';
       resetButton.disabled = busy;
-      resetButton.title = 'Discard the assistant candidate and clear the conversation.';
+      resetButton.title =
+        'Discard the assistant candidate and clear the conversation.';
       resetButton.addEventListener('click', reset);
       target.appendChild(resetButton);
 
       if (busy) {
-        var stopButton = element('button', 'btn btn-outline-danger btn-sm', 'Stop');
+        var stopButton = element(
+          'button',
+          'btn btn-outline-danger btn-sm',
+          'Stop',
+        );
         stopButton.type = 'button';
         stopButton.addEventListener('click', stop);
         target.appendChild(stopButton);
@@ -635,17 +756,21 @@
       if (!isAvailable()) {
         var notice = element('div', 'editor-agent-unavailable');
         notice.setAttribute('role', 'status');
-        notice.appendChild(element(
-          'p',
-          'editor-agent-unavailable-title',
-          'The assistant is not available on this server.'
-        ));
-        notice.appendChild(element(
-          'p',
-          'editor-agent-unavailable-detail',
-          (availability && availability.message) ||
-          'Ask your server administrator to finish setting it up.'
-        ));
+        notice.appendChild(
+          element(
+            'p',
+            'editor-agent-unavailable-title',
+            'The assistant is not available on this server.',
+          ),
+        );
+        notice.appendChild(
+          element(
+            'p',
+            'editor-agent-unavailable-detail',
+            (availability && availability.message) ||
+              'Ask your server administrator to finish setting it up.',
+          ),
+        );
         panel.appendChild(notice);
         container.appendChild(panel);
         return;
@@ -654,8 +779,12 @@
       var status = element('p', 'editor-agent-status');
       status.setAttribute('role', 'status');
       status.setAttribute('aria-live', 'polite');
-      status.textContent = errorMessage || statusMessage || STATE_LABELS[uiState] || '';
-      status.classList.toggle('editor-agent-status-error', Boolean(errorMessage));
+      status.textContent =
+        errorMessage || statusMessage || STATE_LABELS[uiState] || '';
+      status.classList.toggle(
+        'editor-agent-status-error',
+        Boolean(errorMessage),
+      );
       panel.appendChild(status);
 
       var log = element('div', 'editor-agent-transcript');
@@ -678,17 +807,26 @@
       if (remaining !== null && remaining <= 3) {
         var nudge = element('div', 'editor-agent-nudge');
         nudge.setAttribute('role', 'status');
-        nudge.appendChild(element(
-          'p',
-          'editor-agent-nudge-text',
-          remaining === 0
-            ? 'This chat has reached its limit. Apply what you have, then start a ' +
-              'new chat for the next change.'
-            : 'The assistant works best on one task at a time. ' + remaining +
-              (remaining === 1 ? ' request left' : ' requests left') +
-              ' in this chat — apply your changes and start a new one for the next task.'
-        ));
-        var fresh = element('button', 'btn btn-outline-secondary btn-sm', 'New chat');
+        var nudgeText;
+        if (remaining === 0) {
+          nudgeText =
+            'This chat has reached its limit. Apply what you have, then start a ' +
+            'new chat for the next change.';
+        } else {
+          var requestLabel =
+            remaining === 1 ? ' request left' : ' requests left';
+          nudgeText =
+            'The assistant works best on one task at a time. ' +
+            remaining +
+            requestLabel +
+            ' in this chat — apply your changes and start a new one for the next task.';
+        }
+        nudge.appendChild(element('p', 'editor-agent-nudge-text', nudgeText));
+        var fresh = element(
+          'button',
+          'btn btn-outline-secondary btn-sm',
+          'New chat',
+        );
         fresh.type = 'button';
         fresh.disabled = busy;
         fresh.addEventListener('click', startFreshChat);
@@ -697,7 +835,11 @@
       }
 
       var form = element('form', 'editor-agent-composer');
-      var label = element('label', 'visually-hidden', 'Ask the assistant to change this interview');
+      var label = element(
+        'label',
+        'visually-hidden',
+        'Ask the assistant to change this interview',
+      );
       label.setAttribute('for', 'editor-agent-input');
       form.appendChild(label);
       var input = element('textarea', 'form-control');
@@ -706,7 +848,9 @@
       input.value = draft;
       input.placeholder = 'Describe the change you want…';
       input.disabled = busy || isExhausted();
-      input.addEventListener('input', function () { draft = input.value; });
+      input.addEventListener('input', function () {
+        draft = input.value;
+      });
       input.addEventListener('keydown', function (event) {
         if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
           event.preventDefault();
@@ -714,7 +858,11 @@
         }
       });
       form.appendChild(input);
-      var submit = element('button', 'btn btn-primary btn-sm mt-2', busy ? 'Working…' : 'Send');
+      var submit = element(
+        'button',
+        'btn btn-primary btn-sm mt-2',
+        busy ? 'Working…' : 'Send',
+      );
       submit.type = 'submit';
       submit.disabled = busy || isExhausted();
       form.appendChild(submit);
@@ -737,8 +885,12 @@
       endSession: endSession,
       startFreshChat: startFreshChat,
       turnsRemaining: turnsRemaining,
-      getState: function () { return uiState; },
-      getSession: function () { return clone(session); },
+      getState: function () {
+        return uiState;
+      },
+      getSession: function () {
+        return clone(session);
+      },
       canApply: canApply,
       markStale: function (message) {
         setState('stale');

--- a/docassemble/ALWeaver/data/static/editor_api_client.js
+++ b/docassemble/ALWeaver/data/static/editor_api_client.js
@@ -1,11 +1,13 @@
 /* Centralized HTTP client for the graphical editor. */
-(function (root, factory) {
+(function (/** @type {any} */ root, factory) {
   'use strict';
   var api = factory(root);
   if (typeof module === 'object' && module.exports) module.exports = api;
   root.ALWeaverApiClient = api;
 })(typeof globalThis !== 'undefined' ? globalThis : this, function (root) {
   'use strict';
+
+  var requestCounter = 0;
 
   function EditorApiError(message, options) {
     options = options || {};
@@ -24,7 +26,8 @@
     if (root.crypto && typeof root.crypto.randomUUID === 'function') {
       return root.crypto.randomUUID();
     }
-    return 'editor-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2);
+    requestCounter += 1;
+    return 'editor-' + Date.now().toString(36) + '-' + requestCounter;
   }
 
   function discoverCsrfToken() {
@@ -33,15 +36,20 @@
     if (meta && meta.content) return meta.content;
     var input = root.document.querySelector('input[name="csrf_token"]');
     if (input && input.value) return input.value;
-    var match = String(root.document.cookie || '').match(/(?:^|;\s*)csrf_token=([^;]+)/);
+    var match = String(root.document.cookie || '').match(
+      /(?:^|;\s*)csrf_token=([^;]+)/,
+    );
     return match ? decodeURIComponent(match[1]) : null;
   }
 
   function requestKey(method, path) {
     try {
-      return method + ':' + new URL(path, 'http://editor.invalid').pathname;
-    } catch (_error) {
-      return method + ':' + String(path).split('?')[0];
+      return method + ':' + new URL(path, 'https://editor.invalid').pathname;
+    } catch (error) {
+      if (error instanceof TypeError) {
+        return method + ':' + String(path).split('?')[0];
+      }
+      throw error;
     }
   }
 
@@ -56,7 +64,8 @@
     options = options || {};
     var baseUrl = options.baseUrl || '';
     var fetchImpl = options.fetchImpl || root.fetch;
-    var onError = typeof options.onError === 'function' ? options.onError : null;
+    var onError =
+      typeof options.onError === 'function' ? options.onError : null;
     var requestIdFactory = options.requestIdFactory || defaultRequestId;
     var timeoutMs = Number(options.timeoutMs || 30000);
     var sequences = {};
@@ -67,7 +76,11 @@
     }
 
     function emit(error) {
-      if (onError && error.code !== 'stale_response' && error.code !== 'request_cancelled') {
+      if (
+        onError &&
+        error.code !== 'stale_response' &&
+        error.code !== 'request_cancelled'
+      ) {
         onError(error);
       }
       return error;
@@ -76,17 +89,25 @@
     function request(method, path, body, requestOptions) {
       requestOptions = requestOptions || {};
       var key = requestOptions.staleKey || requestKey(method, path);
-      var preventStale = requestOptions.preventStale !== undefined
-        ? Boolean(requestOptions.preventStale)
-        : (method === 'GET' || method === 'HEAD');
+      var preventStale = method === 'GET' || method === 'HEAD';
+      if (requestOptions.preventStale !== undefined) {
+        preventStale = Boolean(requestOptions.preventStale);
+      }
       var sequence = preventStale ? (sequences[key] || 0) + 1 : 0;
       if (preventStale) sequences[key] = sequence;
-      if (preventStale && controllers[key] && requestOptions.cancelPrevious !== false) {
+      if (
+        preventStale &&
+        controllers[key] &&
+        requestOptions.cancelPrevious !== false
+      ) {
         controllers[key].abort();
       }
 
       var AbortControllerImpl = root.AbortController;
-      var controller = typeof AbortControllerImpl === 'function' ? new AbortControllerImpl() : null;
+      var controller = null;
+      if (typeof AbortControllerImpl === 'function') {
+        controller = new AbortControllerImpl();
+      }
       if (controller && preventStale) controllers[key] = controller;
       var timedOut = false;
       var requestId = requestIdFactory();
@@ -111,12 +132,13 @@
       }
       if (controller) fetchOptions.signal = controller.signal;
 
-      var timeout = controller && timeoutMs > 0
-        ? setTimeout(function () {
-          timedOut = true;
-          controller.abort();
-        }, timeoutMs)
-        : null;
+      var timeout =
+        controller && timeoutMs > 0
+          ? setTimeout(function () {
+              timedOut = true;
+              controller.abort();
+            }, timeoutMs)
+          : null;
 
       return Promise.resolve()
         .then(function () {
@@ -124,62 +146,105 @@
         })
         .catch(function (cause) {
           if (preventStale && sequences[key] !== sequence) {
-            throw new EditorApiError('A newer response replaced this request.', {
-              code: 'stale_response', requestId: requestId,
-            });
+            throw new EditorApiError(
+              'A newer response replaced this request.',
+              {
+                code: 'stale_response',
+                requestId: requestId,
+              },
+            );
           }
           var cancelled = cause && cause.name === 'AbortError';
-          throw emit(new EditorApiError(
-            timedOut ? 'The editor server took too long to respond.' :
-              (cancelled ? 'The request was cancelled.' : 'Unable to reach the editor server.'),
-            {
-              code: timedOut ? 'request_timeout' : (cancelled ? 'request_cancelled' : 'network_error'),
+          var errorMessage = 'Unable to reach the editor server.';
+          var errorCode = 'network_error';
+          if (timedOut) {
+            errorMessage = 'The editor server took too long to respond.';
+            errorCode = 'request_timeout';
+          } else if (cancelled) {
+            errorMessage = 'The request was cancelled.';
+            errorCode = 'request_cancelled';
+          }
+          var causeMessage =
+            cause && cause.message ? cause.message : String(cause || '');
+          throw emit(
+            new EditorApiError(errorMessage, {
+              code: errorCode,
               requestId: requestId,
-              details: { cause: cause && cause.message ? cause.message : String(cause || '') },
-            }
-          ));
+              details: { cause: causeMessage },
+            }),
+          );
         })
         .then(function (response) {
           return response.text().then(function (text) {
             if (preventStale && sequences[key] !== sequence) {
-              throw new EditorApiError('A newer response replaced this request.', {
-                code: 'stale_response', requestId: requestId,
-              });
+              throw new EditorApiError(
+                'A newer response replaced this request.',
+                {
+                  code: 'stale_response',
+                  requestId: requestId,
+                },
+              );
             }
             var contentType = response.headers.get('content-type') || '';
             if (contentType.toLowerCase().indexOf('json') === -1) {
-              throw emit(new EditorApiError('The server returned an unexpected response type.', {
-                status: response.status,
-                code: 'invalid_content_type',
-                requestId: requestId,
-                details: { contentType: contentType },
-              }));
+              throw emit(
+                new EditorApiError(
+                  'The server returned an unexpected response type.',
+                  {
+                    status: response.status,
+                    code: 'invalid_content_type',
+                    requestId: requestId,
+                    details: { contentType: contentType },
+                  },
+                ),
+              );
             }
             var payload;
             try {
               payload = text ? JSON.parse(text) : null;
-            } catch (_error) {
-              throw emit(new EditorApiError('The server returned invalid JSON.', {
-                status: response.status,
-                code: 'invalid_json',
-                requestId: requestId,
-              }));
+            } catch (error) {
+              throw emit(
+                new EditorApiError('The server returned invalid JSON.', {
+                  status: response.status,
+                  code: 'invalid_json',
+                  requestId: requestId,
+                  details: {
+                    cause:
+                      error && error.message ? error.message : String(error),
+                  },
+                }),
+              );
             }
             if (!response.ok || !payload || payload.success === false) {
-              var serverError = payload && payload.error ? payload.error : (payload || {});
-              var serverMessage = typeof serverError === 'string' ? serverError : serverError.message;
-              var serverCode = typeof serverError === 'object' && serverError
-                ? (serverError.code || serverError.type)
-                : null;
-              var serverDetails = typeof serverError === 'object' && serverError
-                ? (serverError.details || serverError)
-                : {};
-              throw emit(new EditorApiError(serverMessage || ('Request failed with status ' + response.status + '.'), {
-                status: response.status,
-                code: serverCode || 'http_error',
-                details: serverDetails,
-                requestId: payload && payload.request_id ? payload.request_id : requestId,
-              }));
+              var serverError =
+                payload && payload.error ? payload.error : payload || {};
+              var serverMessage =
+                typeof serverError === 'string'
+                  ? serverError
+                  : serverError.message;
+              var serverCode =
+                typeof serverError === 'object' && serverError
+                  ? serverError.code || serverError.type
+                  : null;
+              var serverDetails =
+                typeof serverError === 'object' && serverError
+                  ? serverError.details || serverError
+                  : {};
+              throw emit(
+                new EditorApiError(
+                  serverMessage ||
+                    'Request failed with status ' + response.status + '.',
+                  {
+                    status: response.status,
+                    code: serverCode || 'http_error',
+                    details: serverDetails,
+                    requestId:
+                      payload && payload.request_id
+                        ? payload.request_id
+                        : requestId,
+                  },
+                ),
+              );
             }
             if (requestOptions.includeResponse) {
               return {
@@ -193,7 +258,8 @@
         })
         .finally(function () {
           if (timeout) clearTimeout(timeout);
-          if (preventStale && controllers[key] === controller) delete controllers[key];
+          if (preventStale && controllers[key] === controller)
+            delete controllers[key];
         });
     }
 
@@ -208,11 +274,15 @@
         return request('DELETE', path, body, requestOptions);
       },
       upload: function (path, formData, requestOptions) {
-        requestOptions = Object.assign({}, requestOptions || {}, { json: false });
+        requestOptions = Object.assign({}, requestOptions || {}, {
+          json: false,
+        });
         return request('POST', path, formData, requestOptions);
       },
       getDetailed: function (path, requestOptions) {
-        requestOptions = Object.assign({}, requestOptions || {}, { includeResponse: true });
+        requestOptions = Object.assign({}, requestOptions || {}, {
+          includeResponse: true,
+        });
         return request('GET', path, undefined, requestOptions);
       },
       uploadDetailed: function (path, formData, requestOptions) {

--- a/docassemble/ALWeaver/data/static/editor_api_client.js
+++ b/docassemble/ALWeaver/data/static/editor_api_client.js
@@ -45,11 +45,8 @@
   function requestKey(method, path) {
     try {
       return method + ':' + new URL(path, 'https://editor.invalid').pathname;
-    } catch (error) {
-      if (error instanceof TypeError) {
-        return method + ':' + String(path).split('?')[0];
-      }
-      throw error;
+    } catch {
+      return method + ':' + String(path).split('?')[0];
     }
   }
 

--- a/docassemble/ALWeaver/data/static/editor_dirty_state.js
+++ b/docassemble/ALWeaver/data/static/editor_dirty_state.js
@@ -1,5 +1,5 @@
 /* Per-file and per-block unsaved-change tracking for the graphical editor. */
-(function (root, factory) {
+(function (/** @type {any} */ root, factory) {
   'use strict';
   var api = factory();
   if (typeof module === 'object' && module.exports) module.exports = api;
@@ -21,7 +21,12 @@
     };
   }
 
-  function preserveDirtyBlocks(serverBlocks, localBlocks, dirtyBlockIds, savedBlockId) {
+  function preserveDirtyBlocks(
+    serverBlocks,
+    localBlocks,
+    dirtyBlockIds,
+    savedBlockId,
+  ) {
     var localById = {};
     (localBlocks || []).forEach(function (block) {
       if (block && block.id) localById[block.id] = block;
@@ -30,7 +35,11 @@
       return blockId !== savedBlockId;
     });
     return (serverBlocks || []).map(function (serverBlock) {
-      if (!serverBlock || preserveIds.indexOf(serverBlock.id) === -1 || !localById[serverBlock.id]) {
+      if (
+        !serverBlock ||
+        preserveIds.indexOf(serverBlock.id) === -1 ||
+        !localById[serverBlock.id]
+      ) {
         return clone(serverBlock);
       }
       return clone(localById[serverBlock.id]);
@@ -66,7 +75,8 @@
     }
 
     function addCommand(fileState, filename, commandId, blockId) {
-      if (!commandId || fileState.pendingCommandIds.indexOf(commandId) !== -1) return;
+      if (!commandId || fileState.pendingCommandIds.indexOf(commandId) !== -1)
+        return;
       fileState.pendingCommandIds.push(commandId);
       commandBlocks[filename][commandId] = blockId || null;
     }
@@ -79,7 +89,12 @@
       if (fileState.dirtyBlockIds.indexOf(targetBlock) === -1) {
         fileState.dirtyBlockIds.push(targetBlock);
       }
-      addCommand(fileState, target, commandId || ('edit-block:' + targetBlock), targetBlock);
+      addCommand(
+        fileState,
+        target,
+        commandId || 'edit-block:' + targetBlock,
+        targetBlock,
+      );
     }
 
     function markSourceDirty(commandId, filename) {
@@ -87,7 +102,7 @@
       var fileState = requireFile(target);
       if (!fileState) return;
       fileState.sourceDirty = true;
-      addCommand(fileState, target, commandId || ('edit-source:' + target), null);
+      addCommand(fileState, target, commandId || 'edit-source:' + target, null);
     }
 
     function setFileSaved(filename, revision, model) {
@@ -107,11 +122,13 @@
       fileState.dirtyBlockIds = fileState.dirtyBlockIds.filter(function (id) {
         return id !== blockId;
       });
-      fileState.pendingCommandIds = fileState.pendingCommandIds.filter(function (commandId) {
-        var keep = commandBlocks[target][commandId] !== blockId;
-        if (!keep) delete commandBlocks[target][commandId];
-        return keep;
-      });
+      fileState.pendingCommandIds = fileState.pendingCommandIds.filter(
+        function (commandId) {
+          var keep = commandBlocks[target][commandId] !== blockId;
+          if (!keep) delete commandBlocks[target][commandId];
+          return keep;
+        },
+      );
       savedModels[target] = clone(model);
     }
 
@@ -122,11 +139,12 @@
 
     function hasDirty(filename) {
       var fileState = state.files[filename || state.activeFile];
-      return Boolean(fileState && (
-        fileState.sourceDirty ||
-        fileState.dirtyBlockIds.length ||
-        fileState.pendingCommandIds.length
-      ));
+      return Boolean(
+        fileState &&
+        (fileState.sourceDirty ||
+          fileState.dirtyBlockIds.length ||
+          fileState.pendingCommandIds.length),
+      );
     }
 
     function getSavedModel(filename) {
@@ -135,7 +153,8 @@
 
     function discardFile(filename) {
       var target = filename || state.activeFile;
-      if (!Object.prototype.hasOwnProperty.call(savedModels, target)) return undefined;
+      if (!Object.prototype.hasOwnProperty.call(savedModels, target))
+        return undefined;
       var fileState = requireFile(target);
       if (!fileState) return undefined;
       fileState.sourceDirty = false;
@@ -156,7 +175,9 @@
       getSavedModel: getSavedModel,
       discardFile: discardFile,
       hasDirty: hasDirty,
-      getState: function () { return clone(state); },
+      getState: function () {
+        return clone(state);
+      },
     };
   }
 

--- a/docassemble/ALWeaver/data/static/editor_module_restart.js
+++ b/docassemble/ALWeaver/data/static/editor_module_restart.js
@@ -11,7 +11,7 @@
  * Restarting is server-wide and disruptive, so the developer is told what it
  * costs and can always decline and keep working.
  */
-(function (root, factory) {
+(function (/** @type {any} */ root, factory) {
   'use strict';
   var api = factory();
   if (typeof module === 'object' && module.exports) module.exports = api;
@@ -23,9 +23,11 @@
   var POLL_TIMEOUT_MS = 180000;
 
   function describeFiles(files) {
-    var names = (files || []).map(function (entry) {
-      return entry && entry.filename ? String(entry.filename) : '';
-    }).filter(Boolean);
+    var names = (files || [])
+      .map(function (entry) {
+        return entry && entry.filename ? String(entry.filename) : '';
+      })
+      .filter(Boolean);
     if (!names.length) return '';
     if (names.length === 1) return names[0];
     if (names.length === 2) return names[0] + ' and ' + names[1];
@@ -37,11 +39,23 @@
     var api = options.api;
     var doc = options.document;
     var win = options.window;
-    var getProject = options.getProject || function () { return null; };
-    var sleep = options.sleep || function (ms) {
-      return new Promise(function (resolve) { win.setTimeout(resolve, ms); });
-    };
-    var now = options.now || function () { return Date.now(); };
+    var getProject =
+      options.getProject ||
+      function () {
+        return null;
+      };
+    var sleep =
+      options.sleep ||
+      function (ms) {
+        return new Promise(function (resolve) {
+          win.setTimeout(resolve, ms);
+        });
+      };
+    var now =
+      options.now ||
+      function () {
+        return Date.now();
+      };
     var state = null;
     var restartInFlight = null;
     // The modal is a single static element, so a second prompt opened before
@@ -63,11 +77,13 @@
         banner.classList.add('d-none');
         return;
       }
-      var message = banner.querySelector('[data-module-restart-banner-message]');
+      var message = banner.querySelector(
+        '[data-module-restart-banner-message]',
+      );
       if (message) {
         var listed = describeFiles(state.files);
         message.textContent = listed
-          ? ('Restart the server to load ' + listed + '.')
+          ? 'Restart the server to load ' + listed + '.'
           : 'Restart the server to load them.';
       }
       var button = banner.querySelector('[data-action="restart-for-modules"]');
@@ -96,7 +112,8 @@
     function refresh() {
       var project = getProject();
       if (!project) return Promise.resolve(state);
-      return api.get('/api/server/restart-state?project=' + encodeURIComponent(project))
+      return api
+        .get('/api/server/restart-state?project=' + encodeURIComponent(project))
         .then(function (response) {
           return adopt(response && response.data);
         })
@@ -130,7 +147,10 @@
         }
         return sleep(POLL_INTERVAL_MS)
           .then(function () {
-            return api.get('/api/server/restart-status?task_id=' + encodeURIComponent(taskId));
+            return api.get(
+              '/api/server/restart-status?task_id=' +
+                encodeURIComponent(taskId),
+            );
           })
           .then(function (response) {
             var status = response && response.data ? response.data.status : '';
@@ -151,8 +171,11 @@
       if (restartInFlight) return restartInFlight;
       var project = getProject();
       setError('');
-      setProgress('Restarting the server… this normally takes 10 to 30 seconds.');
-      restartInFlight = api.post('/api/server/restart', { project: project })
+      setProgress(
+        'Restarting the server… this normally takes 10 to 30 seconds.',
+      );
+      restartInFlight = api
+        .post('/api/server/restart', { project: project })
         .then(function (response) {
           var taskId = response && response.data ? response.data.task_id : null;
           if (!taskId) return false;
@@ -164,13 +187,17 @@
             state = null;
             renderBanner();
           } else {
-            setProgress('The server is taking longer than usual to come back. It should finish shortly.');
+            setProgress(
+              'The server is taking longer than usual to come back. It should finish shortly.',
+            );
           }
           return completed;
         })
         .catch(function (error) {
           setProgress('');
-          setError((error && error.message) || 'The server could not be restarted.');
+          setError(
+            (error && error.message) || 'The server could not be restarted.',
+          );
           throw error;
         })
         .finally(function () {
@@ -192,27 +219,35 @@
         list.innerHTML = '';
         (state.files || []).forEach(function (entry) {
           var item = doc.createElement('li');
-          item.textContent = entry.reason && entry.reason !== 'changed'
-            ? (entry.filename + ' (' + entry.reason + ')')
-            : entry.filename;
+          item.textContent =
+            entry.reason && entry.reason !== 'changed'
+              ? entry.filename + ' (' + entry.reason + ')'
+              : entry.filename;
           list.appendChild(item);
         });
       }
       var message = el('module-restart-message');
       if (message) {
         message.textContent = actionLabel
-          ? ('Before you ' + actionLabel
-            + ', note that these Python modules have changed since the server last started:')
+          ? 'Before you ' +
+            actionLabel +
+            ', note that these Python modules have changed since the server last started:'
           : 'These Python modules have changed since the server last started:';
       }
-      var restartButton = doc.querySelector('[data-module-restart-choice="restart"]');
-      if (restartButton) restartButton.classList.toggle('d-none', !state.restart_allowed);
+      var restartButton = doc.querySelector(
+        '[data-module-restart-choice="restart"]',
+      );
+      if (restartButton)
+        restartButton.classList.toggle('d-none', !state.restart_allowed);
       // Asked from the banner there is no pending action to continue to, so
       // the only choices are restarting and closing the dialog.
       var skipButton = doc.querySelector('[data-module-restart-choice="skip"]');
       if (skipButton) skipButton.classList.toggle('d-none', !allowSkip);
-      var cancelButton = doc.querySelector('[data-module-restart-choice="cancel"]');
-      if (cancelButton) cancelButton.textContent = allowSkip ? 'Cancel' : 'Not now';
+      var cancelButton = doc.querySelector(
+        '[data-module-restart-choice="cancel"]',
+      );
+      if (cancelButton)
+        cancelButton.textContent = allowSkip ? 'Cancel' : 'Not now';
       setError(state.restart_allowed ? '' : state.restart_blocked_reason);
       setProgress('');
     }
@@ -229,7 +264,7 @@
       fillModal(actionLabel, allowSkip !== false);
       promptInFlight = new Promise(function (resolve) {
         var buttons = Array.prototype.slice.call(
-          doc.querySelectorAll('[data-module-restart-choice]')
+          doc.querySelectorAll('[data-module-restart-choice]'),
         );
 
         function cleanup() {
@@ -247,16 +282,24 @@
         }
 
         function onClick(event) {
-          var choice = event.currentTarget.getAttribute('data-module-restart-choice');
+          var choice = event.currentTarget.getAttribute(
+            'data-module-restart-choice',
+          );
           if (choice === 'cancel') return finish(false);
           if (choice === 'skip') return finish(true);
-          buttons.forEach(function (button) { button.disabled = true; });
+          buttons.forEach(function (button) {
+            button.disabled = true;
+          });
           restartNow()
-            .then(function () { finish(true); })
+            .then(function () {
+              finish(true);
+            })
             .catch(function () {
               // The failure is already shown in the modal; let the developer
               // decide whether to continue anyway.
-              buttons.forEach(function (button) { button.disabled = false; });
+              buttons.forEach(function (button) {
+                button.disabled = false;
+              });
             });
         }
 
@@ -275,7 +318,14 @@
         if (!current || !current.pending) return true;
         if (current.policy === 'never') return true;
         if (current.policy === 'auto' && current.restart_allowed) {
-          return restartNow().then(function () { return true; }, function () { return true; });
+          return restartNow().then(
+            function () {
+              return true;
+            },
+            function () {
+              return true;
+            },
+          );
         }
         return promptForRestart(actionLabel, true);
       });

--- a/docassemble/ALWeaver/data/static/editor_runtime_inspector.js
+++ b/docassemble/ALWeaver/data/static/editor_runtime_inspector.js
@@ -1,5 +1,5 @@
 /* Runtime inspector UI backed exclusively by Weaver's authenticated endpoints. */
-(function (root, factory) {
+(function (/** @type {any} */ root, factory) {
   'use strict';
   var api = factory();
   if (typeof module === 'object' && module.exports) module.exports = api;
@@ -13,44 +13,67 @@
   }
 
   function filterVariables(variables, query) {
-    var needle = String(query || '').trim().toLowerCase();
+    var needle = String(query || '')
+      .trim()
+      .toLowerCase();
     var result = {};
-    Object.keys(variables || {}).sort().forEach(function (name) {
-      if (!needle || name.toLowerCase().indexOf(needle) !== -1) result[name] = variables[name];
-    });
+    Object.keys(variables || {})
+      .sort()
+      .forEach(function (name) {
+        if (!needle || name.toLowerCase().indexOf(needle) !== -1)
+          result[name] = variables[name];
+      });
     return result;
   }
 
   function changedVariableNames(before, after) {
     var names = {};
-    Object.keys(before || {}).concat(Object.keys(after || {})).forEach(function (name) {
-      if (JSON.stringify((before || {})[name]) !== JSON.stringify((after || {})[name])) {
-        names[name] = true;
-      }
-    });
+    Object.keys(before || {})
+      .concat(Object.keys(after || {}))
+      .forEach(function (name) {
+        if (
+          JSON.stringify((before || {})[name]) !==
+          JSON.stringify((after || {})[name])
+        ) {
+          names[name] = true;
+        }
+      });
     return Object.keys(names).sort();
   }
 
   function findQuestionSource(question, blocks) {
     var questionName = question && question.questionName;
     if (!questionName) return null;
-    return (blocks || []).find(function (block) {
-      return block && (
-        block.id === questionName ||
-        (block.data && (block.data.id === questionName || block.data.event === questionName))
-      );
-    }) || null;
+    return (
+      (blocks || []).find(function (block) {
+        return (
+          block &&
+          (block.id === questionName ||
+            (block.data &&
+              (block.data.id === questionName ||
+                block.data.event === questionName)))
+        );
+      }) || null
+    );
   }
 
   function createRuntimeInspector(options) {
     options = options || {};
     var api = options.api;
     var getContext = options.getContext;
-    var getBlocks = options.getBlocks || function () { return []; };
+    var getBlocks =
+      options.getBlocks ||
+      function () {
+        return [];
+      };
     var onSessionChange = options.onSessionChange || function () {};
     // Runs before a test session is created, so pending Python module changes
     // can be loaded first. Resolving false abandons the start.
-    var beforeStart = options.beforeStart || function () { return Promise.resolve(true); };
+    var beforeStart =
+      options.beforeStart ||
+      function () {
+        return Promise.resolve(true);
+      };
     var session = null;
     var question = null;
     var variables = {};
@@ -63,8 +86,13 @@
     var container = null;
 
     function sessionPath(suffix) {
-      if (!session || !session.weaver_session_id) throw new Error('Start a test session first.');
-      return '/api/runtime/sessions/' + encodeURIComponent(session.weaver_session_id) + (suffix || '');
+      if (!session || !session.weaver_session_id)
+        throw new Error('Start a test session first.');
+      return (
+        '/api/runtime/sessions/' +
+        encodeURIComponent(session.weaver_session_id) +
+        (suffix || '')
+      );
     }
 
     function setStatus(message, isError) {
@@ -78,24 +106,30 @@
         if (proceed === false) return undefined;
         setStatus('Starting a separate Docassemble test session...');
         render(container);
-        return api.post('/api/runtime/sessions', {
-          project: context.project,
-          filename: context.filename,
-          purpose: 'test',
-        }).then(function (response) {
-          session = clone(response.data);
-          question = null;
-          variables = {};
-          previousVariables = {};
-          changed = [];
-          onSessionChange(clone(session));
-          setStatus('Test session started.');
-          render(container);
-          return refreshAll();
-        }).catch(function (requestError) {
-          setStatus(requestError.message || 'Unable to start the test session.', true);
-          render(container);
-        });
+        return api
+          .post('/api/runtime/sessions', {
+            project: context.project,
+            filename: context.filename,
+            purpose: 'test',
+          })
+          .then(function (response) {
+            session = clone(response.data);
+            question = null;
+            variables = {};
+            previousVariables = {};
+            changed = [];
+            onSessionChange(clone(session));
+            setStatus('Test session started.');
+            render(container);
+            return refreshAll();
+          })
+          .catch(function (requestError) {
+            setStatus(
+              requestError.message || 'Unable to start the test session.',
+              true,
+            );
+            render(container);
+          });
       });
     }
 
@@ -121,7 +155,9 @@
     }
 
     function refreshVariables() {
-      var path = sessionPath('/variables') + (includeInternal ? '?include_internal=true' : '');
+      var path =
+        sessionPath('/variables') +
+        (includeInternal ? '?include_internal=true' : '');
       return api.get(path).then(function (response) {
         previousVariables = variables;
         variables = clone(response.data.variables || {});
@@ -132,27 +168,46 @@
 
     function refreshAll() {
       if (!session) return Promise.resolve();
-      return Promise.all([refreshQuestion(), refreshVariables()]).catch(function (requestError) {
-        setStatus(requestError.message || 'Unable to refresh runtime facts.', true);
-        render(container);
-      });
+      return Promise.all([refreshQuestion(), refreshVariables()]).catch(
+        function (requestError) {
+          setStatus(
+            requestError.message || 'Unable to refresh runtime facts.',
+            true,
+          );
+          render(container);
+        },
+      );
     }
 
     function goBack() {
-      return api.post(sessionPath('/back'), {}).then(refreshAll).catch(function (requestError) {
-        setStatus(requestError.message || 'Docassemble could not go back.', true);
-        render(container);
-      });
+      return api
+        .post(sessionPath('/back'), {})
+        .then(refreshAll)
+        .catch(function (requestError) {
+          setStatus(
+            requestError.message || 'Docassemble could not go back.',
+            true,
+          );
+          render(container);
+        });
     }
 
     function applyScenario(text) {
-      return api.post(sessionPath('/variables'), { scenario_yaml: String(text || '') }).then(function () {
-        setStatus('Scenario applied. Seeded state may bypass earlier questions.');
-        return refreshAll();
-      }).catch(function (requestError) {
-        setStatus(requestError.message || 'Unable to apply the scenario.', true);
-        render(container);
-      });
+      return api
+        .post(sessionPath('/variables'), { scenario_yaml: String(text || '') })
+        .then(function () {
+          setStatus(
+            'Scenario applied. Seeded state may bypass earlier questions.',
+          );
+          return refreshAll();
+        })
+        .catch(function (requestError) {
+          setStatus(
+            requestError.message || 'Unable to apply the scenario.',
+            true,
+          );
+          render(container);
+        });
     }
 
     function appendVariableRows(target) {
@@ -166,9 +221,13 @@
       names.forEach(function (name) {
         var details = document.createElement('details');
         details.className = 'editor-runtime-variable border rounded p-2 mb-2';
-        if (changed.indexOf(name) !== -1) details.classList.add('border-warning', 'bg-warning-subtle');
+        if (changed.indexOf(name) !== -1)
+          details.classList.add('border-warning', 'bg-warning-subtle');
         var summary = document.createElement('summary');
-        summary.textContent = name + ' · ' + (visible[name] === null ? 'null' : typeof visible[name]);
+        summary.textContent =
+          name +
+          ' · ' +
+          (visible[name] === null ? 'null' : typeof visible[name]);
         details.appendChild(summary);
         var value = document.createElement('pre');
         value.className = 'small mt-2 mb-0 text-wrap';
@@ -196,7 +255,8 @@
       var undefinedName = question.undefinedVariable || question.undefined;
       if (undefinedName) {
         var undefinedEl = document.createElement('p');
-        undefinedEl.textContent = 'Undefined variable: ' + String(undefinedName);
+        undefinedEl.textContent =
+          'Undefined variable: ' + String(undefinedName);
         target.appendChild(undefinedEl);
       }
       var sourceBlock = findQuestionSource(question, getBlocks());
@@ -223,15 +283,20 @@
       wrapper.setAttribute('aria-labelledby', 'runtime-inspector-title');
       wrapper.innerHTML =
         '<div class="d-flex flex-wrap justify-content-between gap-2 align-items-start">' +
-          '<div><h2 class="h4 mb-1" id="runtime-inspector-title">Runtime inspector</h2>' +
-          '<p class="text-muted small">Docassemble is the authoritative runtime. This view only inspects a separate test session.</p></div>' +
-          '<div class="d-flex flex-wrap gap-2" id="runtime-session-actions"></div>' +
+        '<div><h2 class="h4 mb-1" id="runtime-inspector-title">Runtime inspector</h2>' +
+        '<p class="text-muted small">Docassemble is the authoritative runtime. This view only inspects a separate test session.</p></div>' +
+        '<div class="d-flex flex-wrap gap-2" id="runtime-session-actions"></div>' +
         '</div>' +
         '<div class="alert alert-info py-2" id="runtime-status" role="status" aria-live="polite"></div>' +
         '<div id="runtime-session-content"></div>';
       container.appendChild(wrapper);
       var statusNode = wrapper.querySelector('#runtime-status');
-      statusNode.textContent = error || status || (session ? 'Test session is active.' : 'Start a test session to inspect Docassemble runtime facts.');
+      statusNode.textContent =
+        error ||
+        status ||
+        (session
+          ? 'Test session is active.'
+          : 'Start a test session to inspect Docassemble runtime facts.');
       statusNode.classList.toggle('alert-danger', Boolean(error));
       statusNode.classList.toggle('alert-info', !error);
       var actions = wrapper.querySelector('#runtime-session-actions');
@@ -254,7 +319,12 @@
       open.rel = 'noopener';
       open.href = session.target_url;
       actions.appendChild(open);
-      [['Inspect current question', refreshQuestion], ['Refresh variables', refreshVariables], ['Back', goBack]].forEach(function (item) {
+      var sessionActions = /** @type {Array<[string, function(): any]>} */ ([
+        ['Inspect current question', refreshQuestion],
+        ['Refresh variables', refreshVariables],
+        ['Back', goBack],
+      ]);
+      sessionActions.forEach(function (item) {
         var button = document.createElement('button');
         button.type = 'button';
         button.className = 'btn btn-outline-secondary';
@@ -266,7 +336,9 @@
       restart.type = 'button';
       restart.className = 'btn btn-outline-secondary';
       restart.textContent = 'Start new test session';
-      restart.addEventListener('click', function () { endSession().then(startSession); });
+      restart.addEventListener('click', function () {
+        endSession().then(startSession);
+      });
       actions.appendChild(restart);
       var end = document.createElement('button');
       end.type = 'button';
@@ -277,36 +349,45 @@
 
       content.innerHTML =
         '<div class="row g-3">' +
-          '<div class="col-12 col-xl-6"><div class="card h-100"><div class="card-body">' +
-            '<h3 class="h5">Current question</h3><div id="runtime-question"></div>' +
-          '</div></div></div>' +
-          '<div class="col-12 col-xl-6"><div class="card h-100"><div class="card-body">' +
-            '<h3 class="h5">Apply scenario</h3>' +
-            '<p class="small text-muted">A scenario is a test fixture and may bypass earlier questions.</p>' +
-            '<label for="runtime-scenario" class="form-label">Scenario YAML</label>' +
-            '<textarea id="runtime-scenario" class="form-control font-monospace" rows="7">name: Test scenario\nvariables:\n  user.marital_status: married\ndelete:\n  - final_document</textarea>' +
-            '<button type="button" class="btn btn-outline-primary mt-2" id="runtime-apply-scenario">Apply scenario</button>' +
-          '</div></div></div>' +
-          '<div class="col-12"><div class="card"><div class="card-body">' +
-            '<div class="d-flex flex-wrap justify-content-between gap-2"><h3 class="h5">Session variables</h3>' +
-              '<label class="form-check"><input class="form-check-input" type="checkbox" id="runtime-include-internal"> <span class="form-check-label">Show _internal data</span></label></div>' +
-            '<label for="runtime-variable-search" class="visually-hidden">Search variables</label>' +
-            '<input id="runtime-variable-search" class="form-control form-control-sm mb-3" placeholder="Search variables">' +
-            '<div id="runtime-variable-list"></div>' +
-          '</div></div></div>' +
+        '<div class="col-12 col-xl-6"><div class="card h-100"><div class="card-body">' +
+        '<h3 class="h5">Current question</h3><div id="runtime-question"></div>' +
+        '</div></div></div>' +
+        '<div class="col-12 col-xl-6"><div class="card h-100"><div class="card-body">' +
+        '<h3 class="h5">Apply scenario</h3>' +
+        '<p class="small text-muted">A scenario is a test fixture and may bypass earlier questions.</p>' +
+        '<label for="runtime-scenario" class="form-label">Scenario YAML</label>' +
+        '<textarea id="runtime-scenario" class="form-control font-monospace" rows="7">name: Test scenario\nvariables:\n  user.marital_status: married\ndelete:\n  - final_document</textarea>' +
+        '<button type="button" class="btn btn-outline-primary mt-2" id="runtime-apply-scenario">Apply scenario</button>' +
+        '</div></div></div>' +
+        '<div class="col-12"><div class="card"><div class="card-body">' +
+        '<div class="d-flex flex-wrap justify-content-between gap-2"><h3 class="h5">Session variables</h3>' +
+        '<label class="form-check"><input class="form-check-input" type="checkbox" id="runtime-include-internal"> <span class="form-check-label">Show _internal data</span></label></div>' +
+        '<label for="runtime-variable-search" class="visually-hidden">Search variables</label>' +
+        '<input id="runtime-variable-search" class="form-control form-control-sm mb-3" placeholder="Search variables">' +
+        '<div id="runtime-variable-list"></div>' +
+        '</div></div></div>' +
         '</div>';
       renderQuestion(content.querySelector('#runtime-question'));
       appendVariableRows(content.querySelector('#runtime-variable-list'));
-      content.querySelector('#runtime-apply-scenario').addEventListener('click', function () {
-        applyScenario(content.querySelector('#runtime-scenario').value);
-      });
-      var internalToggle = content.querySelector('#runtime-include-internal');
+      content
+        .querySelector('#runtime-apply-scenario')
+        .addEventListener('click', function () {
+          var scenario = /** @type {HTMLTextAreaElement} */ (
+            content.querySelector('#runtime-scenario')
+          );
+          applyScenario(scenario.value);
+        });
+      var internalToggle = /** @type {HTMLInputElement} */ (
+        content.querySelector('#runtime-include-internal')
+      );
       internalToggle.checked = includeInternal;
       internalToggle.addEventListener('change', function () {
         includeInternal = internalToggle.checked;
         refreshVariables();
       });
-      var search = content.querySelector('#runtime-variable-search');
+      var search = /** @type {HTMLInputElement} */ (
+        content.querySelector('#runtime-variable-search')
+      );
       search.value = variableQuery;
       search.addEventListener('input', function () {
         variableQuery = search.value;
@@ -319,8 +400,13 @@
     return {
       render: render,
       refreshAll: refreshAll,
-      getSession: function () { return clone(session); },
-      setSession: function (value) { session = clone(value); onSessionChange(clone(session)); },
+      getSession: function () {
+        return clone(session);
+      },
+      setSession: function (value) {
+        session = clone(value);
+        onSessionChange(clone(session));
+      },
     };
   }
 

--- a/docassemble/ALWeaver/data/static/editor_validation_source.js
+++ b/docassemble/ALWeaver/data/static/editor_validation_source.js
@@ -5,7 +5,7 @@
  * unsaved edits. When a dirty subsystem cannot be mapped onto the source file
  * safely, these helpers throw rather than quietly fall back to the saved file.
  */
-(function (root, factory) {
+(function (/** @type {any} */ root, factory) {
   'use strict';
   var api = factory();
   if (typeof module === 'object' && module.exports) module.exports = api;
@@ -27,19 +27,28 @@
   function blockReplacement(source, block, text) {
     var startLine = Number(block && block.line_start);
     var endLine = Number(block && block.line_end);
-    if (!Number.isFinite(startLine) || !Number.isFinite(endLine) || startLine < 1 || endLine < startLine) {
+    if (
+      !Number.isFinite(startLine) ||
+      !Number.isFinite(endLine) ||
+      startLine < 1 ||
+      endLine < startLine
+    ) {
       throw new Error('Cannot map an unsaved block to the source file safely.');
     }
     var start = lineStartOffset(source, startLine);
     var end = lineStartOffset(source, endLine + 1);
     var original = source.slice(start, end);
     var replacement = String(text === undefined || text === null ? '' : text);
-    var newline = original.indexOf('\r\n') !== -1 ||
+    var newline =
+      original.indexOf('\r\n') !== -1 ||
       (original.indexOf('\n') === -1 && source.indexOf('\r\n') !== -1)
-      ? '\r\n'
-      : '\n';
+        ? '\r\n'
+        : '\n';
     replacement = replacement.replace(/\r\n|\r|\n/g, newline);
-    if (/(?:\r\n|\r|\n)$/.test(original) && !/(?:\r\n|\r|\n)$/.test(replacement)) {
+    if (
+      /(?:\r\n|\r|\n)$/.test(original) &&
+      !/(?:\r\n|\r|\n)$/.test(replacement)
+    ) {
       replacement += newline;
     }
     return { start: start, end: end, text: replacement };
@@ -55,23 +64,35 @@
       bodyStart = match.index + match[0].length;
     }
     bodies.push(source.slice(bodyStart));
-    return bodies.filter(function (body) { return body.trim() !== ''; });
+    return bodies.filter(function (body) {
+      return body.trim() !== '';
+    });
   }
 
   function applyOperations(source, operations) {
     var result = source;
-    operations.slice().sort(function (left, right) {
-      return right.start - left.start;
-    }).forEach(function (operation) {
-      result = result.slice(0, operation.start) + operation.text + result.slice(operation.end);
-    });
+    operations
+      .slice()
+      .sort(function (left, right) {
+        return right.start - left.start;
+      })
+      .forEach(function (operation) {
+        result =
+          result.slice(0, operation.start) +
+          operation.text +
+          result.slice(operation.end);
+      });
     return result;
   }
 
   function buildValidationSource(options) {
     options = options || {};
     if (typeof options.fullSource === 'string') return options.fullSource;
-    var source = String(options.rawYaml === undefined || options.rawYaml === null ? '' : options.rawYaml);
+    var source = String(
+      options.rawYaml === undefined || options.rawYaml === null
+        ? ''
+        : options.rawYaml,
+    );
     var blocks = Array.isArray(options.blocks) ? options.blocks : [];
     var replacements = options.blockReplacements || {};
     var operations = [];
@@ -80,20 +101,32 @@
       var block = blocks.find(function (candidate) {
         return String(candidate && candidate.id) === String(blockId);
       });
-      if (!block) throw new Error('Cannot find unsaved block ' + blockId + ' in the source file.');
+      if (!block)
+        throw new Error(
+          'Cannot find unsaved block ' + blockId + ' in the source file.',
+        );
       operations.push(blockReplacement(source, block, replacements[blockId]));
     });
 
     if (typeof options.metadataSource === 'string') {
       var metadataBlocks = blocks.filter(function (block) {
-        return block && ['metadata', 'includes', 'default_screen_parts'].indexOf(block.type) !== -1;
+        return (
+          block &&
+          ['metadata', 'includes', 'default_screen_parts'].indexOf(
+            block.type,
+          ) !== -1
+        );
       });
       var editedDocuments = splitDocumentBodies(options.metadataSource);
       if (metadataBlocks.length !== editedDocuments.length) {
-        throw new Error('Metadata documents no longer match the source file. Validate in full source mode.');
+        throw new Error(
+          'Metadata documents no longer match the source file. Validate in full source mode.',
+        );
       }
       metadataBlocks.forEach(function (block, index) {
-        operations.push(blockReplacement(source, block, editedDocuments[index]));
+        operations.push(
+          blockReplacement(source, block, editedDocuments[index]),
+        );
       });
     }
 
@@ -103,7 +136,11 @@
   function hasUnsavedEdits(options) {
     if (typeof options.fullSource === 'string') return true;
     if (typeof options.metadataSource === 'string') return true;
-    if (options.blockReplacements && Object.keys(options.blockReplacements).length) return true;
+    if (
+      options.blockReplacements &&
+      Object.keys(options.blockReplacements).length
+    )
+      return true;
     return Boolean(options.hasUnsavedChanges);
   }
 
@@ -115,9 +152,11 @@
   function buildWorkingSourceSnapshot(options) {
     options = options || {};
     if (options.orderDirty) {
-      throw new Error(options.orderDirtyMessage ||
-        'Unsaved order-builder changes cannot be represented safely. ' +
-        'Save them or discard them before using the assistant.');
+      throw new Error(
+        options.orderDirtyMessage ||
+          'Unsaved order-builder changes cannot be represented safely. ' +
+            'Save them or discard them before using the assistant.',
+      );
     }
     var rawYaml = buildValidationSource(options);
     var unsaved = hasUnsavedEdits(options);

--- a/docassemble/ALWeaver/test_editor_api_client.js
+++ b/docassemble/ALWeaver/test_editor_api_client.js
@@ -16,7 +16,9 @@ async function expectError(promise, expected) {
     assert.fail('Expected EditorApiError');
   } catch (error) {
     assert.ok(error instanceof api.EditorApiError, error);
-    Object.keys(expected).forEach((key) => assert.strictEqual(error[key], expected[key], key));
+    Object.keys(expected).forEach((key) =>
+      assert.strictEqual(error[key], expected[key], key),
+    );
   }
 }
 
@@ -34,7 +36,10 @@ async function run() {
   const payload = await client.post('/api/file', { content: '' });
   assert.strictEqual(payload.data.raw_yaml, '');
   assert.strictEqual(requests[0].options.headers['X-CSRF-Token'], 'csrf-value');
-  assert.strictEqual(requests[0].options.headers['X-Request-ID'], 'request-123');
+  assert.strictEqual(
+    requests[0].options.headers['X-Request-ID'],
+    'request-123',
+  );
   assert.strictEqual(requests[0].options.credentials, 'same-origin');
 
   await client.delete('/api/runtime/sessions/test-session');
@@ -46,20 +51,37 @@ async function run() {
     csrfToken: 'upload-csrf',
     fetchImpl: async (url, options) => {
       uploadRequests.push({ url, options });
-      return jsonResponse({ success: true, data: { saved_files: ['brief.pdf'] } });
+      return jsonResponse({
+        success: true,
+        data: { saved_files: ['brief.pdf'] },
+      });
     },
   });
   const formData = new FormData();
   formData.append('files', new Blob(['contents']), 'brief.pdf');
   await uploadClient.upload('/api/upload', formData);
   assert.strictEqual(uploadRequests[0].options.body, formData);
-  assert.strictEqual(uploadRequests[0].options.headers['X-CSRF-Token'], 'upload-csrf');
-  assert.strictEqual(uploadRequests[0].options.headers['Content-Type'], undefined);
+  assert.strictEqual(
+    uploadRequests[0].options.headers['X-CSRF-Token'],
+    'upload-csrf',
+  );
+  assert.strictEqual(
+    uploadRequests[0].options.headers['Content-Type'],
+    undefined,
+  );
 
   const httpClient = api.createClient({
-    fetchImpl: async () => jsonResponse({
-      error: { code: 'revision_conflict', message: 'Changed', details: { current: 'b' } },
-    }, 409),
+    fetchImpl: async () =>
+      jsonResponse(
+        {
+          error: {
+            code: 'revision_conflict',
+            message: 'Changed',
+            details: { current: 'b' },
+          },
+        },
+        409,
+      ),
   });
   await expectError(httpClient.get('/conflict'), {
     status: 409,
@@ -68,33 +90,49 @@ async function run() {
   });
 
   const htmlClient = api.createClient({
-    fetchImpl: async () => new Response('<html>Error</html>', {
-      status: 500,
-      headers: { 'Content-Type': 'text/html' },
-    }),
+    fetchImpl: async () =>
+      new Response('<html>Error</html>', {
+        status: 500,
+        headers: { 'Content-Type': 'text/html' },
+      }),
   });
-  await expectError(htmlClient.get('/html'), { status: 500, code: 'invalid_content_type' });
+  await expectError(htmlClient.get('/html'), {
+    status: 500,
+    code: 'invalid_content_type',
+  });
 
   const malformedClient = api.createClient({
-    fetchImpl: async () => new Response('{', {
-      status: 200,
-      headers: { 'Content-Type': 'application/json' },
-    }),
+    fetchImpl: async () =>
+      new Response('{', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
   });
-  await expectError(malformedClient.get('/bad-json'), { status: 200, code: 'invalid_json' });
+  await expectError(malformedClient.get('/bad-json'), {
+    status: 200,
+    code: 'invalid_json',
+  });
 
   const synchronousFailureClient = api.createClient({
-    fetchImpl: () => { throw new Error('socket unavailable'); },
+    fetchImpl: () => {
+      throw new Error('socket unavailable');
+    },
   });
-  await expectError(synchronousFailureClient.get('/sync-failure'), { code: 'network_error' });
+  await expectError(synchronousFailureClient.get('/sync-failure'), {
+    code: 'network_error',
+  });
 
   let resolveFirst;
   const staleClient = api.createClient({
     fetchImpl: (url) => {
       if (url.includes('first')) {
-        return new Promise((resolve) => { resolveFirst = resolve; });
+        return new Promise((resolve) => {
+          resolveFirst = resolve;
+        });
       }
-      return Promise.resolve(jsonResponse({ success: true, data: { value: 'new' } }));
+      return Promise.resolve(
+        jsonResponse({ success: true, data: { value: 'new' } }),
+      );
     },
   });
   const first = staleClient.get('/api/file?name=first');
@@ -103,15 +141,49 @@ async function run() {
   resolveFirst(jsonResponse({ success: true, data: { value: 'old' } }));
   await expectError(first, { code: 'stale_response' });
 
+  const originalUrl = globalThis.URL;
+  let resolveMissingUrlFirst;
+  try {
+    globalThis.URL = undefined;
+    const missingUrlClient = api.createClient({
+      fetchImpl: (url) => {
+        if (url.includes('first')) {
+          return new Promise((resolve) => {
+            resolveMissingUrlFirst = resolve;
+          });
+        }
+        return Promise.resolve(
+          jsonResponse({ success: true, data: { value: 'fallback' } }),
+        );
+      },
+    });
+    const missingUrlFirst = missingUrlClient.get('/api/file?name=first');
+    const missingUrlSecond = missingUrlClient.get('/api/file?name=second');
+    assert.strictEqual((await missingUrlSecond).data.value, 'fallback');
+    resolveMissingUrlFirst(
+      jsonResponse({ success: true, data: { value: 'stale' } }),
+    );
+    await expectError(missingUrlFirst, { code: 'stale_response' });
+  } finally {
+    globalThis.URL = originalUrl;
+  }
+
   const writeResolvers = [];
   const writeClient = api.createClient({
-    fetchImpl: () => new Promise((resolve) => { writeResolvers.push(resolve); }),
+    fetchImpl: () =>
+      new Promise((resolve) => {
+        writeResolvers.push(resolve);
+      }),
   });
   const firstWrite = writeClient.post('/api/file', { raw_yaml: 'first' });
   const secondWrite = writeClient.post('/api/file', { raw_yaml: 'second' });
   await Promise.resolve();
-  writeResolvers[1](jsonResponse({ success: true, data: { revision: 'second' } }));
-  writeResolvers[0](jsonResponse({ success: true, data: { revision: 'first' } }));
+  writeResolvers[1](
+    jsonResponse({ success: true, data: { revision: 'second' } }),
+  );
+  writeResolvers[0](
+    jsonResponse({ success: true, data: { revision: 'first' } }),
+  );
   assert.strictEqual((await firstWrite).data.revision, 'first');
   assert.strictEqual((await secondWrite).data.revision, 'second');
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,41 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import sonarjs from 'eslint-plugin-sonarjs';
+
+const endpointFiles = [
+  'docassemble/ALWeaver/data/static/editor_api_client.js',
+  'docassemble/ALWeaver/data/static/editor_agent_chat.js',
+  'docassemble/ALWeaver/data/static/editor_module_restart.js',
+  'docassemble/ALWeaver/data/static/editor_runtime_inspector.js',
+  'docassemble/ALWeaver/data/static/editor_validation_source.js',
+  'docassemble/ALWeaver/data/static/editor_dirty_state.js',
+];
+
+export default [
+  {
+    ignores: ['node_modules/**'],
+  },
+  {
+    files: endpointFiles,
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'script',
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
+    },
+    plugins: {
+      sonarjs,
+    },
+    rules: {
+      ...js.configs.recommended.rules,
+      ...sonarjs.configs.recommended.rules,
+      // These browser modules intentionally use nested closures for their
+      // stateful controllers and promise callbacks. Keep the other SonarJS
+      // correctness rules active without penalising that implementation shape.
+      'sonarjs/no-nested-functions': 'off',
+      'sonarjs/cognitive-complexity': 'off',
+    },
+  },
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1333 @@
+{
+  "name": "docassemble-alweaver-static-checks",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "docassemble-alweaver-static-checks",
+      "devDependencies": {
+        "@eslint/js": "^9.35.0",
+        "@types/node": "^24.3.0",
+        "eslint": "^9.35.0",
+        "eslint-plugin-sonarjs": "^3.0.5",
+        "globals": "^16.3.0",
+        "prettier": "^3.6.2",
+        "ts-api-utils": "^2.5.0",
+        "typescript": "^5.9.2"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.3.0",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/brace-expansion": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
+      "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/balanced-match": "^4.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-3.0.7.tgz",
+      "integrity": "sha512-62jB20krIPvcwBLAyG3VVKa2ce2j2lL1yCb8Y0ylMRR/dLvCCTiQx8gQbXb+G81k1alPZ2/I3muZinqWQdBbzw==",
+      "dev": true,
+      "license": "LGPL-3.0-only",
+      "dependencies": {
+        "@eslint-community/regexpp": "4.12.2",
+        "builtin-modules": "3.3.0",
+        "bytes": "3.1.2",
+        "functional-red-black-tree": "1.0.1",
+        "jsx-ast-utils-x": "0.1.0",
+        "lodash.merge": "4.6.2",
+        "minimatch": "10.1.2",
+        "scslre": "0.3.0",
+        "semver": "7.7.4",
+        "typescript": ">=5"
+      },
+      "peerDependencies": {
+        "eslint": "^8.0.0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/minimatch": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.2.tgz",
+      "integrity": "sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsx-ast-utils-x": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils-x/-/jsx-ast-utils-x-0.1.0.tgz",
+      "integrity": "sha512-eQQBjBnsVtGacsG9uJNB8qOr3yA8rga4wAaGG1qRcBzSIvfhERLrWxMAM1hp5fcS6Abo8M4+bUBTekYR0qTPQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/refa": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/refa/-/refa-0.12.1.tgz",
+      "integrity": "sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0"
+      },
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/regexp-ast-analysis": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.7.1.tgz",
+      "integrity": "sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0",
+        "refa": "^0.12.1"
+      },
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/scslre": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.3.0.tgz",
+      "integrity": "sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0",
+        "refa": "^0.12.0",
+        "regexp-ast-analysis": "^0.7.0"
+      },
+      "engines": {
+        "node": "^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "docassemble-alweaver-static-checks",
+  "private": true,
+  "scripts": {
+    "format": "prettier --write $npm_package_config_jsFiles",
+    "format:check": "prettier --check $npm_package_config_jsFiles",
+    "lint": "eslint $npm_package_config_jsFiles",
+    "typecheck": "tsc --project tsconfig.json",
+    "check": "npm run format:check && npm run lint && npm run typecheck",
+    "prepare": "git config core.hooksPath .githooks 2>/dev/null || true"
+  },
+  "config": {
+    "jsFiles": "docassemble/ALWeaver/data/static/editor_api_client.js docassemble/ALWeaver/data/static/editor_agent_chat.js docassemble/ALWeaver/data/static/editor_module_restart.js docassemble/ALWeaver/data/static/editor_runtime_inspector.js docassemble/ALWeaver/data/static/editor_validation_source.js docassemble/ALWeaver/data/static/editor_dirty_state.js"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.35.0",
+    "@types/node": "^24.3.0",
+    "eslint": "^9.35.0",
+    "eslint-plugin-sonarjs": "^3.0.5",
+    "globals": "^16.3.0",
+    "prettier": "^3.6.2",
+    "ts-api-utils": "^2.5.0",
+    "typescript": "^5.9.2"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "docassemble-alweaver-static-checks",
   "private": true,
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "format": "prettier --write $npm_package_config_jsFiles",
     "format:check": "prettier --check $npm_package_config_jsFiles",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "target": "ES2021",
+    "lib": ["ES2021", "DOM"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "strict": false,
+    "skipLibCheck": true
+  },
+  "include": [
+    "docassemble/ALWeaver/data/static/editor_api_client.js",
+    "docassemble/ALWeaver/data/static/editor_agent_chat.js",
+    "docassemble/ALWeaver/data/static/editor_module_restart.js",
+    "docassemble/ALWeaver/data/static/editor_runtime_inspector.js",
+    "docassemble/ALWeaver/data/static/editor_validation_source.js",
+    "docassemble/ALWeaver/data/static/editor_dirty_state.js"
+  ]
+}


### PR DESCRIPTION
## Summary

- add reproducible Prettier, ESLint/SonarJS, and JavaScript `checkJs` tooling for the maintained editor endpoint clients
- add a tracked local pre-commit hook that formats staged JavaScript and runs the complete `npm run check` suite
- add GitHub Actions coverage for the same checks on pushes and pull requests
- fix the existing formatting, lint, SonarJS, and type-check findings without converting the browser code to TypeScript

## Verification

- `npm ci && npm run check`
- commit hook completed successfully during commit
- Node syntax and JavaScript tests passed
- frontend regression tests: 46 passed, 29 subtests passed
- GitHub Actions workflow: `.github/workflows/static_checks.yml`
