### PR TITLE
Improve editor navigation menus

### DIFF
--- a/.github/scripts/editor_a11y.js
+++ b/.github/scripts/editor_a11y.js
@@ -108,14 +108,14 @@ async function closeModal(page, selector) {
   await modal.waitFor({ state: "hidden", timeout: 10_000 });
 }
 
-async function openMoreMenu(page) {
-  const button = page.locator("#topbar-more-menu");
-  const menu = page.locator('ul[aria-labelledby="topbar-more-menu"]');
+async function openInterviewMenu(page) {
+  const button = page.locator("#interview-menu");
+  const menu = page.locator('ul[aria-labelledby="interview-menu"]');
   if ((await button.getAttribute("aria-expanded")) !== "true") {
     await button.click();
   }
   await page.waitForFunction(
-    () => document.querySelector("#topbar-more-menu")?.getAttribute("aria-expanded") === "true",
+    () => document.querySelector("#interview-menu")?.getAttribute("aria-expanded") === "true",
     undefined,
     { timeout: 10_000 }
   );
@@ -218,7 +218,7 @@ async function main() {
     );
 
     // Full YAML, metadata, and interview-order source editors.
-    await openMoreMenu(page);
+    await openInterviewMenu(page);
     await page.locator('[data-action="open-full-yaml"]').click();
     await page.locator("#full-source-editor").waitFor({ state: "visible" });
     blockingViolations = blockingViolations.concat(
@@ -235,7 +235,7 @@ async function main() {
     await page.locator("#outline-list .editor-outline-item").first().waitFor();
 
     // AssemblyLine settings, including its explanatory popover.
-    await openMoreMenu(page);
+    await openInterviewMenu(page);
     await page.locator('[data-action="open-assemblyline-settings"]').click();
     await page.locator("#assemblyline-settings-filter").waitFor({ state: "visible" });
     blockingViolations = blockingViolations.concat(

--- a/docassemble/ALWeaver/data/static/editor.css
+++ b/docassemble/ALWeaver/data/static/editor.css
@@ -99,12 +99,6 @@ html, body {
   white-space: nowrap;
 }
 
-.editor-brand-caret {
-  font-size: 0.75em;
-  opacity: 0.7;
-  flex: 0 0 auto;
-}
-
 .editor-top-tab {
   /* nav-link renders an <a>; these are <button>s doing the same job. */
   border-width: 0 0 var(--bs-nav-underline-border-width);
@@ -2339,8 +2333,8 @@ html, body {
 .editor-top-tab-caret {
   background: transparent;
   border: none;
-  color: inherit;
-  opacity: 0.75;
+  color: rgba(255, 255, 255, 0.9);
+  opacity: 1;
   cursor: pointer;
   padding: 4px 6px;
   font-size: 11px;

--- a/docassemble/ALWeaver/data/static/editor.js
+++ b/docassemble/ALWeaver/data/static/editor.js
@@ -16575,6 +16575,25 @@
       openRuntimeInspector();
       return;
     }
+    if (uiAction === 'open-interview-order') {
+      var requestedMenuOrderBlock =
+        state.activeOrderBlockId || getDefaultOrderBlockId();
+      if (
+        deferNavigationForUnsavedChanges(
+          'open the interview order',
+          function () {
+            enterOrderBuilder(requestedMenuOrderBlock, 'interview-menu');
+          },
+        )
+      )
+        return;
+      enterOrderBuilder(requestedMenuOrderBlock, 'interview-menu');
+      return;
+    }
+    if (uiAction === 'open-interview-flow-report') {
+      openInterviewFlowReport();
+      return;
+    }
     if (orderBuilderBtn) {
       var requestedOrderBlock =
         state.activeOrderBlockId || getDefaultOrderBlockId();

--- a/docassemble/ALWeaver/data/static/editor.js
+++ b/docassemble/ALWeaver/data/static/editor.js
@@ -16591,6 +16591,7 @@
       return;
     }
     if (uiAction === 'open-interview-flow-report') {
+      stashCurrentEditorState();
       openInterviewFlowReport();
       return;
     }

--- a/docassemble/ALWeaver/data/templates/editor.html
+++ b/docassemble/ALWeaver/data/templates/editor.html
@@ -18,14 +18,28 @@
       <button type="button" class="navbar-brand editor-brand" data-action="open-project-selector" title="Choose a different project">
         <img class="editor-brand-logo" src="/packagestatic/docassemble.ALWeaver/logo.svg?v=2.1.0" alt="ALWeaver">
         <span class="editor-brand-project" id="topbar-project-name">No project selected</span>
-        <i class="fa-solid fa-angle-down editor-brand-caret" aria-hidden="true"></i>
       </button>
       <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#editor-navbar-collapse" aria-controls="editor-navbar-collapse" aria-expanded="false" aria-label="Show the menu">
         <span class="navbar-toggler-icon"></span>
       </button>
       <div class="collapse navbar-collapse" id="editor-navbar-collapse">
         <ul class="navbar-nav nav-underline me-auto" id="view-tabs">
-          <li class="nav-item"><button type="button" class="nav-link editor-top-tab active" data-view="interview" aria-current="page">Interview</button></li>
+          <li class="nav-item dropdown editor-top-tab-split">
+            <button type="button" class="nav-link editor-top-tab active" data-view="interview" aria-current="page">Interview</button>
+            <button type="button" class="editor-top-tab-caret" id="interview-menu" data-bs-toggle="dropdown" data-bs-display="static" aria-expanded="false" aria-label="Interview menu"><i class="fa-solid fa-angle-down" aria-hidden="true"></i></button>
+            <ul class="dropdown-menu" data-bs-theme="light" aria-labelledby="interview-menu">
+              <li><button type="button" class="dropdown-item" data-action="open-interview-order"><i class="fa-solid fa-list-ol fa-fw me-2" aria-hidden="true"></i>Interview Order</button></li>
+              <li><button type="button" class="dropdown-item" data-action="open-interview-flow-report"><i class="fa-solid fa-file-lines fa-fw me-2" aria-hidden="true"></i>Flow report</button></li>
+              <li><hr class="dropdown-divider"></li>
+              <li><button type="button" class="dropdown-item" data-action="open-full-yaml"><i class="fa-solid fa-code fa-fw me-2" aria-hidden="true"></i>YAML source</button></li>
+              <li><button type="button" class="dropdown-item" data-action="open-assemblyline-settings"><i class="fa-solid fa-sliders fa-fw me-2" aria-hidden="true"></i>AssemblyLine settings</button></li>
+              <li><button type="button" class="dropdown-item" data-action="open-standard-playground"><i class="fa-solid fa-flask fa-fw me-2" aria-hidden="true"></i>Open in Playground</button></li>
+              <li><button type="button" class="dropdown-item" data-action="open-github-publish"><i class="fa-brands fa-github fa-fw me-2" aria-hidden="true"></i>Commit to GitHub</button></li>
+              <li class="d-none" id="github-pull-menu-item"><button type="button" class="dropdown-item" data-action="pull-github"><i class="fa-solid fa-code-pull-request fa-fw me-2" aria-hidden="true"></i>Pull changes from GitHub</button></li>
+              <li><hr class="dropdown-divider"></li>
+              <li><button type="button" class="dropdown-item" data-action="open-project-selector"><i class="fa-solid fa-folder-open fa-fw me-2" aria-hidden="true"></i>Switch project</button></li>
+            </ul>
+          </li>
           <li class="nav-item dropdown editor-top-tab-split">
             <button type="button" class="nav-link editor-top-tab" data-view="templates">Templates</button>
             <button type="button" class="editor-top-tab-caret" id="templates-menu" data-bs-toggle="dropdown" data-bs-display="static" aria-expanded="false" aria-label="Templates menu"><i class="fa-solid fa-angle-down" aria-hidden="true"></i></button>
@@ -44,18 +58,6 @@
           <button type="button" class="btn btn-sm btn-outline-light" id="btn-debug-interview" data-action="open-runtime-inspector"><i class="fa-solid fa-bug me-1" aria-hidden="true"></i>Debug</button>
           <button type="button" class="btn btn-sm btn-light js-save-file-btn" id="btn-save-file" data-action="save-file" title="Save your changes (Ctrl+S)" aria-label="Save your changes" disabled><i class="fa-solid fa-floppy-disk me-1" aria-hidden="true"></i>Save<span class="editor-save-badge js-save-badge d-none"></span></button>
           <button type="button" class="btn btn-sm btn-outline-light d-none js-assistant-toggle" id="btn-toggle-assistant" data-action="toggle-assistant" aria-controls="editor-assistant" aria-expanded="false" aria-label="Toggle the editing assistant"><i class="fa-solid fa-wand-magic-sparkles me-1" aria-hidden="true"></i>Assistant</button>
-          <div class="dropdown">
-            <button type="button" class="btn btn-sm btn-outline-light dropdown-toggle" id="topbar-more-menu" data-bs-toggle="dropdown" data-bs-display="static" aria-expanded="false" aria-label="More editor tools">More</button>
-            <ul class="dropdown-menu dropdown-menu-end" data-bs-theme="light" aria-labelledby="topbar-more-menu">
-              <li><button type="button" class="dropdown-item" data-action="open-full-yaml"><i class="fa-solid fa-code fa-fw me-2" aria-hidden="true"></i>YAML source</button></li>
-              <li><button type="button" class="dropdown-item" data-action="open-assemblyline-settings"><i class="fa-solid fa-sliders fa-fw me-2" aria-hidden="true"></i>AssemblyLine settings</button></li>
-              <li><button type="button" class="dropdown-item" data-action="open-standard-playground"><i class="fa-solid fa-flask fa-fw me-2" aria-hidden="true"></i>Open in Playground</button></li>
-              <li><button type="button" class="dropdown-item" data-action="open-github-publish"><i class="fa-brands fa-github fa-fw me-2" aria-hidden="true"></i>Commit to GitHub</button></li>
-              <li class="d-none" id="github-pull-menu-item"><button type="button" class="dropdown-item" data-action="pull-github"><i class="fa-solid fa-code-pull-request fa-fw me-2" aria-hidden="true"></i>Pull changes from GitHub</button></li>
-              <li><hr class="dropdown-divider"></li>
-              <li><button type="button" class="dropdown-item" data-action="open-project-selector"><i class="fa-solid fa-folder-open fa-fw me-2" aria-hidden="true"></i>Switch project</button></li>
-            </ul>
-          </div>
         </div>
         <ul class="navbar-nav editor-account-nav" id="editor-account-nav"></ul>
       </div>

--- a/docassemble/ALWeaver/test_editor_frontend.py
+++ b/docassemble/ALWeaver/test_editor_frontend.py
@@ -743,6 +743,20 @@ class TestEditorFrontend(unittest.TestCase):
         )
         self.assertNotIn("renderDocumentsCard(fileMeta)", editor)
 
+    def test_interview_menu_replaces_more_and_exposes_order_tools(self):
+        template = (self.package_dir / "data/templates/editor.html").read_text()
+        editor = (self.package_dir / "data/static/editor.js").read_text()
+        css = (self.package_dir / "data/static/editor.css").read_text()
+
+        self.assertNotIn("editor-brand-caret", template)
+        self.assertNotIn('id="topbar-more-menu"', template)
+        self.assertIn('id="interview-menu"', template)
+        self.assertIn('data-action="open-interview-order"', template)
+        self.assertIn('data-action="open-interview-flow-report"', template)
+        self.assertIn("uiAction === 'open-interview-order'", editor)
+        self.assertIn("uiAction === 'open-interview-flow-report'", editor)
+        self.assertIn("color: rgba(255, 255, 255, 0.9);", css)
+
     def test_a_template_is_imported_not_analyzed(self):
         """The author's verb is the deed, not the means."""
         editor = (self.package_dir / "data/static/editor.js").read_text()


### PR DESCRIPTION
Closes #1053.

## Summary

- remove the misleading caret next to the project name in the editor brand
- replace the top-bar **More** dropdown with a split **Interview** menu
- add **Interview Order** and **Flow report** to that menu while retaining the existing editor tools
- increase the Interview and Templates caret contrast
- update the browser accessibility route and add frontend regression coverage

## Verification

- installed this branch on `http://localhost` with `~/venv/bin/dainstall`
- exercised `/al/editor` end-to-end with Playwright against `default/test.yml`
- confirmed the old project caret and More control are absent
- confirmed both menu carets compute to `rgba(255, 255, 255, 0.9)`
- opened Interview Order from the new menu
- opened Flow report from the new menu and confirmed the report tab rendered
- pre-commit: Black, mypy, JavaScript static checks, and full unit-test hook all passed
- focused frontend suite: 48 tests and 30 subtests passed

## Screenshots

The screenshots are hosted in a [public gist](https://gist.github.com/nonprofittechy/a6a197b5c17878cf456098eda826d520) and are not committed to this branch.

### Interview menu

![Interview menu with Interview Order, Flow report, and editor tools](https://gist.githubusercontent.com/nonprofittechy/a6a197b5c17878cf456098eda826d520/raw/alweaver-editor-menu.png)

### Interview Order opened from the menu

![Interview Order view](https://gist.githubusercontent.com/nonprofittechy/a6a197b5c17878cf456098eda826d520/raw/alweaver-interview-order.png)
