### PR TITLE
Turn the runtime inspector into a first-class interview debugger

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,13 @@ The revisioned graphical source-patch API is an opt-in beta. Set
 environment variable) to enable it. The default production path remains off
 until graphical editing paths have migrated to exact source-range commands.
 
-The server-side runtime inspector is also opt-in. Set
-`WEAVER_ENABLE_RUNTIME_INSPECTOR: true` to enable owner-scoped target sessions,
-current-question and variable inspection, scenario seeding, back navigation, and
-the fixed read-only `al_weaver.inspect_*` action allowlist. Docassemble remains
-the only interview runtime.
+The editor's interview debugger is enabled by default for authenticated
+developers and administrators. It runs the real interview in a separate test
+session beside current-question details, a step recorder, variable inspection,
+scenario seeding, and back navigation. Set `weaver: {runtime inspector: false}`
+(or `WEAVER_ENABLE_RUNTIME_INSPECTOR: false`) to turn it off. Its server API uses
+owner-scoped target sessions and a fixed read-only `al_weaver.inspect_*` action
+allowlist; Docassemble remains the only interview runtime.
 
 ## History
 

--- a/architecture.md
+++ b/architecture.md
@@ -105,7 +105,7 @@ grouped under one heading:
 weaver:
   assistant: True            # the editing assistant; on unless set to False
   assistant model: gpt-5-mini
-  runtime inspector: False   # opt-in
+  runtime inspector: True    # developer interview debugger; set False to hide
   source patch api: False    # opt-in
 ```
 
@@ -269,13 +269,16 @@ Pluggy hook and otherwise use the populated 1.9 server implementation. The same
 module owns access to initialized Flask, storage, Redis, and worker objects so
 the rest of Weaver does not depend on version-specific private module paths.
 
-The runtime inspector server API is disabled by default behind
-`WEAVER_ENABLE_RUNTIME_INSPECTOR`. It creates a Docassemble session separate from
-the editor and stores an expiring, owner-scoped `WeaverTargetSession` record in
-Redis. Browser calls use only Weaver's opaque session ID; every lookup verifies
-the current developer, and public session metadata excludes the raw Docassemble
-ID and any secret. Deleting the Weaver record revokes further inspector access;
-it does not claim to delete Docassemble's underlying session.
+The interview debugger and its runtime inspector API are enabled by default for
+authenticated developers and administrators, and can be disabled with
+`weaver: {runtime inspector: False}` or the legacy
+`WEAVER_ENABLE_RUNTIME_INSPECTOR` setting. It creates a Docassemble session
+separate from the editor and stores an expiring, owner-scoped
+`WeaverTargetSession` record in Redis. Browser calls use only Weaver's opaque
+session ID; every lookup verifies the current developer, and public session
+metadata excludes the raw Docassemble ID and any secret. Deleting the Weaver
+record revokes further inspector access; it does not claim to delete
+Docassemble's underlying session.
 
 Variable reads are simplified and omit `_internal` by default. Variable writes
 never deserialize objects. Question and back operations call Docassemble through
@@ -285,14 +288,18 @@ HTML, non-JSON, and oversized responses. Returned questions, variables, and
 action data are labeled `observed_runtime` so they cannot be confused with
 static-analysis findings. Weaver never chooses the next question.
 
-The browser inspector is isolated in `editor_runtime_inspector.js`. It can start
-or restart a test session, open the authoritative interview, inspect the current
-question, browse simplified variables, reveal `_internal` data explicitly, go
-back, and apply a YAML test scenario. Scenario YAML is parsed and validated on
-the server, never in browser JavaScript. Scenario seeding is labeled as a fixture
-that may bypass earlier questions. Question-to-source links are shown only when a
-stable returned `questionName` matches a known block; otherwise the UI says that
-no confident match is available.
+The browser debugger is isolated in `editor_runtime_inspector.js`. Its main pane
+runs the authoritative interview in an iframe while a sidebar follows the
+current question, records visited screens and the variables changed on each
+screen, and provides searchable simplified session variables. It can restart a
+test session, reveal `_internal` data explicitly, go back, and apply a YAML test
+scenario. Iframe loads trigger a fresh observation, while the iframe node itself
+survives sidebar redraws so inspection cannot accidentally restart the
+interview. Scenario YAML is parsed and validated on the server, never in browser
+JavaScript. Scenario seeding is labeled as a fixture that may bypass earlier
+questions. Question-to-source links are shown only when a stable returned
+`questionName` matches a known block; otherwise the UI says that no confident
+match is available.
 
 Saving a Playground Python module is the one editor action that cannot take
 effect on its own. Docassemble does not import modules from where the Playground

--- a/docassemble/ALWeaver/api_editor.py
+++ b/docassemble/ALWeaver/api_editor.py
@@ -4644,7 +4644,8 @@ RUNTIME_VARIABLE_RESULT_LIMIT = 1024 * 1024
 
 
 def _runtime_inspector_enabled() -> bool:
-    return _weaver_flag("runtime inspector", False)
+    """The developer-only interview debugger is on unless explicitly disabled."""
+    return _weaver_flag("runtime inspector", True)
 
 
 def _runtime_disabled(request_id: str) -> Response:
@@ -4700,6 +4701,27 @@ def _runtime_operation_failed(
     )
 
 
+def _browser_session_secret() -> Optional[str]:
+    """The developer's own Docassemble decryption key, from their cookie.
+
+    Docassemble's ``/interview`` route decrypts a session with nothing but the
+    visitor's ``secret`` cookie — there is no query-string equivalent — so the
+    debugger iframe can open the target session only if Weaver encrypted it
+    with that same key. Creating the session with any other key makes
+    Docassemble discard it and silently start a different one in the iframe,
+    leaving the panels describing a session the developer is not using.
+
+    Read per request rather than stored: this key decrypts every session the
+    developer owns, and it is already in the browser making the request.
+    """
+    try:
+        secret = request.cookies.get("secret")
+    except RuntimeError:
+        # Outside a request context there is no browser to keep in sync.
+        return None
+    return str(secret) if secret else None
+
+
 def _runtime_target_url(record: Any) -> str:
     return (
         "/interview?i="
@@ -4743,13 +4765,12 @@ def editor_api_runtime_create_session() -> Response:
         # does not, so without this the inspector can run against a parse from
         # before the developer's last save.
         bump_interview_source_index(yaml_filename)
+        browser_secret = _browser_session_secret()
         target = create_target_session(
             yaml_filename,
-            secret=None,
+            secret=browser_secret,
             url_args=url_args or None,
         )
-        if target.secret is not None:
-            raise ValueError("Encrypted target sessions are not currently supported")
         record = create_runtime_record(
             weaver_session_id=str(uuid.uuid4()),
             owner_user_id=uid,
@@ -4758,6 +4779,7 @@ def editor_api_runtime_create_session() -> Response:
             yaml_filename=yaml_filename,
             target=target,
             purpose=purpose,
+            persist_secret=browser_secret is None,
         )
         store_runtime_record(r, record)
         return jsonify_with_status(
@@ -4783,7 +4805,11 @@ def editor_api_runtime_create_session() -> Response:
             status,
         )
     except Exception as exc:
-        log(f"ALWeaver editor: runtime session creation failed: {exc!r}", "error")
+        log(
+            "ALWeaver editor: runtime session creation failed: "
+            f"{exc!r}\n{traceback.format_exc()}",
+            "error",
+        )
         return jsonify_with_status(
             {
                 "success": False,
@@ -4839,7 +4865,7 @@ def editor_api_runtime_variables(weaver_session_id: str) -> Response:
     if record is None:
         return _runtime_not_found(request_id)
     try:
-        target = record.target()
+        target = record.target(_browser_session_secret())
         if request.method == "POST":
             post_data = request.get_json(silent=True)
             if not isinstance(post_data, dict):
@@ -4954,7 +4980,7 @@ def editor_api_runtime_question(weaver_session_id: str) -> Response:
     if record is None:
         return _runtime_not_found(request_id)
     try:
-        question = get_target_question(record.target())
+        question = get_target_question(record.target(_browser_session_secret()))
         append_runtime_event(
             r,
             record,
@@ -4986,7 +5012,7 @@ def editor_api_runtime_back(weaver_session_id: str) -> Response:
     if record is None:
         return _runtime_not_found(request_id)
     try:
-        go_back_target_session(record.target())
+        go_back_target_session(record.target(_browser_session_secret()))
         append_runtime_event(r, record, "back_invoked")
         return jsonify(
             {
@@ -5042,7 +5068,10 @@ def editor_api_runtime_action(weaver_session_id: str, action_name: str) -> Respo
         )
     try:
         result = run_target_action_raw(
-            record.target(), action_name, arguments=arguments, read_only=True
+            record.target(_browser_session_secret()),
+            action_name,
+            arguments=arguments,
+            read_only=True,
         )
     except Exception as exc:
         return _runtime_operation_failed(request_id, "action", exc)
@@ -5219,16 +5248,17 @@ class _AgentRuntimeBridge:
     def _target(self) -> Any:
         if self._record is None:
             raise ValueError("No runtime session has been started")
-        return self._record.target()
+        return self._record.target(_browser_session_secret())
 
     def start_session(self) -> Dict[str, Any]:
         playground_read_yaml(self._user_id, self._project, self._filename)
         yaml_filename = playground_yaml_filename(
             self._user_id, self._project, self._filename
         )
-        target = create_target_session(yaml_filename, secret=None, url_args=None)
-        if target.secret is not None:
-            raise ValueError("Encrypted target sessions are not currently supported")
+        browser_secret = _browser_session_secret()
+        target = create_target_session(
+            yaml_filename, secret=browser_secret, url_args=None
+        )
         record = create_runtime_record(
             weaver_session_id=str(uuid.uuid4()),
             owner_user_id=self._user_id,
@@ -5237,6 +5267,7 @@ class _AgentRuntimeBridge:
             yaml_filename=yaml_filename,
             target=target,
             purpose="inspection",
+            persist_secret=browser_secret is None,
         )
         store_runtime_record(r, record)
         self._record = record

--- a/docassemble/ALWeaver/data/static/editor.css
+++ b/docassemble/ALWeaver/data/static/editor.css
@@ -4197,3 +4197,240 @@ html, body {
   text-align: center;
   color: var(--editor-muted);
 }
+
+/* ===== Live interview debugger ===== */
+
+.editor-main:has(.editor-runtime-inspector) {
+  overflow: hidden;
+}
+
+.editor-layout.editor-layout-runtime {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.editor-layout.editor-layout-runtime > .editor-left {
+  display: none;
+}
+
+.editor-canvas:has(.editor-runtime-inspector) {
+  height: 100%;
+  padding: 0;
+}
+
+.editor-runtime-inspector {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  background: #fff;
+}
+
+.editor-runtime-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--editor-border);
+  flex: 0 0 auto;
+}
+
+#runtime-session-content {
+  min-height: 0;
+  flex: 1 1 auto;
+}
+
+.editor-runtime-empty {
+  max-width: 580px;
+  margin: 10vh auto 0;
+  padding: 32px;
+  text-align: center;
+}
+
+.editor-runtime-empty > .fa-bug,
+.editor-runtime-empty > svg {
+  margin-bottom: 16px;
+  color: var(--editor-primary);
+  font-size: 2.5rem;
+}
+
+.editor-runtime-workbench {
+  display: grid;
+  grid-template-columns: minmax(290px, 360px) minmax(0, 1fr);
+  height: 100%;
+  min-height: 0;
+}
+
+.editor-runtime-sidebar {
+  min-height: 0;
+  overflow-y: auto;
+  padding: 10px;
+  background: var(--editor-bg);
+  border-right: 1px solid var(--editor-border);
+}
+
+.editor-runtime-panel {
+  margin-bottom: 8px;
+  border: 1px solid var(--editor-border);
+  border-radius: var(--editor-radius-sm);
+  background: #fff;
+  box-shadow: var(--editor-card-shadow);
+}
+
+.editor-runtime-panel > summary {
+  cursor: pointer;
+  padding: 9px 11px;
+  font-weight: 650;
+}
+
+.editor-runtime-panel-body {
+  padding: 0 11px 11px;
+}
+
+.editor-runtime-step-list {
+  max-height: 250px;
+  overflow-y: auto;
+}
+
+.editor-runtime-steps {
+  margin: 0;
+  padding-left: 24px;
+}
+
+.editor-runtime-steps > li {
+  position: relative;
+  padding: 0 0 12px 5px;
+}
+
+.editor-runtime-steps > li::before {
+  content: "";
+  position: absolute;
+  top: 6px;
+  bottom: -5px;
+  left: -15px;
+  border-left: 2px solid var(--editor-border);
+}
+
+.editor-runtime-steps > li:last-child::before {
+  display: none;
+}
+
+.editor-runtime-steps > li::marker,
+.editor-runtime-steps > li.is-current::marker {
+  color: var(--editor-primary);
+  font-weight: 700;
+}
+
+.editor-runtime-step-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.editor-runtime-step-answers {
+  margin: 5px 0 0;
+  padding-left: 16px;
+  color: var(--editor-muted);
+  font-family: var(--bs-font-monospace);
+  font-size: 0.72rem;
+  overflow-wrap: anywhere;
+}
+
+.editor-runtime-variable {
+  margin-bottom: 6px;
+  border: 1px solid var(--editor-border);
+  border-radius: 5px;
+  background: #fff;
+}
+
+.editor-runtime-variable > summary {
+  cursor: pointer;
+  padding: 6px 8px;
+  font-family: var(--bs-font-monospace);
+  font-size: 0.76rem;
+  overflow-wrap: anywhere;
+}
+
+.editor-runtime-variable > pre {
+  max-height: 220px;
+  margin: 0;
+  padding: 8px;
+  overflow: auto;
+  border-top: 1px solid var(--editor-border);
+  background: #f8f9fa;
+  font-size: 0.72rem;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.editor-runtime-variable-changed {
+  border-color: #d39e00;
+  background: #fff8db;
+}
+
+.editor-runtime-interview {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  background: #e9edf2;
+}
+
+.editor-runtime-frame-bar {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 7px 12px;
+  border-bottom: 1px solid var(--editor-border);
+  background: #fff;
+  font-weight: 600;
+}
+
+#runtime-frame-host {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.editor-runtime-frame {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  background: #fff;
+}
+
+@media (max-width: 1100px) {
+  .editor-runtime-workbench {
+    grid-template-columns: minmax(250px, 310px) minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 760px) {
+  .editor-main:has(.editor-runtime-inspector) {
+    overflow-y: auto;
+  }
+
+  .editor-canvas:has(.editor-runtime-inspector) {
+    height: auto;
+    min-height: 100%;
+  }
+
+  .editor-runtime-header,
+  .editor-runtime-frame-bar {
+    flex-direction: column;
+  }
+
+  .editor-runtime-workbench {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .editor-runtime-sidebar {
+    max-height: 48vh;
+    border-right: 0;
+    border-bottom: 1px solid var(--editor-border);
+  }
+
+  .editor-runtime-interview {
+    min-height: 70vh;
+  }
+}

--- a/docassemble/ALWeaver/data/static/editor.js
+++ b/docassemble/ALWeaver/data/static/editor.js
@@ -1551,6 +1551,14 @@
     onError: showApiError,
   });
 
+  // Runtime inspector renders its own inline, aria-live status.  Keep its
+  // failures out of the editor-wide floating error banner so one failure is
+  // announced exactly once.
+  var runtimeApiClient = window.ALWeaverApiClient.createClient({
+    baseUrl: API,
+    csrfToken: BOOT.csrfToken || null,
+  });
+
   function apiGet(path, options) {
     return apiClient.get(path, options);
   }
@@ -2228,9 +2236,9 @@
 
   var runtimeInspector = window.ALWeaverRuntimeInspector.createRuntimeInspector({
     api: {
-      get: apiGet,
-      post: apiPost,
-      delete: apiDelete,
+      get: runtimeApiClient.get,
+      post: runtimeApiClient.post,
+      delete: runtimeApiClient.delete,
     },
     getContext: function () {
       return { project: state.project, filename: state.filename };
@@ -2239,6 +2247,26 @@
     beforeStart: function () { return ensureModulesLoaded('start a test session'); },
     onSessionChange: function (session) {
       state.runtimeTargetSession = session;
+    },
+    onOpenSource: function (blockId) {
+      var block = getBlockById(blockId);
+      if (!block) return;
+      state.currentView = 'interview';
+      state.canvasMode = 'question';
+      state.selectedBlockId = blockId;
+      state.questionEditMode = 'preview';
+      // A runtime question may live outside the developer's current outline
+      // filter. Widen it before selecting so the source link cannot land on a
+      // block that the outline immediately replaces.
+      state.jumpTarget = 'all';
+      syncJumpSelect();
+      renderCanvas();
+      renderOutline();
+    },
+    onClose: function () {
+      state.canvasMode = 'question';
+      renderCanvas();
+      renderOutline();
     },
   });
 
@@ -5016,6 +5044,12 @@
 
   function loadFile() {
     if (!state.filename) return Promise.resolve();
+    var runtimeSession = runtimeInspector.getSession();
+    if (runtimeSession && (
+      runtimeSession.project !== state.project || runtimeSession.filename !== state.filename
+    )) {
+      runtimeInspector.releaseSession();
+    }
     endAssistantSessionForFileChange();
     return apiGet(
       '/api/file?project=' + encodeURIComponent(state.project) +
@@ -6384,6 +6418,13 @@
 
   function renderCanvas() {
     disposeSourceEditors();
+    var editorLayout = document.getElementById('editor-layout');
+    if (editorLayout) {
+      editorLayout.classList.toggle(
+        'editor-layout-runtime',
+        state.currentView === 'interview' && state.canvasMode === 'runtime-inspector'
+      );
+    }
     updateLeftRailMode();
     updateLeftSearchPlaceholder();
     updateTopbarProject();

--- a/docassemble/ALWeaver/data/static/editor_runtime_inspector.js
+++ b/docassemble/ALWeaver/data/static/editor_runtime_inspector.js
@@ -47,7 +47,7 @@
         // Each pattern here has a single unbounded quantifier whose
         // character class excludes the delimiter that ends it, so matching
         // is linear in the input length despite sonarjs's generic warning.
-        // eslint-disable-next-line sonarjs/slow-regex
+        // eslint-disable-next-line sonarjs/super-linear-regex
         .replace(/<[^>]*>/g, ' ')
         .replace(/&nbsp;/gi, ' ')
         .replace(/&amp;/gi, '&')
@@ -56,7 +56,7 @@
         .replace(/&quot;/gi, '"')
         .replace(/&#(?:39|x27);/gi, "'")
         .replace(/\s+/g, ' ')
-        // eslint-disable-next-line sonarjs/slow-regex
+        // eslint-disable-next-line sonarjs/super-linear-regex
         .replace(/\s+([?!.,:;])/g, '$1')
         .trim()
     );

--- a/docassemble/ALWeaver/data/static/editor_runtime_inspector.js
+++ b/docassemble/ALWeaver/data/static/editor_runtime_inspector.js
@@ -1,4 +1,4 @@
-/* Runtime inspector UI backed exclusively by Weaver's authenticated endpoints. */
+/* First-class interview debugger backed by Weaver's authenticated runtime API. */
 (function (root, factory) {
   'use strict';
   var api = factory();
@@ -31,6 +31,35 @@
     return Object.keys(names).sort();
   }
 
+  function plainText(value) {
+    return String(value || '')
+      .replace(/<[^>]*>/g, ' ')
+      .replace(/&nbsp;/gi, ' ')
+      .replace(/&amp;/gi, '&')
+      .replace(/&lt;/gi, '<')
+      .replace(/&gt;/gi, '>')
+      .replace(/&quot;/gi, '"')
+      .replace(/&#(?:39|x27);/gi, "'")
+      .replace(/\s+/g, ' ')
+      .replace(/\s+([?!.,:;])/g, '$1')
+      .trim();
+  }
+
+  function questionLabel(question) {
+    question = question || {};
+    var candidate = question.questionText || question.question || question.title ||
+      question.questionName || 'Unnamed screen';
+    if (typeof candidate !== 'string') candidate = question.questionName || 'Unnamed screen';
+    var label = plainText(candidate) || question.questionName || 'Unnamed screen';
+    return label.length > 120 ? label.slice(0, 117) + '...' : label;
+  }
+
+  function questionIdentity(question) {
+    question = question || {};
+    return String(question.questionName || '') ||
+      [questionLabel(question), question.questionType || question.type || ''].join('|');
+  }
+
   function findQuestionSource(question, blocks) {
     var questionName = question && question.questionName;
     if (!questionName) return null;
@@ -42,25 +71,67 @@
     }) || null;
   }
 
+  function variablePreview(value) {
+    if (value === undefined) return '(removed)';
+    var serialized;
+    try {
+      serialized = JSON.stringify(value);
+    } catch (ignore) {
+      serialized = String(value);
+    }
+    if (serialized === undefined) serialized = String(value);
+    return serialized.length > 90 ? serialized.slice(0, 87) + '...' : serialized;
+  }
+
+  function updateStepHistory(history, nextQuestion, nextVariables, nextChanged) {
+    var result = clone(history || []);
+    var latest = result.length ? result[result.length - 1] : null;
+    if (latest && nextChanged.length) {
+      latest.answers = nextChanged.map(function (name) {
+        return { name: name, value: clone(nextVariables[name]) };
+      });
+    }
+    var identity = questionIdentity(nextQuestion);
+    if (!latest || latest.identity !== identity) {
+      result.push({
+        identity: identity,
+        label: questionLabel(nextQuestion),
+        questionName: nextQuestion.questionName || '',
+        questionType: nextQuestion.questionType || nextQuestion.type || 'unknown',
+        visitedAt: new Date().toISOString(),
+        answers: [],
+      });
+    }
+    return result.slice(-100);
+  }
+
   function createRuntimeInspector(options) {
     options = options || {};
     var api = options.api;
     var getContext = options.getContext;
     var getBlocks = options.getBlocks || function () { return []; };
     var onSessionChange = options.onSessionChange || function () {};
-    // Runs before a test session is created, so pending Python module changes
-    // can be loaded first. Resolving false abandons the start.
+    var onOpenSource = options.onOpenSource || function () {};
+    var onClose = options.onClose || function () {};
     var beforeStart = options.beforeStart || function () { return Promise.resolve(true); };
     var session = null;
     var question = null;
     var variables = {};
-    var previousVariables = {};
     var changed = [];
+    var hasVariableSnapshot = false;
+    var steps = [];
     var includeInternal = false;
     var variableQuery = '';
+    var scenarioText = 'name: Test scenario\nvariables:\n  user.marital_status: married\ndelete:\n  - final_document';
     var status = '';
     var error = '';
     var container = null;
+    var busy = false;
+    var observing = false;
+    var observeAgain = false;
+    var observationPromise = null;
+    var pollTimer = null;
+    var hidden = true;
 
     function sessionPath(suffix) {
       if (!session || !session.weaver_session_id) throw new Error('Start a test session first.');
@@ -72,8 +143,39 @@
       error = isError ? String(message || '') : '';
     }
 
+    function resetObservedState() {
+      question = null;
+      variables = {};
+      changed = [];
+      hasVariableSnapshot = false;
+      steps = [];
+    }
+
+    function stopPolling() {
+      if (pollTimer !== null) {
+        window.clearInterval(pollTimer);
+        pollTimer = null;
+      }
+    }
+
+    function startPolling() {
+      stopPolling();
+      // The interview runs in an iframe and normally advances through AJAX,
+      // so its load event is not a reliable navigation signal.  Coalesced
+      // observations make this inexpensive while ensuring every click is
+      // eventually reflected in the debugger panels.
+      pollTimer = window.setInterval(function () {
+        if (session && !busy) observeRuntime();
+      }, 1000);
+    }
+
+    function recordObservation(nextQuestion, nextVariables, nextChanged) {
+      steps = updateStepHistory(steps, nextQuestion, nextVariables, nextChanged);
+    }
+
     function startSession() {
       var context = getContext();
+      busy = true;
       return Promise.resolve(beforeStart()).then(function (proceed) {
         if (proceed === false) return undefined;
         setStatus('Starting a separate Docassemble test session...');
@@ -84,73 +186,119 @@
           purpose: 'test',
         }).then(function (response) {
           session = clone(response.data);
-          question = null;
-          variables = {};
-          previousVariables = {};
-          changed = [];
+          resetObservedState();
+          startPolling();
           onSessionChange(clone(session));
-          setStatus('Test session started.');
+          setStatus('Test session started. Use the interview and the debugger will follow along.');
           render(container);
-          return refreshAll();
-        }).catch(function (requestError) {
-          setStatus(requestError.message || 'Unable to start the test session.', true);
-          render(container);
+          return observeRuntime('Debugger synchronized with the interview.');
         });
+      }).catch(function (requestError) {
+        setStatus(requestError.message || 'Unable to start the test session.', true);
+      }).finally(function () {
+        busy = false;
+        render(container);
       });
     }
 
     function endSession() {
       if (!session) return Promise.resolve();
+      busy = true;
+      stopPolling();
       return api.delete(sessionPath()).then(function () {
         session = null;
-        question = null;
-        variables = {};
-        changed = [];
+        resetObservedState();
         onSessionChange(null);
-        setStatus('Inspector access to the test session ended.');
+        setStatus('Debugger access to the test session ended.');
+      }).catch(function (requestError) {
+        setStatus(requestError.message || 'Unable to end the test session.', true);
+      }).finally(function () {
+        busy = false;
         render(container);
       });
     }
 
-    function refreshQuestion() {
-      return api.get(sessionPath('/question')).then(function (response) {
-        question = clone(response.data.question || {});
-        setStatus('Current question observed from Docassemble.');
-        render(container);
-      });
-    }
-
-    function refreshVariables() {
-      var path = sessionPath('/variables') + (includeInternal ? '?include_internal=true' : '');
-      return api.get(path).then(function (response) {
-        previousVariables = variables;
-        variables = clone(response.data.variables || {});
-        changed = changedVariableNames(previousVariables, variables);
-        render(container);
-      });
-    }
-
-    function refreshAll() {
+    function releaseSession() {
       if (!session) return Promise.resolve();
-      return Promise.all([refreshQuestion(), refreshVariables()]).catch(function (requestError) {
-        setStatus(requestError.message || 'Unable to refresh runtime facts.', true);
-        render(container);
+      var path = sessionPath();
+      stopPolling();
+      session = null;
+      resetObservedState();
+      onSessionChange(null);
+      return api.delete(path).catch(function () {
+        // The owner-scoped server record expires on its own. Context changes
+        // should not be blocked just because revocation could not finish.
       });
+    }
+
+    function observeRuntime(successMessage) {
+      if (!session) return Promise.resolve();
+      if (observing) {
+        observeAgain = true;
+        return observationPromise || Promise.resolve();
+      }
+      observing = true;
+      var variablePath = sessionPath('/variables') +
+        (includeInternal ? '?include_internal=true' : '');
+      observationPromise = Promise.all([
+        api.get(sessionPath('/question')),
+        api.get(variablePath),
+      ]).then(function (responses) {
+        var nextQuestion = clone((responses[0].data || {}).question || {});
+        var nextVariables = clone((responses[1].data || {}).variables || {});
+        var nextChanged = hasVariableSnapshot
+          ? changedVariableNames(variables, nextVariables)
+          : [];
+        recordObservation(nextQuestion, nextVariables, nextChanged);
+        question = nextQuestion;
+        variables = nextVariables;
+        changed = nextChanged;
+        hasVariableSnapshot = true;
+        setStatus(successMessage || 'Debugger synchronized with the interview.');
+      }).catch(function (requestError) {
+        setStatus(requestError.message || 'Unable to refresh runtime facts.', true);
+      }).finally(function () {
+        observing = false;
+        observationPromise = null;
+        render(container);
+        if (observeAgain) {
+          observeAgain = false;
+          window.setTimeout(function () { observeRuntime(); }, 100);
+        }
+      });
+      return observationPromise;
+    }
+
+    function reloadInterview() {
+      var frame = container && container.querySelector('#runtime-interview-frame');
+      if (frame && session) frame.src = session.target_url;
     }
 
     function goBack() {
-      return api.post(sessionPath('/back'), {}).then(refreshAll).catch(function (requestError) {
+      busy = true;
+      return api.post(sessionPath('/back'), {}).then(function () {
+        setStatus('Moved the test session back one screen.');
+        reloadInterview();
+        return observeRuntime();
+      }).catch(function (requestError) {
         setStatus(requestError.message || 'Docassemble could not go back.', true);
+      }).finally(function () {
+        busy = false;
         render(container);
       });
     }
 
     function applyScenario(text) {
-      return api.post(sessionPath('/variables'), { scenario_yaml: String(text || '') }).then(function () {
+      scenarioText = String(text || '');
+      busy = true;
+      return api.post(sessionPath('/variables'), { scenario_yaml: scenarioText }).then(function () {
         setStatus('Scenario applied. Seeded state may bypass earlier questions.');
-        return refreshAll();
+        reloadInterview();
+        return observeRuntime();
       }).catch(function (requestError) {
         setStatus(requestError.message || 'Unable to apply the scenario.', true);
+      }).finally(function () {
+        busy = false;
         render(container);
       });
     }
@@ -159,19 +307,18 @@
       var visible = filterVariables(variables, variableQuery);
       var names = Object.keys(visible);
       if (!names.length) {
-        target.textContent = 'No matching variables.';
+        target.textContent = hasVariableSnapshot ? 'No matching variables.' : 'Variables will appear after the session starts.';
         target.className = 'text-muted small';
         return;
       }
       names.forEach(function (name) {
         var details = document.createElement('details');
-        details.className = 'editor-runtime-variable border rounded p-2 mb-2';
-        if (changed.indexOf(name) !== -1) details.classList.add('border-warning', 'bg-warning-subtle');
+        details.className = 'editor-runtime-variable';
+        if (changed.indexOf(name) !== -1) details.classList.add('editor-runtime-variable-changed');
         var summary = document.createElement('summary');
         summary.textContent = name + ' · ' + (visible[name] === null ? 'null' : typeof visible[name]);
         details.appendChild(summary);
         var value = document.createElement('pre');
-        value.className = 'small mt-2 mb-0 text-wrap';
         value.textContent = JSON.stringify(visible[name], null, 2);
         details.appendChild(value);
         target.appendChild(details);
@@ -180,131 +327,227 @@
 
     function renderQuestion(target) {
       if (!question) {
-        target.textContent = 'No runtime question has been inspected yet.';
+        target.innerHTML = '<p class="text-muted small mb-0">The current screen will appear here.</p>';
         return;
       }
-      var name = question.questionName || '(no stable question name)';
-      var type = question.questionType || question.type || 'unknown';
       var heading = document.createElement('h3');
-      heading.className = 'h6';
-      heading.textContent = name;
+      heading.className = 'h6 mb-1';
+      heading.textContent = questionLabel(question);
       target.appendChild(heading);
       var meta = document.createElement('p');
-      meta.className = 'small text-muted';
-      meta.textContent = 'Question type: ' + type + ' · observed runtime fact';
+      meta.className = 'editor-tiny text-muted mb-2';
+      meta.textContent = (question.questionName || 'No stable question name') +
+        ' · ' + (question.questionType || question.type || 'unknown') +
+        ' · observed runtime';
       target.appendChild(meta);
       var undefinedName = question.undefinedVariable || question.undefined;
       if (undefinedName) {
         var undefinedEl = document.createElement('p');
+        undefinedEl.className = 'small mb-2';
         undefinedEl.textContent = 'Undefined variable: ' + String(undefinedName);
         target.appendChild(undefinedEl);
       }
       var sourceBlock = findQuestionSource(question, getBlocks());
-      var mapping = document.createElement('p');
-      mapping.className = 'small';
-      mapping.textContent = sourceBlock
-        ? 'Source match: ' + sourceBlock.id
-        : 'No confident source-block match is available.';
-      target.appendChild(mapping);
-      if (question.fields) {
-        var fields = document.createElement('pre');
-        fields.className = 'small bg-light border rounded p-2';
-        fields.textContent = JSON.stringify(question.fields, null, 2);
-        target.appendChild(fields);
+      if (sourceBlock) {
+        var source = document.createElement('button');
+        source.type = 'button';
+        source.className = 'btn btn-sm btn-outline-secondary';
+        source.textContent = 'Open source block';
+        source.addEventListener('click', function () { onOpenSource(sourceBlock.id); });
+        target.appendChild(source);
+      } else {
+        var mapping = document.createElement('p');
+        mapping.className = 'editor-tiny text-muted mb-0';
+        mapping.textContent = 'No confident source-block match is available.';
+        target.appendChild(mapping);
       }
+    }
+
+    function renderSteps(target) {
+      if (!steps.length) {
+        target.innerHTML = '<p class="text-muted small mb-0">Visited screens and changed answers will be recorded here.</p>';
+        return;
+      }
+      var list = document.createElement('ol');
+      list.className = 'editor-runtime-steps';
+      steps.forEach(function (step, index) {
+        var item = document.createElement('li');
+        if (index === steps.length - 1) item.className = 'is-current';
+        var label = document.createElement('div');
+        label.className = 'editor-runtime-step-label';
+        label.textContent = step.label;
+        item.appendChild(label);
+        var meta = document.createElement('div');
+        meta.className = 'editor-tiny text-muted';
+        meta.textContent = step.questionName || step.questionType;
+        item.appendChild(meta);
+        if (step.answers && step.answers.length) {
+          var answers = document.createElement('ul');
+          answers.className = 'editor-runtime-step-answers';
+          step.answers.forEach(function (answer) {
+            var answerItem = document.createElement('li');
+            answerItem.textContent = answer.name + ': ' + variablePreview(answer.value);
+            answers.appendChild(answerItem);
+          });
+          item.appendChild(answers);
+        }
+        list.appendChild(item);
+      });
+      target.appendChild(list);
+      target.scrollTop = target.scrollHeight;
+    }
+
+    function makeButton(label, className, handler) {
+      var button = document.createElement('button');
+      button.type = 'button';
+      button.className = className;
+      button.textContent = label;
+      button.disabled = busy;
+      button.addEventListener('click', handler);
+      return button;
+    }
+
+    function refreshRenderedDebugger(wrapper) {
+      var statusNode = wrapper.querySelector('#runtime-status');
+      statusNode.textContent = error || status || 'The debugger is synchronized with this test session.';
+      statusNode.classList.toggle('alert-danger', Boolean(error));
+      statusNode.classList.toggle('alert-info', !error);
+      wrapper.querySelectorAll('#runtime-session-actions button').forEach(function (button) {
+        button.disabled = busy;
+      });
+
+      var questionTarget = wrapper.querySelector('#runtime-question');
+      questionTarget.innerHTML = '';
+      renderQuestion(questionTarget);
+      var stepTarget = wrapper.querySelector('#runtime-step-list');
+      var previousScrollTop = stepTarget.scrollTop;
+      var wasAtBottom = stepTarget.scrollHeight - stepTarget.scrollTop - stepTarget.clientHeight < 24;
+      stepTarget.innerHTML = '';
+      renderSteps(stepTarget);
+      // Polling re-renders this panel. Keep a user's scroll position instead
+      // of forcing them back to the newest step on every refresh. New sessions
+      // and users already at the bottom still follow the latest step.
+      if (!wasAtBottom) stepTarget.scrollTop = previousScrollTop;
+      wrapper.querySelector('#runtime-step-count').textContent = String(steps.length);
+      wrapper.querySelector('#runtime-variable-count').textContent = String(Object.keys(variables).length);
+      var variableTarget = wrapper.querySelector('#runtime-variable-list');
+      variableTarget.innerHTML = '';
+      variableTarget.className = '';
+      appendVariableRows(variableTarget);
+      wrapper.querySelector('#runtime-include-internal').checked = includeInternal;
+    }
+
+    // Editor.js owns the canvas this panel draws into, so an internal re-render
+    // that arrives after the developer left the debugger would paint over
+    // whatever replaced it.
+    function show(target) {
+      hidden = false;
+      container = target || container;
+      if (session) startPolling();
+      render(container);
     }
 
     function render(target) {
       container = target || container;
-      if (!container) return;
+      if (!container || hidden) return;
+      // Never replace or detach a live iframe merely to update observations.
+      // Removing it can destroy its browsing context in some browsers.
+      var liveFrame = session && container.querySelector
+        ? container.querySelector('#runtime-interview-frame')
+        : null;
+      if (liveFrame) {
+        refreshRenderedDebugger(liveFrame.closest('.editor-runtime-inspector'));
+        return;
+      }
       container.innerHTML = '';
+
       var wrapper = document.createElement('section');
-      wrapper.className = 'editor-runtime-inspector p-3';
+      wrapper.className = 'editor-runtime-inspector';
       wrapper.setAttribute('aria-labelledby', 'runtime-inspector-title');
       wrapper.innerHTML =
-        '<div class="d-flex flex-wrap justify-content-between gap-2 align-items-start">' +
-          '<div><h2 class="h4 mb-1" id="runtime-inspector-title">Runtime inspector</h2>' +
-          '<p class="text-muted small">Docassemble is the authoritative runtime. This view only inspects a separate test session.</p></div>' +
+        '<header class="editor-runtime-header">' +
+          '<div><div class="d-flex align-items-center gap-2"><h2 class="h4 mb-0" id="runtime-inspector-title">Debug interview</h2>' +
+            '<span class="badge text-bg-success ' + (session ? '' : 'd-none') + '">Live test session</span></div>' +
+            '<p class="text-muted small mb-0">Run the real interview while Weaver follows its screens, answers, and variables.</p></div>' +
           '<div class="d-flex flex-wrap gap-2" id="runtime-session-actions"></div>' +
-        '</div>' +
-        '<div class="alert alert-info py-2" id="runtime-status" role="status" aria-live="polite"></div>' +
+        '</header>' +
+        '<div class="alert py-2 mb-0 ' + (error ? 'alert-danger' : 'alert-info') + '" id="runtime-status" role="status" aria-live="polite"></div>' +
         '<div id="runtime-session-content"></div>';
       container.appendChild(wrapper);
-      var statusNode = wrapper.querySelector('#runtime-status');
-      statusNode.textContent = error || status || (session ? 'Test session is active.' : 'Start a test session to inspect Docassemble runtime facts.');
-      statusNode.classList.toggle('alert-danger', Boolean(error));
-      statusNode.classList.toggle('alert-info', !error);
+      wrapper.querySelector('#runtime-status').textContent = error || status ||
+        (session ? 'The debugger is synchronized with this test session.' :
+          'Start a test session. It is separate from every end-user interview.');
       var actions = wrapper.querySelector('#runtime-session-actions');
       var content = wrapper.querySelector('#runtime-session-content');
+      // Going back to the editor keeps the test session alive but tears down
+      // this panel, so stop polling for observations nothing is displaying.
+      // Reopening the debugger re-renders and starts it again.
+      actions.appendChild(makeButton('Back to editor', 'btn btn-sm btn-outline-secondary', function () {
+        hidden = true;
+        stopPolling();
+        onClose();
+      }));
 
       if (!session) {
-        var start = document.createElement('button');
-        start.type = 'button';
-        start.className = 'btn btn-primary';
-        start.textContent = 'Start new test session';
-        start.addEventListener('click', startSession);
-        actions.appendChild(start);
+        actions.appendChild(makeButton('Start debugging', 'btn btn-sm btn-primary', startSession));
+        content.innerHTML =
+          '<div class="editor-runtime-empty">' +
+            '<i class="fa-solid fa-bug" aria-hidden="true"></i>' +
+            '<h3 class="h5">See what your interview is doing</h3>' +
+            '<p class="text-muted">Weaver opens a fresh test session here and records each screen you visit. Your regular interview sessions are untouched.</p>' +
+          '</div>';
         return;
       }
 
       var open = document.createElement('a');
-      open.className = 'btn btn-primary';
-      open.textContent = 'Open interview';
+      open.className = 'btn btn-sm btn-outline-secondary';
+      open.textContent = 'Open in new tab';
       open.target = '_blank';
       open.rel = 'noopener';
       open.href = session.target_url;
       actions.appendChild(open);
-      [['Inspect current question', refreshQuestion], ['Refresh variables', refreshVariables], ['Back', goBack]].forEach(function (item) {
-        var button = document.createElement('button');
-        button.type = 'button';
-        button.className = 'btn btn-outline-secondary';
-        button.textContent = item[0];
-        button.addEventListener('click', item[1]);
-        actions.appendChild(button);
-      });
-      var restart = document.createElement('button');
-      restart.type = 'button';
-      restart.className = 'btn btn-outline-secondary';
-      restart.textContent = 'Start new test session';
-      restart.addEventListener('click', function () { endSession().then(startSession); });
-      actions.appendChild(restart);
-      var end = document.createElement('button');
-      end.type = 'button';
-      end.className = 'btn btn-outline-danger';
-      end.textContent = 'End inspection';
-      end.addEventListener('click', endSession);
-      actions.appendChild(end);
+      actions.appendChild(makeButton('Refresh', 'btn btn-sm btn-outline-secondary', function () {
+        observeRuntime('Runtime facts refreshed.');
+      }));
+      actions.appendChild(makeButton('Back one screen', 'btn btn-sm btn-outline-secondary', goBack));
+      actions.appendChild(makeButton('Restart', 'btn btn-sm btn-outline-secondary', function () {
+        endSession().then(function () { if (!session) startSession(); });
+      }));
+      actions.appendChild(makeButton('End', 'btn btn-sm btn-outline-danger', endSession));
 
       content.innerHTML =
-        '<div class="row g-3">' +
-          '<div class="col-12 col-xl-6"><div class="card h-100"><div class="card-body">' +
-            '<h3 class="h5">Current question</h3><div id="runtime-question"></div>' +
-          '</div></div></div>' +
-          '<div class="col-12 col-xl-6"><div class="card h-100"><div class="card-body">' +
-            '<h3 class="h5">Apply scenario</h3>' +
-            '<p class="small text-muted">A scenario is a test fixture and may bypass earlier questions.</p>' +
-            '<label for="runtime-scenario" class="form-label">Scenario YAML</label>' +
-            '<textarea id="runtime-scenario" class="form-control font-monospace" rows="7">name: Test scenario\nvariables:\n  user.marital_status: married\ndelete:\n  - final_document</textarea>' +
-            '<button type="button" class="btn btn-outline-primary mt-2" id="runtime-apply-scenario">Apply scenario</button>' +
-          '</div></div></div>' +
-          '<div class="col-12"><div class="card"><div class="card-body">' +
-            '<div class="d-flex flex-wrap justify-content-between gap-2"><h3 class="h5">Session variables</h3>' +
-              '<label class="form-check"><input class="form-check-input" type="checkbox" id="runtime-include-internal"> <span class="form-check-label">Show _internal data</span></label></div>' +
-            '<label for="runtime-variable-search" class="visually-hidden">Search variables</label>' +
-            '<input id="runtime-variable-search" class="form-control form-control-sm mb-3" placeholder="Search variables">' +
-            '<div id="runtime-variable-list"></div>' +
-          '</div></div></div>' +
+        '<div class="editor-runtime-workbench">' +
+          '<aside class="editor-runtime-sidebar" aria-label="Interview debugging details">' +
+            '<details class="editor-runtime-panel" open><summary>Current screen</summary><div id="runtime-question" class="editor-runtime-panel-body"></div></details>' +
+            '<details class="editor-runtime-panel" open><summary>Step recorder <span class="badge text-bg-secondary" id="runtime-step-count"></span></summary><div id="runtime-step-list" class="editor-runtime-panel-body editor-runtime-step-list"></div></details>' +
+            '<details class="editor-runtime-panel" open><summary>Session variables <span class="badge text-bg-secondary" id="runtime-variable-count"></span></summary>' +
+              '<div class="editor-runtime-panel-body"><div class="d-flex gap-2 mb-2">' +
+                '<label for="runtime-variable-search" class="visually-hidden">Search variables</label>' +
+                '<input id="runtime-variable-search" class="form-control form-control-sm" type="search" placeholder="Filter variables">' +
+              '</div><label class="form-check editor-tiny mb-2"><input class="form-check-input" type="checkbox" id="runtime-include-internal"> <span class="form-check-label">Show _internal data</span></label>' +
+              '<div id="runtime-variable-list"></div></div></details>' +
+            '<details class="editor-runtime-panel"><summary>Test scenario</summary><div class="editor-runtime-panel-body">' +
+              '<p class="editor-tiny text-muted">Seed variables for a test path. This fixture can bypass earlier screens.</p>' +
+              '<label for="runtime-scenario" class="form-label editor-tiny">Scenario YAML</label>' +
+              '<textarea id="runtime-scenario" class="form-control form-control-sm font-monospace" rows="7"></textarea>' +
+              '<button type="button" class="btn btn-sm btn-outline-primary mt-2" id="runtime-apply-scenario">Apply and reload</button>' +
+            '</div></details>' +
+          '</aside>' +
+          '<div class="editor-runtime-interview"><div class="editor-runtime-frame-bar"><span><i class="fa-solid fa-display me-1" aria-hidden="true"></i>Live interview</span><span class="editor-tiny text-muted">Actions here are recorded automatically</span></div><div id="runtime-frame-host"></div></div>' +
         '</div>';
+
       renderQuestion(content.querySelector('#runtime-question'));
+      renderSteps(content.querySelector('#runtime-step-list'));
+      content.querySelector('#runtime-step-count').textContent = String(steps.length);
+      content.querySelector('#runtime-variable-count').textContent = String(Object.keys(variables).length);
       appendVariableRows(content.querySelector('#runtime-variable-list'));
-      content.querySelector('#runtime-apply-scenario').addEventListener('click', function () {
-        applyScenario(content.querySelector('#runtime-scenario').value);
-      });
+
       var internalToggle = content.querySelector('#runtime-include-internal');
       internalToggle.checked = includeInternal;
       internalToggle.addEventListener('change', function () {
         includeInternal = internalToggle.checked;
-        refreshVariables();
+        hasVariableSnapshot = false;
+        observeRuntime('Variable visibility updated.');
       });
       var search = content.querySelector('#runtime-variable-search');
       search.value = variableQuery;
@@ -314,13 +557,34 @@
         list.innerHTML = '';
         appendVariableRows(list);
       });
+      var scenario = content.querySelector('#runtime-scenario');
+      scenario.value = scenarioText;
+      scenario.addEventListener('input', function () { scenarioText = scenario.value; });
+      content.querySelector('#runtime-apply-scenario').addEventListener('click', function () {
+        applyScenario(scenario.value);
+      });
+
+      var frame = document.createElement('iframe');
+      frame.id = 'runtime-interview-frame';
+      frame.className = 'editor-runtime-frame';
+      frame.title = 'Live Docassemble test interview';
+      frame.src = session.target_url;
+      frame.addEventListener('load', function () {
+        if (session) observeRuntime('Interview advanced; debugger synchronized.');
+      });
+      content.querySelector('#runtime-frame-host').appendChild(frame);
     }
 
     return {
-      render: render,
-      refreshAll: refreshAll,
+      render: show,
+      refreshAll: observeRuntime,
       getSession: function () { return clone(session); },
-      setSession: function (value) { session = clone(value); onSessionChange(clone(session)); },
+      releaseSession: releaseSession,
+      setSession: function (value) {
+        session = clone(value);
+        resetObservedState();
+        onSessionChange(clone(session));
+      },
     };
   }
 
@@ -329,5 +593,9 @@
     filterVariables: filterVariables,
     changedVariableNames: changedVariableNames,
     findQuestionSource: findQuestionSource,
+    questionLabel: questionLabel,
+    questionIdentity: questionIdentity,
+    variablePreview: variablePreview,
+    updateStepHistory: updateStepHistory,
   };
 });

--- a/docassemble/ALWeaver/data/templates/editor.html
+++ b/docassemble/ALWeaver/data/templates/editor.html
@@ -41,6 +41,7 @@
         <div class="editor-top-actions">
           <button type="button" class="btn btn-sm btn-outline-light js-check-errors-btn" data-action="check-errors" title="Check for errors"><i class="fa-solid fa-triangle-exclamation js-check-errors-icon d-none" aria-hidden="true"></i><span class="js-check-errors-label">Errors</span><span class="editor-validation-badge js-validation-badge d-none" data-validation-badge></span></button>
           <button type="button" class="btn btn-sm btn-outline-light" data-action="preview-interview"><i class="fa-solid fa-arrow-up-right-from-square me-1" aria-hidden="true"></i>Open interview</button>
+          <button type="button" class="btn btn-sm btn-outline-light" id="btn-debug-interview" data-action="open-runtime-inspector"><i class="fa-solid fa-bug me-1" aria-hidden="true"></i>Debug</button>
           <button type="button" class="btn btn-sm btn-light js-save-file-btn" id="btn-save-file" data-action="save-file" title="Save your changes (Ctrl+S)" aria-label="Save your changes" disabled><i class="fa-solid fa-floppy-disk me-1" aria-hidden="true"></i>Save<span class="editor-save-badge js-save-badge d-none"></span></button>
           <button type="button" class="btn btn-sm btn-outline-light d-none js-assistant-toggle" id="btn-toggle-assistant" data-action="toggle-assistant" aria-controls="editor-assistant" aria-expanded="false" aria-label="Toggle the editing assistant"><i class="fa-solid fa-wand-magic-sparkles me-1" aria-hidden="true"></i>Assistant</button>
           <div class="dropdown">
@@ -51,7 +52,6 @@
               <li><button type="button" class="dropdown-item" data-action="open-standard-playground"><i class="fa-solid fa-flask fa-fw me-2" aria-hidden="true"></i>Open in Playground</button></li>
               <li><button type="button" class="dropdown-item" data-action="open-github-publish"><i class="fa-brands fa-github fa-fw me-2" aria-hidden="true"></i>Commit to GitHub</button></li>
               <li class="d-none" id="github-pull-menu-item"><button type="button" class="dropdown-item" data-action="pull-github"><i class="fa-solid fa-code-pull-request fa-fw me-2" aria-hidden="true"></i>Pull changes from GitHub</button></li>
-              <li class="d-none"><button type="button" class="dropdown-item" data-action="open-runtime-inspector"><i class="fa-solid fa-magnifying-glass-chart fa-fw me-2" aria-hidden="true"></i>Inspect variables</button></li>
               <li><hr class="dropdown-divider"></li>
               <li><button type="button" class="dropdown-item" data-action="open-project-selector"><i class="fa-solid fa-folder-open fa-fw me-2" aria-hidden="true"></i>Switch project</button></li>
             </ul>

--- a/docassemble/ALWeaver/docassemble_compat.py
+++ b/docassemble/ALWeaver/docassemble_compat.py
@@ -80,9 +80,13 @@ def initialize_interview_context() -> None:
             device_id=device_id,
             session_uid=str(user_id or "alweaver-runtime"),
         )
-    except Exception:
+    except (Exception, SystemExit):
         # The downstream Docassemble call provides the authoritative error if
-        # this compatibility setup is unavailable on an older release.
+        # this compatibility setup is unavailable on an older release. A
+        # server with no config file (e.g. this test suite) makes importing
+        # ``docassemble.webapp.utils.helpers`` call ``sys.exit(1)``, which is
+        # a ``SystemExit`` rather than an ``Exception`` and must be caught
+        # here too so it does not escape as a fatal error.
         return
 
 

--- a/docassemble/ALWeaver/docassemble_compat.py
+++ b/docassemble/ALWeaver/docassemble_compat.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from contextlib import AbstractContextManager
+from contextlib import AbstractContextManager, contextmanager
 from dataclasses import dataclass, field
 import base64
 import importlib
@@ -16,6 +16,8 @@ import subprocess
 import sys
 import tempfile
 import tarfile
+import pathlib
+import threading
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 from urllib.parse import quote, urlparse
 
@@ -59,6 +61,109 @@ class TargetActionResult:
     data: Any = None
     warnings: List[str] = field(default_factory=list)
     raw: Any = field(default=None, repr=False, compare=False)
+
+
+def initialize_interview_context() -> None:
+    """Install Docassemble's normal request context for server-side sessions."""
+    try:
+        from flask import request
+        from flask_login import current_user
+        from docassemble.base.thread_context import this_thread
+        from docassemble.webapp.utils.helpers import current_info
+
+        user_id = getattr(current_user, "id", None)
+        device_id = request.cookies.get("ds") or "alweaver-runtime"
+        this_thread.current_info = current_info(
+            yaml=None,
+            req=request,
+            secret=None,
+            device_id=device_id,
+            session_uid=str(user_id or "alweaver-runtime"),
+        )
+    except Exception:
+        # The downstream Docassemble call provides the authoritative error if
+        # this compatibility setup is unavailable on an older release.
+        return
+
+
+_CUSTOM_DATATYPES_LOADED = False
+_CUSTOM_DATATYPES_LOCK = threading.Lock()
+
+
+def _custom_datatype_roots() -> List[pathlib.Path]:
+    """The ``docassemble`` package trees to search for custom datatypes.
+
+    Docassemble installs every package — including the copies it makes of each
+    developer's Playground modules at startup — under one directory, so walking
+    that covers exactly what its own ``import_necessary`` covers.  The
+    ``sys.path`` fallback is for processes that never loaded the webapp
+    configuration and therefore cannot say where that directory is.
+    """
+    directory = full_package_directory()
+    if directory:
+        return [pathlib.Path(directory) / "docassemble"]
+    return [pathlib.Path(root) / "docassemble" for root in sys.path]
+
+
+def _load_custom_datatypes() -> None:
+    """Register installed Docassemble custom datatypes, if startup did not.
+
+    Docassemble registers ``CustomDataType`` subclasses as a side effect of
+    importing the modules that define them, which its ``import_necessary`` does
+    for every installed package when a web or Celery process boots.  A process
+    where that did not happen renders custom fields as plain text and can fail
+    to assemble a screen that depends on one, so this repeats the same narrowly
+    scoped discovery as a fallback; unlike ``import_necessary`` it never
+    imports arbitrary endpoint modules.
+
+    Docassemble having any custom datatype registered means its own startup
+    import already ran, so the scan never happens on a healthy server.
+    """
+    global _CUSTOM_DATATYPES_LOADED
+    if _CUSTOM_DATATYPES_LOADED:
+        return
+    # Without this lock two first requests in a threaded worker would both run
+    # the filesystem walk below.
+    with _CUSTOM_DATATYPES_LOCK:
+        if _CUSTOM_DATATYPES_LOADED:
+            return
+        try:
+            already_registered = bool(_base_functions().custom_types)
+        except Exception:
+            already_registered = False
+        if not already_registered:
+            _import_custom_datatype_modules()
+        _CUSTOM_DATATYPES_LOADED = True
+
+
+def _import_custom_datatype_modules() -> None:
+    for package_root in _custom_datatype_roots():
+        if not package_root.is_dir():
+            continue
+        for source in package_root.glob("*/**/*.py"):
+            try:
+                text = source.read_text(encoding="utf-8")
+            except (OSError, UnicodeError):
+                continue
+            if "class " not in text or "(CustomDataType" not in text:
+                continue
+            relative = source.relative_to(package_root).with_suffix("")
+            module_name = "docassemble." + ".".join(relative.parts)
+            try:
+                importlib.import_module(module_name)
+            except Exception:
+                continue
+
+
+@contextmanager
+def _runtime_context():
+    """Provide the thread-local globals Docassemble expects for API calls."""
+    from docassemble.base.thread_context import empty_globals, global_context
+
+    with global_context(empty_globals()):
+        initialize_interview_context()
+        _load_custom_datatypes()
+        yield
 
 
 def _base_functions() -> Any:
@@ -179,9 +284,19 @@ def create_target_session(
     secret: Optional[str] = None,
     url_args: Optional[Dict[str, Any]] = None,
 ) -> TargetSession:
-    session_id = _base_functions().create_session(
-        yaml_filename, secret=secret, url_args=url_args
-    )
+    if secret is None:
+        # Docassemble encrypts a new session whether or not a secret was
+        # supplied, generating its own and discarding it, which would leave the
+        # session unreadable.  Generate one Weaver can keep instead.  Callers
+        # that want the developer's browser to be able to open the session must
+        # pass that browser's own key; see ``_browser_session_secret``.
+        from docassemble.base.generate_key import random_string
+
+        secret = random_string(16)
+    with _runtime_context():
+        session_id = _base_functions().create_session(
+            yaml_filename, secret=secret, url_args=url_args
+        )
     return TargetSession(
         yaml_filename=yaml_filename,
         session_id=str(session_id),
@@ -192,12 +307,13 @@ def create_target_session(
 def get_target_variables(
     target: TargetSession, *, simplify: bool = True
 ) -> Dict[str, Any]:
-    result = _base_functions().get_session_variables(
-        target.yaml_filename,
-        target.session_id,
-        secret=target.secret,
-        simplify=simplify,
-    )
+    with _runtime_context():
+        result = _base_functions().get_session_variables(
+            target.yaml_filename,
+            target.session_id,
+            secret=target.secret,
+            simplify=simplify,
+        )
     if not isinstance(result, dict):
         raise DocassembleCompatibilityError(
             "Docassemble returned a non-dictionary session variable result"
@@ -213,21 +329,23 @@ def set_target_variables(
     overwrite: bool = False,
     process_objects: bool = False,
 ) -> None:
-    _base_functions().set_session_variables(
-        target.yaml_filename,
-        target.session_id,
-        variables,
-        secret=target.secret,
-        delete=delete,
-        overwrite=overwrite,
-        process_objects=process_objects,
-    )
+    with _runtime_context():
+        _base_functions().set_session_variables(
+            target.yaml_filename,
+            target.session_id,
+            variables,
+            secret=target.secret,
+            delete=delete,
+            overwrite=overwrite,
+            process_objects=process_objects,
+        )
 
 
 def get_target_question(target: TargetSession) -> Dict[str, Any]:
-    result = _base_functions().get_question_data(
-        target.yaml_filename, target.session_id, secret=target.secret
-    )
+    with _runtime_context():
+        result = _base_functions().get_question_data(
+            target.yaml_filename, target.session_id, secret=target.secret
+        )
     if not isinstance(result, dict):
         raise DocassembleCompatibilityError(
             "Docassemble returned a non-dictionary question result"
@@ -236,9 +354,10 @@ def get_target_question(target: TargetSession) -> Dict[str, Any]:
 
 
 def go_back_target_session(target: TargetSession) -> Any:
-    return _base_functions().go_back_in_session(
-        target.yaml_filename, target.session_id, secret=target.secret
-    )
+    with _runtime_context():
+        return _base_functions().go_back_in_session(
+            target.yaml_filename, target.session_id, secret=target.secret
+        )
 
 
 def run_target_action(
@@ -248,14 +367,15 @@ def run_target_action(
     arguments: Optional[Dict[str, Any]] = None,
     read_only: bool = True,
 ) -> None:
-    _base_functions().run_action_in_session(
-        target.yaml_filename,
-        target.session_id,
-        action,
-        arguments=arguments or {},
-        secret=target.secret,
-        read_only=read_only,
-    )
+    with _runtime_context():
+        _base_functions().run_action_in_session(
+            target.yaml_filename,
+            target.session_id,
+            action,
+            arguments=arguments or {},
+            secret=target.secret,
+            read_only=read_only,
+        )
 
 
 def _normalize_raw_action_result(result: Any) -> TargetActionResult:
@@ -308,7 +428,8 @@ def run_target_action_raw(
         raise DocassembleCompatibilityError(
             "This Docassemble installation does not expose raw session actions"
         )
-    return _normalize_raw_action_result(raw_action(**kwargs))
+    with _runtime_context():
+        return _normalize_raw_action_result(raw_action(**kwargs))
 
 
 def get_flask_app() -> Any:

--- a/docassemble/ALWeaver/runtime_sessions.py
+++ b/docassemble/ALWeaver/runtime_sessions.py
@@ -32,15 +32,24 @@ class WeaverTargetSession:
     purpose: str
     history: List[Dict[str, Any]] = field(default_factory=list)
 
-    def target(self) -> TargetSession:
-        # Encrypted target sessions are not enabled until Weaver has a supported
-        # server-side secret handoff. Never expose or accept secrets in browser APIs.
-        if self.encrypted or self.encrypted_secret:
-            raise ValueError("Encrypted target sessions are not currently supported")
+    def target(self, secret: Optional[str] = None) -> TargetSession:
+        """Address the Docassemble session, decrypting it with ``secret``.
+
+        The developer's own Docassemble key is deliberately not part of this
+        record: it can decrypt every session they own, so callers supply it per
+        request from the browser cookie that already carries it. ``encrypted_secret``
+        holds a key only for a session Weaver had to encrypt with a generated
+        one, which no browser can open.
+        """
+        secret = secret or self.encrypted_secret
+        if self.encrypted and not secret:
+            raise ValueError(
+                "This target session is encrypted and no decryption key is available"
+            )
         return TargetSession(
             yaml_filename=self.yaml_filename,
             session_id=self.docassemble_session_id,
-            secret=None,
+            secret=secret,
         )
 
     def public_dict(self, target_url: str) -> Dict[str, Any]:
@@ -72,7 +81,13 @@ def create_runtime_record(
     yaml_filename: str,
     target: TargetSession,
     purpose: str = "test",
+    persist_secret: bool = True,
 ) -> WeaverTargetSession:
+    """Build the server-side record for one target session.
+
+    Pass ``persist_secret=False`` when the target was encrypted with a key the
+    caller can recover on every later request, so the record never stores it.
+    """
     timestamp = utc_now()
     return WeaverTargetSession(
         weaver_session_id=weaver_session_id,
@@ -82,7 +97,7 @@ def create_runtime_record(
         yaml_filename=yaml_filename,
         docassemble_session_id=target.session_id,
         encrypted=target.secret is not None,
-        encrypted_secret=None,
+        encrypted_secret=target.secret if persist_secret else None,
         created_at=timestamp,
         last_accessed_at=timestamp,
         purpose=purpose,

--- a/docassemble/ALWeaver/test_docassemble_compat.py
+++ b/docassemble/ALWeaver/test_docassemble_compat.py
@@ -26,6 +26,9 @@ class TestDocassembleCompatibilityInterface(unittest.TestCase):
 
         class FakeFunctions:
             server = types.SimpleNamespace()
+            # Stands in for a server whose startup already imported every
+            # package, so the custom datatype fallback stays out of the way.
+            custom_types = {"fake_datatype": {}}
 
             @staticmethod
             def create_session(yaml_filename, secret=None, url_args=None):
@@ -124,6 +127,51 @@ class TestDocassembleCompatibilityInterface(unittest.TestCase):
 
         self.assertEqual(result.data, {"hook": True})
         self.assertTrue(captured["read_only"])
+
+    def test_every_target_session_call_gets_the_runtime_thread_context(self):
+        """Actions need the same thread context the other wrappers install.
+
+        Without it Docassemble runs an allowlisted ``al_weaver.inspect_*``
+        action with no ``current_info`` and no guarantee that custom datatypes
+        are registered, unlike the identical question and variable reads.
+        """
+        entered = []
+        target = docassemble_compat.TargetSession("pkg:interview.yml", "session-123")
+
+        @contextmanager
+        def counting_context():
+            entered.append(True)
+            yield
+
+        with patch.object(docassemble_compat, "_runtime_context", counting_context):
+            docassemble_compat.run_target_action(target, "inspect")
+            docassemble_compat.run_target_action_raw(target, "inspect")
+
+        self.assertEqual(len(entered), 2)
+
+    def test_custom_datatype_discovery_is_skipped_when_docassemble_loaded_them(self):
+        """Docassemble's own startup import is what normally registers these.
+
+        Repeating its filesystem walk on a server that already has custom
+        datatypes would read every installed package on the first debugger
+        click for nothing.
+        """
+        self.functions.custom_types = {"al_phone": object()}
+        with (
+            patch.object(docassemble_compat, "_CUSTOM_DATATYPES_LOADED", False),
+            patch.object(docassemble_compat, "_import_custom_datatype_modules") as scan,
+        ):
+            docassemble_compat._load_custom_datatypes()
+            self.assertFalse(scan.called)
+
+        self.functions.custom_types = {}
+        with (
+            patch.object(docassemble_compat, "_CUSTOM_DATATYPES_LOADED", False),
+            patch.object(docassemble_compat, "_import_custom_datatype_modules") as scan,
+        ):
+            docassemble_compat._load_custom_datatypes()
+            docassemble_compat._load_custom_datatypes()
+            self.assertEqual(scan.call_count, 1)
 
     def test_docx_jinja_environment_uses_installed_docassemble_layout(self):
         environment = docassemble_compat.create_docx_jinja_environment(

--- a/docassemble/ALWeaver/test_editor_agent_api.py
+++ b/docassemble/ALWeaver/test_editor_agent_api.py
@@ -235,6 +235,11 @@ class TestConfiguration(unittest.TestCase):
         with patch.object(api_editor, "_daconfig", return_value=config):
             self.assertTrue(api_editor._runtime_inspector_enabled())
 
+    def test_the_runtime_debugger_can_be_explicitly_disabled(self):
+        config = {"weaver": {"runtime inspector": False}}
+        with patch.object(api_editor, "_daconfig", return_value=config):
+            self.assertFalse(api_editor._runtime_inspector_enabled())
+
     def test_the_model_can_be_named_in_the_configuration(self):
         config = {"weaver": {"assistant model": "gpt-5-mini"}}
         with patch.object(api_editor, "_daconfig", return_value=config):
@@ -394,7 +399,7 @@ class TestFeatureFlags(AgentApiTestCase):
         ):
             features = api_editor._editor_feature_bootstrap()
         self.assertFalse(features["patch_model"])
-        self.assertFalse(features["runtime_inspector"])
+        self.assertTrue(features["runtime_inspector"])
         self.assertTrue(features["agent_editor"])
         self.assertTrue(features["assistant_status"]["available"])
 

--- a/docassemble/ALWeaver/test_editor_frontend.py
+++ b/docassemble/ALWeaver/test_editor_frontend.py
@@ -14,6 +14,7 @@ NODE_TESTS = (
     "test_editor_agent_chat.js",
     "test_editor_screen_preview.js",
     "test_editor_interview_report.js",
+    "test_editor_runtime_inspector.js",
 )
 
 
@@ -89,6 +90,41 @@ class TestEditorFrontend(unittest.TestCase):
         self.assertIn("Display text — unchanged", editor)
         self.assertIn("hasUnsavedChanges()", editor)
         self.assertIn(".editor-project-search-context", css)
+
+    def test_interview_debugger_is_a_first_class_editor_workbench(self):
+        template = (self.package_dir / "data/templates/editor.html").read_text()
+        editor = (self.package_dir / "data/static/editor.js").read_text()
+        runtime = (
+            self.package_dir / "data/static/editor_runtime_inspector.js"
+        ).read_text()
+        css = (self.package_dir / "data/static/editor.css").read_text()
+
+        self.assertIn('id="btn-debug-interview"', template)
+        self.assertIn('data-action="open-runtime-inspector"', template)
+        self.assertLess(
+            template.index("editor_runtime_inspector.js"), template.index("editor.js")
+        )
+        self.assertIn("editor-layout-runtime", editor)
+        self.assertIn("onOpenSource: function (blockId)", editor)
+        self.assertIn("Live interview", runtime)
+        self.assertIn("Step recorder", runtime)
+        self.assertIn("Session variables", runtime)
+        self.assertIn("frame.addEventListener('load'", runtime)
+        self.assertIn("recordObservation(nextQuestion", runtime)
+        self.assertIn("refreshRenderedDebugger", runtime)
+        self.assertIn("if (liveFrame)", runtime)
+        self.assertIn("releaseSession: releaseSession", runtime)
+        self.assertIn("runtimeInspector.releaseSession()", editor)
+        # Leaving the debugger keeps the test session but tears down the panel,
+        # so the once-a-second polling must not outlive the view that shows it,
+        # and a late observation must not repaint over the editor canvas.
+        self.assertIn(
+            "hidden = true;\n        stopPolling();\n        onClose();", runtime
+        )
+        self.assertIn("if (!container || hidden) return;", runtime)
+        self.assertIn("render: show,", runtime)
+        self.assertIn(".editor-runtime-workbench", css)
+        self.assertIn(".editor-runtime-frame", css)
 
     def test_new_template_offers_a_blank_file_or_a_drafted_document(self):
         template = (self.package_dir / "data/templates/editor.html").read_text()

--- a/docassemble/ALWeaver/test_editor_runtime_api.py
+++ b/docassemble/ALWeaver/test_editor_runtime_api.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 from .docassemble_compat import TargetActionResult, TargetSession
 from .runtime_sessions import (
+    RUNTIME_SESSION_KEY_PREFIX,
     create_runtime_record,
     delete_runtime_record,
     load_runtime_record,
@@ -107,6 +108,55 @@ class TestEditorRuntimeApi(unittest.TestCase):
         create.assert_called_once_with(
             "docassemble.playground7:main.yml", secret=None, url_args=None
         )
+
+    def test_the_debuggers_iframe_can_decrypt_the_session_weaver_created(self):
+        """Docassemble decrypts a session only with the visitor's own cookie.
+
+        A target session encrypted with any other key makes ``/interview``
+        discard it and start a different one, so the iframe would show a
+        session the debugger panels are not describing.
+        """
+        target = TargetSession(
+            "docassemble.playground7:main.yml", "raw-target-id", secret="browser-key"
+        )
+        patches = self._base_patches()
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patch.object(
+                api_editor, "playground_read_yaml", return_value="id: intro\n"
+            ),
+            patch.object(
+                api_editor, "create_target_session", return_value=target
+            ) as create,
+        ):
+            with api_editor.app.test_request_context(
+                "/al/editor/api/runtime/sessions",
+                method="POST",
+                json={"project": "default", "filename": "main.yml"},
+                headers={"Cookie": "secret=browser-key"},
+            ):
+                response = api_editor.editor_api_runtime_create_session()
+
+        self.assertEqual(response.status_code, 201)
+        create.assert_called_once_with(
+            "docassemble.playground7:main.yml",
+            secret="browser-key",
+            url_args=None,
+        )
+        stored = json.loads(
+            self.redis.get(
+                RUNTIME_SESSION_KEY_PREFIX
+                + response.get_json()["data"]["weaver_session_id"]
+            )
+        )
+        self.assertTrue(stored["encrypted"])
+        # The developer's key decrypts every session they own; the browser
+        # sends it on each request, so Weaver never keeps a copy.
+        self.assertIsNone(stored["encrypted_secret"])
+        self.assertNotIn("browser-key", json.dumps(stored))
 
     def test_variable_read_filters_internal_values_by_default(self):
         self._record()

--- a/docassemble/ALWeaver/test_editor_runtime_inspector.js
+++ b/docassemble/ALWeaver/test_editor_runtime_inspector.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const assert = require('assert');
+const runtime = require('./data/static/editor_runtime_inspector.js');
+
+assert.deepStrictEqual(
+  runtime.filterVariables({ zebra: 1, Alpha: 2, beta: 3 }, 'a'),
+  { Alpha: 2, beta: 3, zebra: 1 }
+);
+assert.deepStrictEqual(
+  runtime.changedVariableNames(
+    { unchanged: 1, changed: 'old', removed: true },
+    { unchanged: 1, changed: 'new', added: false }
+  ),
+  ['added', 'changed', 'removed']
+);
+
+assert.strictEqual(
+  runtime.questionLabel({ questionText: '<p>What is <strong>your name</strong>?</p>' }),
+  'What is your name?'
+);
+assert.strictEqual(
+  runtime.questionIdentity({ questionName: 'user_name', questionText: 'Your name' }),
+  'user_name'
+);
+assert.strictEqual(
+  runtime.findQuestionSource(
+    { questionName: 'user_name' },
+    [{ id: 'other' }, { id: 'user_name', type: 'question' }]
+  ).id,
+  'user_name'
+);
+assert.strictEqual(
+  runtime.findQuestionSource(
+    { questionName: 'review_answers' },
+    [{ id: 'generated', data: { event: 'review_answers' } }]
+  ).id,
+  'generated'
+);
+assert.strictEqual(runtime.variablePreview(undefined), '(removed)');
+assert.ok(runtime.variablePreview('x'.repeat(200)).length <= 90);
+
+let steps = runtime.updateStepHistory(
+  [],
+  { questionName: 'name', questionText: 'Your name' },
+  {},
+  []
+);
+steps = runtime.updateStepHistory(
+  steps,
+  { questionName: 'address', questionText: 'Your address' },
+  { user_name: 'Pat' },
+  ['user_name']
+);
+assert.strictEqual(steps.length, 2, 'a new screen adds a recorder step');
+assert.deepStrictEqual(
+  steps[0].answers,
+  [{ name: 'user_name', value: 'Pat' }],
+  'changed variables are attributed to the screen that collected them'
+);
+steps = runtime.updateStepHistory(
+  steps,
+  { questionName: 'address', questionText: 'Your address' },
+  { user_name: 'Pat' },
+  []
+);
+assert.strictEqual(steps.length, 2, 'refreshing one screen does not duplicate it');
+
+console.log('editor_runtime_inspector.js: all assertions passed');

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "docassemble.ALWeaver"
-version = "2.2.0"
+version = "2.2.1"
 description = "Quickly turn a PDF or Word form into a draft Docassemble interview."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Summary
- Adds a live iframe debugger to the editor — step recorder, variable inspection, scenario seeding, back navigation — running against a real Docassemble test session alongside the source editor. Enabled by default.
- Fixes encrypted target-session support so the debugger iframe and the API panels observe the *same* session: the target session is now encrypted with the developer's own browser-cookie secret (the only key Docassemble's `/interview` route accepts) instead of a server-generated one the browser could never decrypt. That key is never persisted server-side.
- All target-session calls (including the two action paths that were previously unwrapped) now run inside the shared thread-local runtime context.
- Custom-datatype discovery now skips its filesystem scan once Docassemble's own startup import has already registered them, and is guarded against concurrent first requests.
- Leaving the debugger panel now stops its polling loop instead of leaving it running against a hidden view.

## Test plan
- [x] `pytest docassemble/ALWeaver` — 824 passed, 759 subtests passed
- [x] `black --check` on touched files
- [x] End-to-end: deployed this branch into a local Docassemble 1.10.7 + AssemblyLine 4.7.0 container, drove the editor with a headless browser as a throwaway developer account, opened the debugger against a real AssemblyLine-based interview (`ALIndividual` + `name_fields()`), and confirmed:
  - the debugger iframe and the "current question" panel agree on the same session id and question before *and after* answering a real screen
  - the step recorder and variable count both advance after answering
  - no console/page errors traceable to this branch (two pre-existing Docassemble/jQuery frontend quirks were confirmed to reproduce identically on a plain, non-debugger interview page, so they're out of scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)