### PR TITLE
Give an uploaded template a name Docassemble can resolve

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -413,6 +413,7 @@ kinds of interviews that the Weaver can produce.
 - `review_screen.py` groups the review screen a generated interview gets: one entry per question screen, in asking order, with `.revisit` entries for lists, and it decides which attributes a revisit table's `edit:` may name
 - `review_screen_sync.py` re-drafts a review screen for an interview that already exists, so one that has drifted from the questions can be brought back in line without hand-editing
 - `variable_report.py` drafts a starter DOCX template from the questions an interview already asks, for intakes where the answers are the output and there is no form to start from
+- `project_filenames.py` is the one place an uploaded file gets its project name. Docassemble resolves a Playground template reference by stripping every character outside `[A-Za-z0-9-_. ]` out of the name written in the YAML, so a template stored as `demand (1).docx` is looked for as `demand 1.docx` and the interview reports it missing. Uploads are renamed at the door instead, and the stored file, the generated `docx template file:` line and the packaged template all use that one name
 - `editor_modules.py` decides what saving a Playground Python module means: which names Docassemble will actually load, whether the source compiles, whether the module can go live immediately, and which projects are waiting on a restart
 
 `review_screen_sync.py` re-drafts a review screen for an interview that already

--- a/docassemble/ALWeaver/api_editor.py
+++ b/docassemble/ALWeaver/api_editor.py
@@ -158,6 +158,7 @@ from .editor_modules import (
     unpublish_module,
     validate_module_filename,
 )
+from .project_filenames import safe_project_filename
 from .assemblyline_settings import read_settings, update_settings
 from .question_library import (
     attribute_references,
@@ -2917,8 +2918,11 @@ def editor_api_template_variable_report() -> Response:
         )
         suggested = suggested_report_names(yaml_texts, primary_filename=filename)
         report_title = str(post_data.get("title") or suggested["title"]).strip()
-        output_filename = _normalize_storage_filename(
-            post_data.get("output_filename") or suggested["filename"]
+        output_filename = safe_project_filename(
+            _normalize_storage_filename(
+                post_data.get("output_filename") or suggested["filename"]
+            ),
+            default_stem="variables",
         )
         if not output_filename.lower().endswith(".docx"):
             output_filename += ".docx"
@@ -3043,7 +3047,12 @@ def editor_api_upload_section_file() -> Response:
         saved_files: List[str] = []
         modules: List[Dict[str, Any]] = []
         for upload in uploads:
-            candidate_name = _normalize_storage_filename(upload.filename)
+            # A name Docassemble cannot resolve -- `contract (1).docx` -- would
+            # be stored happily and then reported missing by every interview
+            # that referred to it, so uploads are renamed at the door.
+            candidate_name = safe_project_filename(
+                _normalize_storage_filename(upload.filename), default_stem=section
+            )
             if section == "modules":
                 validate_module_filename(candidate_name)
             path = os.path.join(directory, candidate_name)
@@ -6333,8 +6342,11 @@ def editor_api_rename_section_file() -> Response:
         project = _normalize_project(post_data.get("project"))
         section = _normalize_section(post_data.get("section"))
         old_filename = _normalize_storage_filename(post_data.get("filename"))
-        new_filename = _normalize_renamed_storage_filename(
-            post_data.get("new_filename"), old_filename
+        new_filename = safe_project_filename(
+            _normalize_renamed_storage_filename(
+                post_data.get("new_filename"), old_filename
+            ),
+            default_stem=section,
         )
         if old_filename == new_filename:
             raise ValueError("New filename must be different")
@@ -9430,8 +9442,16 @@ def editor_api_new_project_job(job_id: str) -> Response:
         )
 
 
-def _template_import_target(uid: int, project: str, template_filename: str) -> str:
+def _template_import_target(
+    uid: int, project: str, template_filename: str
+) -> Tuple[str, str]:
     """Locate a template file inside the project's templates section.
+
+    A template that predates upload renaming may still carry a name
+    Docassemble cannot resolve from a `docx template file:` line. Importing it
+    would write an attachment block pointing at a file the interview then
+    reports as missing, so the file is renamed on the way in and the caller
+    works with the name that will resolve.
 
     Args:
         uid (int): the Playground owner.
@@ -9439,13 +9459,14 @@ def _template_import_target(uid: int, project: str, template_filename: str) -> s
         template_filename (str): the template's filename.
 
     Returns:
-        str: the path to the template on disk.
+        Tuple[str, str]: the path to the template on disk, and the name the
+        project now stores it under.
 
     Raises:
         FileNotFoundError: when the project has no such template.
         ValueError: when the file is not a PDF or DOCX Weaver can read.
     """
-    _area, directory = _editor_storage_directory(
+    area, directory = _editor_storage_directory(
         uid, project, EDITOR_SECTION_TO_STORAGE["templates"]
     )
     path = os.path.join(directory, template_filename)
@@ -9453,7 +9474,23 @@ def _template_import_target(uid: int, project: str, template_filename: str) -> s
         raise FileNotFoundError(f"{template_filename} is not in this project")
     if not template_filename.lower().endswith((".pdf", ".docx")):
         raise ValueError("Only PDF and DOCX templates can be analyzed.")
-    return path
+    safe_filename = safe_project_filename(template_filename, default_stem="template")
+    if safe_filename == template_filename:
+        return path, template_filename
+    safe_path = os.path.join(directory, safe_filename)
+    if os.path.exists(safe_path):
+        raise ValueError(
+            f"{template_filename} cannot be used under a name Docassemble can "
+            f"resolve, because {safe_filename} is already in this project. "
+            "Rename one of them."
+        )
+    rename_saved_file(area, directory, template_filename, safe_filename)
+    log(
+        "ALWeaver editor: renamed template to a resolvable name "
+        f"project={project} from={template_filename!r} to={safe_filename!r}",
+        "info",
+    )
+    return safe_path, safe_filename
 
 
 def _complete_template_import_job(
@@ -9497,7 +9534,9 @@ def _complete_template_import_job(
             message=f"Reading {template_filename}.",
             progress=10,
         )
-        template_path = _template_import_target(uid, project, template_filename)
+        template_path, template_filename = _template_import_target(
+            uid, project, template_filename
+        )
         interview_yaml = playground_read_yaml(uid, project, interview_filename)
 
         stage = "analyze"
@@ -9570,7 +9609,9 @@ def editor_api_import_template() -> Response:
         use_llm_assist = parse_bool(post_data.get("use_llm_assist"), default=False)
         # Fail here rather than in the worker: an author who picked the wrong
         # file should hear about it now.
-        _template_import_target(uid, project, template_filename)
+        _template_path, template_filename = _template_import_target(
+            uid, project, template_filename
+        )
         playground_read_yaml(uid, project, interview_filename)
 
         if not _editor_async_is_configured():

--- a/docassemble/ALWeaver/api_editor.py
+++ b/docassemble/ALWeaver/api_editor.py
@@ -737,6 +737,30 @@ def _normalize_storage_filename(raw: Optional[str]) -> str:
     return value
 
 
+def _renamed_file_message(requested: str, stored: str, reason: str) -> str:
+    """Explain, to the author, why the file is not called what they called it.
+
+    Args:
+        requested (str): the name the file arrived with.
+        stored (str): the name the project actually stores it under.
+        reason (str): ``unsupported_characters`` or ``name_taken``.
+
+    Returns:
+        str: a sentence naming both names and the rule behind the change.
+    """
+    if reason == "name_taken":
+        return (
+            f"{requested} was saved as {stored}, because this project already "
+            "has a file with that name."
+        )
+    return (
+        f"{requested} was saved as {stored}. The Playground can only find a "
+        "file whose name is made of letters, digits, dots, hyphens and "
+        "underscores, so anything else in the name is replaced. Refer to it "
+        f"as {stored} in your interview."
+    )
+
+
 def _optional_flag(raw: Any) -> Optional[bool]:
     """A yes/no that is allowed to be neither, for a setting with a default.
 
@@ -3045,13 +3069,16 @@ def editor_api_upload_section_file() -> Response:
         storage_section = EDITOR_SECTION_TO_STORAGE[section]
         area, directory = _editor_storage_directory(uid, project, storage_section)
         saved_files: List[str] = []
+        renamed_files: List[Dict[str, str]] = []
         modules: List[Dict[str, Any]] = []
         for upload in uploads:
+            requested_name = _normalize_storage_filename(upload.filename)
             # A name Docassemble cannot resolve -- `contract (1).docx` -- would
             # be stored happily and then reported missing by every interview
             # that referred to it, so uploads are renamed at the door.
-            candidate_name = safe_project_filename(
-                _normalize_storage_filename(upload.filename), default_stem=section
+            candidate_name = safe_project_filename(requested_name, default_stem=section)
+            reason = (
+                "unsupported_characters" if candidate_name != requested_name else ""
             )
             if section == "modules":
                 validate_module_filename(candidate_name)
@@ -3063,12 +3090,26 @@ def editor_api_upload_section_file() -> Response:
                     candidate_name = f"{stem}_{counter}{ext}"
                     path = os.path.join(directory, candidate_name)
                     counter += 1
+                reason = "name_taken"
                 # De-duplicating the name can produce one Docassemble would
                 # skip, e.g. util_1.py is fine but a leading digit would not be.
                 if section == "modules":
                     validate_module_filename(candidate_name)
             upload.save(path)
             saved_files.append(candidate_name)
+            # Say so rather than leaving the author to notice: the name they
+            # uploaded is not the name anything in the project may refer to.
+            if reason:
+                renamed_files.append(
+                    {
+                        "from": requested_name,
+                        "to": candidate_name,
+                        "reason": reason,
+                        "message": _renamed_file_message(
+                            requested_name, candidate_name, reason
+                        ),
+                    }
+                )
         area.finalize()
         for candidate_name in saved_files if section == "modules" else []:
             with open(os.path.join(directory, candidate_name), encoding="utf-8") as fh:
@@ -3095,6 +3136,7 @@ def editor_api_upload_section_file() -> Response:
             "project": project,
             "section": section,
             "saved_files": saved_files,
+            "renamed_files": renamed_files,
         }
         if section == "modules":
             data["modules"] = modules
@@ -6342,12 +6384,10 @@ def editor_api_rename_section_file() -> Response:
         project = _normalize_project(post_data.get("project"))
         section = _normalize_section(post_data.get("section"))
         old_filename = _normalize_storage_filename(post_data.get("filename"))
-        new_filename = safe_project_filename(
-            _normalize_renamed_storage_filename(
-                post_data.get("new_filename"), old_filename
-            ),
-            default_stem=section,
+        requested_filename = _normalize_renamed_storage_filename(
+            post_data.get("new_filename"), old_filename
         )
+        new_filename = safe_project_filename(requested_filename, default_stem=section)
         if old_filename == new_filename:
             raise ValueError("New filename must be different")
         if section == "modules":
@@ -6360,6 +6400,22 @@ def editor_api_rename_section_file() -> Response:
             "section": section,
             "filename": new_filename,
             "old_filename": old_filename,
+            # The author typed a name the Playground could not have found, so
+            # they need to hear which name the file actually has now.
+            "renamed_files": (
+                []
+                if new_filename == requested_filename
+                else [
+                    {
+                        "from": requested_filename,
+                        "to": new_filename,
+                        "reason": "unsupported_characters",
+                        "message": _renamed_file_message(
+                            requested_filename, new_filename, "unsupported_characters"
+                        ),
+                    }
+                ]
+            ),
         }
         if section == "modules":
             data["module"] = _rename_module_file(
@@ -8597,6 +8653,7 @@ def _start_new_project_upload_job(
     debug_requested: bool,
     interview_filename: Optional[str] = None,
     create_test: bool = True,
+    renamed_files: Optional[List[Dict[str, str]]] = None,
 ) -> Dict[str, Any]:
     job_id = str(uuid.uuid4())
     queued_at = time.time()
@@ -8611,6 +8668,9 @@ def _start_new_project_upload_job(
         "request_id": request_id,
         "generated_from": uploaded_files[0].get("filename") if uploaded_files else None,
         "uploaded_count": len(uploaded_files),
+        # The generated YAML refers to the template by the name the project
+        # stores it under, which is not always the name that was uploaded.
+        "renamed_files": list(renamed_files or []),
         "queued_at": queued_at,
         "started_at": None,
         "finished_at": None,
@@ -9263,6 +9323,7 @@ def _new_project_from_uploads(
             f"normalize_field_names={normalize_field_names}",
             "info",
         )
+        renamed_uploads: List[Dict[str, str]] = []
         for file_storage in uploaded_files:
             filename = file_storage.filename or ""
             content_bytes = file_storage.read()
@@ -9274,6 +9335,18 @@ def _new_project_from_uploads(
                 content_bytes=content_bytes,
                 mimetype=mimetype,
             )
+            requested_name = os.path.basename(str(filename).strip())
+            if safe_name != requested_name:
+                renamed_uploads.append(
+                    {
+                        "from": requested_name,
+                        "to": safe_name,
+                        "reason": "unsupported_characters",
+                        "message": _renamed_file_message(
+                            requested_name, safe_name, "unsupported_characters"
+                        ),
+                    }
+                )
             uploaded_payloads.append(
                 {
                     "filename": safe_name,
@@ -9348,6 +9421,7 @@ def _new_project_from_uploads(
             debug_requested=debug_requested,
             interview_filename=interview_filename,
             create_test=create_test,
+            renamed_files=renamed_uploads,
         )
 
         return jsonify_with_status(
@@ -9534,6 +9608,7 @@ def _complete_template_import_job(
             message=f"Reading {template_filename}.",
             progress=10,
         )
+        requested_filename = template_filename
         template_path, template_filename = _template_import_target(
             uid, project, template_filename
         )
@@ -9556,6 +9631,23 @@ def _complete_template_import_job(
         )
         result = analysis.to_dict()
         result["project"] = project
+        result["template_filename"] = template_filename
+        # The attachment block will name the renamed file, so the author has
+        # to be told the template is not called what they picked any more.
+        result["renamed_files"] = (
+            []
+            if template_filename == requested_filename
+            else [
+                {
+                    "from": requested_filename,
+                    "to": template_filename,
+                    "reason": "unsupported_characters",
+                    "message": _renamed_file_message(
+                        requested_filename, template_filename, "unsupported_characters"
+                    ),
+                }
+            ]
+        )
         result["interview_filename"] = interview_filename
         result["interview_revision"] = source_revision(interview_yaml)
         _update_job_state(
@@ -9609,6 +9701,7 @@ def editor_api_import_template() -> Response:
         use_llm_assist = parse_bool(post_data.get("use_llm_assist"), default=False)
         # Fail here rather than in the worker: an author who picked the wrong
         # file should hear about it now.
+        requested_filename = template_filename
         _template_path, template_filename = _template_import_target(
             uid, project, template_filename
         )
@@ -9643,6 +9736,24 @@ def editor_api_import_template() -> Response:
             "operation_type": "template_import",
             "project": project,
             "template": template_filename,
+            # Renaming happened before the job was queued, so say so here as
+            # well as on the finished analysis.
+            "renamed_files": (
+                []
+                if template_filename == requested_filename
+                else [
+                    {
+                        "from": requested_filename,
+                        "to": template_filename,
+                        "reason": "unsupported_characters",
+                        "message": _renamed_file_message(
+                            requested_filename,
+                            template_filename,
+                            "unsupported_characters",
+                        ),
+                    }
+                ]
+            ),
             "filename": interview_filename,
             "request_id": request_id,
             "queued_at": time.time(),

--- a/docassemble/ALWeaver/api_utils.py
+++ b/docassemble/ALWeaver/api_utils.py
@@ -7,6 +7,7 @@ import tempfile
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 
 from .interview_generator import generate_interview_from_path, TemplateInput
+from .project_filenames import safe_project_filename
 
 WEAVER_API_BASE_PATH = "/al/api/v1/weaver"
 
@@ -204,6 +205,9 @@ def validate_upload_metadata(
             safe_filename + extension if "." not in safe_filename else safe_filename
         )
 
+    # Whatever the upload was called, the project stores it -- and the
+    # generated YAML refers to it -- under a name Docassemble can resolve.
+    safe_filename = safe_project_filename(safe_filename, default_stem="template")
     return safe_filename, extension
 
 

--- a/docassemble/ALWeaver/data/static/editor.js
+++ b/docassemble/ALWeaver/data/static/editor.js
@@ -2270,6 +2270,47 @@
         error && error.message ? error.message : 'The editor request failed.';
   }
 
+  /* A file the project could not store under the name it was given.  The
+     author has to hear about it: the name they will refer to the file by in
+     the interview is not the name they uploaded. */
+  function reportRenamedFiles(data) {
+    var renamed = (data && data.renamed_files) || [];
+    if (!renamed.length) return;
+    var banner = document.getElementById('editor-file-renamed');
+    if (!banner) {
+      banner = document.createElement('div');
+      banner.id = 'editor-file-renamed';
+      banner.className = 'alert alert-warning alert-dismissible position-fixed';
+      banner.setAttribute('role', 'status');
+      banner.setAttribute('aria-live', 'polite');
+      banner.style.cssText =
+        'top:1rem;left:50%;transform:translateX(-50%);z-index:10000;min-width:300px;max-width:600px;';
+      var message = document.createElement('div');
+      message.setAttribute('data-renamed-message', '');
+      banner.appendChild(message);
+      var closeButton = document.createElement('button');
+      closeButton.type = 'button';
+      closeButton.className = 'btn-close';
+      closeButton.setAttribute('aria-label', 'Dismiss');
+      closeButton.addEventListener('click', function () {
+        banner.remove();
+      });
+      banner.appendChild(closeButton);
+      document.body.appendChild(banner);
+    }
+    var renamedNode = banner.querySelector('[data-renamed-message]');
+    if (!renamedNode) return;
+    renamedNode.textContent = '';
+    renamed.forEach(function (entry) {
+      var line = document.createElement('p');
+      line.className = 'mb-1';
+      line.textContent =
+        (entry && entry.message) ||
+        'Renamed ' + (entry && entry.from) + ' to ' + (entry && entry.to) + '.';
+      renamedNode.appendChild(line);
+    });
+  }
+
   function renderSystemChecks() {
     var warning = document.getElementById('editor-celery-warning');
     if (!warning) return;
@@ -15212,6 +15253,9 @@
         state.templateImportBusy = null;
         state.templateImportResult = result;
         state.templateImportMessage = '';
+        // An older template with an unresolvable name is renamed before it is
+        // read, and the attachment block will name the renamed file.
+        reportRenamedFiles(result);
         renderCanvas();
       })
       .catch(function (error) {
@@ -16615,6 +16659,7 @@
         state.sectionSelectedFile[state.currentView] =
           res.data && res.data.filename ? res.data.filename : sfNewName;
         noteModuleSaveResult(res.data);
+        reportRenamedFiles(res.data);
         loadSectionFiles(state.currentView);
       });
       return;
@@ -16899,6 +16944,7 @@
             ? res.data.filename
             : renamedSectionFile;
         noteModuleSaveResult(res.data);
+        reportRenamedFiles(res.data);
         loadSectionFiles(state.currentView);
       });
       return;
@@ -18242,6 +18288,11 @@
                       esc(state.project) +
                       '" created successfully.',
                   );
+                  // The generated YAML refers to each template by the name the
+                  // project stores it under, which may not be the one uploaded.
+                  reportRenamedFiles(
+                    jobData.renamed_files ? jobData : queuedData,
+                  );
                   return apiGet('/api/projects').then(function (r) {
                     if (r.success) applyProjectListData(r.data);
                     populateProjects();
@@ -18536,6 +18587,7 @@
           }
           state.sectionDirty = false;
           noteModuleSaveResult(res.data);
+          reportRenamedFiles(res.data);
           reportUploadedModuleProblems(res.data);
           loadSectionFiles(state.currentView);
         })

--- a/docassemble/ALWeaver/interview_generator.py
+++ b/docassemble/ALWeaver/interview_generator.py
@@ -2,6 +2,7 @@ from .custom_values import get_matching_deps, get_output_mako_package_and_path
 from .generator_constants import generator_constants
 from .question_library import baseline_question_specs
 from .review_screen import build_review_entries, table_edit_attributes
+from .project_filenames import safe_project_filename
 from .validate_template_files import matching_reserved_names, has_fields
 from collections import defaultdict
 from dataclasses import field
@@ -3751,6 +3752,7 @@ Rules:
             self.uploaded_templates = input_file.copy_deep(
                 self.attr_name("uploaded_templates")
             )
+            self._rename_uploaded_templates_safely()
             return
         # A plain list is how the non-interview entry points hand us several
         # templates: they build the file objects themselves, so there is
@@ -3761,6 +3763,7 @@ Rules:
             )
             for index, one_file in enumerate(input_file):
                 self.uploaded_templates[index] = one_file
+            self._rename_uploaded_templates_safely()
             return
         self.uploaded_templates = DAFileList(
             self.attr_name("uploaded_templates"), auto_gather=False, gathered=True
@@ -3768,6 +3771,43 @@ Rules:
         self.uploaded_templates[0] = input_file.copy_deep(
             self.attr_name("uploaded_templates") + "[0]"
         )
+        self._rename_uploaded_templates_safely()
+
+    def _rename_uploaded_templates_safely(self) -> None:
+        """Give every uploaded template a name Docassemble can resolve.
+
+        Docassemble keeps accents and spaces in the name it gives an uploaded
+        file, then strips both out again when it resolves a Playground
+        `docx template file:` reference -- so the generated interview would
+        report a template missing that is sitting in the project. The name on
+        the file object is the one the YAML and the package both use, so it is
+        the one to fix.
+
+        Only real uploads are renamed. A `DAStaticFile`'s filename *is* how it
+        finds itself on disk, and the callers that hand us those have already
+        named them.
+        """
+        # Two names that differed only in punctuation -- `demand (1).docx` and
+        # `demand 1.docx` -- would collide once both are made safe, and a
+        # package cannot hold two templates under one name.
+        used: Set[str] = {
+            str(getattr(template, "filename", "") or "")
+            for template in self.uploaded_templates
+            if not isinstance(template, DAFile)
+        }
+        for template in self.uploaded_templates:
+            if not isinstance(template, DAFile):
+                continue
+            current = str(getattr(template, "filename", "") or "")
+            safe_name = safe_project_filename(current, default_stem="template")
+            stem, extension = os.path.splitext(safe_name)
+            counter = 1
+            while safe_name in used:
+                counter += 1
+                safe_name = f"{stem}_{counter}{extension}"
+            used.add(safe_name)
+            if safe_name != current:
+                template.filename = safe_name
 
     def _guess_posture(self, title: str):
         """
@@ -7139,6 +7179,11 @@ def _resolve_template_inputs(
 ) -> List[TemplateInput]:
     """Put the templates in order, give each one a usable, distinct filename.
 
+    Names are made safe first: a template Docassemble cannot resolve by the
+    name written in the YAML -- anything with a space, a parenthesis or an
+    accent in it -- would leave the finished interview reporting a missing
+    template for a file sitting right there in the project.
+
     Two uploads can arrive with the same name, and two files cannot share one
     name in a package, so repeats are suffixed. Templates whose names differ
     only by extension keep both names: `document_names` tells those apart.
@@ -7166,8 +7211,9 @@ def _resolve_template_inputs(
     resolved: List[TemplateInput] = []
     used_names: Set[str] = set()
     for candidate in candidates:
-        name = os.path.basename(
-            str(candidate.exact_name or os.path.basename(candidate.path)).strip()
+        name = safe_project_filename(
+            str(candidate.exact_name or os.path.basename(candidate.path)),
+            default_stem="template",
         )
         stem, extension = os.path.splitext(name)
         counter = 1

--- a/docassemble/ALWeaver/project_filenames.py
+++ b/docassemble/ALWeaver/project_filenames.py
@@ -1,0 +1,71 @@
+"""Filenames a Docassemble project can actually use.
+
+Docassemble resolves a Playground template reference by stripping every
+character outside ``[A-Za-z0-9-_. ]`` out of the name written in the YAML and
+then looking for a file called what is left. A template uploaded as
+``93A_demand_letter (1).docx`` lands in the templates folder under that name,
+but the ``docx template file:`` line pointing at it resolves to
+``93A_demand_letter 1.docx``, which is not there -- so the interview reports a
+missing template for a file the author can plainly see. See
+``package_template_filename`` in ``docassemble.base.functions``.
+
+The fix is to never let such a name into a project in the first place: an
+upload is renamed once, at the door, and the stored file and every reference
+the generated YAML makes to it use that one name.
+"""
+
+import os
+import re
+import unicodedata
+
+__all__ = ["safe_project_filename", "is_safe_project_filename"]
+
+# Anything outside this set becomes an underscore. Spaces are inside what
+# Docassemble will resolve, but they make for awkward YAML, shell arguments and
+# package contents, so they go too.
+_UNSAFE_RUN = re.compile(r"[^A-Za-z0-9._-]+")
+# `report - final` should read `report-final`, not `report_-_final`.
+_PADDED_PUNCTUATION = re.compile(r"_*([.-])_*")
+_REPEATED_UNDERSCORES = re.compile(r"__+")
+
+
+def _clean(part: str) -> str:
+    """Reduce one piece of a filename to characters Docassemble keeps."""
+    cleaned = _UNSAFE_RUN.sub("_", part)
+    cleaned = _PADDED_PUNCTUATION.sub(r"\1", cleaned)
+    cleaned = _REPEATED_UNDERSCORES.sub("_", cleaned)
+    return cleaned.strip("._-")
+
+
+def safe_project_filename(filename: str, *, default_stem: str = "file") -> str:
+    """Rename a file to something a Docassemble project can refer to.
+
+    The name keeps its extension and as much of its stem as survives: letters,
+    digits, ``.``, ``-`` and ``_``. Everything else -- spaces, parentheses,
+    accents, quotes -- collapses to a single underscore.
+
+    Args:
+        filename (str): the name as uploaded, which may include a directory.
+        default_stem (str): what to call a file whose stem is left empty, as
+            an upload named only with punctuation would be.
+
+    Returns:
+        str: a filename with no directory part and no surprising characters.
+    """
+    name = os.path.basename(str(filename or "").strip())
+    # Turn accented letters into their plain equivalents rather than dropping
+    # them: `Citación.pdf` should be `Citacion.pdf`, not `Citacin.pdf`.
+    name = unicodedata.normalize("NFKD", name)
+    name = name.encode("ascii", "ignore").decode("ascii")
+
+    stem, extension = os.path.splitext(name)
+    stem = _clean(stem)
+    extension = _clean(extension)
+    if not stem:
+        stem = _clean(default_stem) or "file"
+    return f"{stem}.{extension}" if extension else stem
+
+
+def is_safe_project_filename(filename: str) -> bool:
+    """True when :func:`safe_project_filename` would leave this name alone."""
+    return bool(filename) and safe_project_filename(filename) == filename

--- a/docassemble/ALWeaver/test_api_utils.py
+++ b/docassemble/ALWeaver/test_api_utils.py
@@ -100,6 +100,20 @@ class test_api_utils(unittest.TestCase):
         self.assertEqual(filename, "example.pdf")
         self.assertEqual(extension, ".pdf")
 
+    def test_validate_upload_metadata_strips_punctuation(self):
+        filename, extension = validate_upload_metadata(
+            filename="93A_demand_letter_sample-labeled-highlighted (1).docx",
+            content_bytes=b"123",
+            mimetype=(
+                "application/vnd.openxmlformats-officedocument"
+                ".wordprocessingml.document"
+            ),
+        )
+        self.assertEqual(
+            filename, "93A_demand_letter_sample-labeled-highlighted_1.docx"
+        )
+        self.assertEqual(extension, ".docx")
+
     def test_validate_upload_metadata_unsupported_type(self):
         with self.assertRaises(WeaverAPIValidationError):
             validate_upload_metadata(

--- a/docassemble/ALWeaver/test_editor_api.py
+++ b/docassemble/ALWeaver/test_editor_api.py
@@ -3602,9 +3602,127 @@ class TestEditorProjectFileNaming(unittest.TestCase):
                     response = api_editor.editor_api_upload_section_file()
 
             self.assertEqual(response.status_code, 200)
-            saved = response.get_json()["data"]["saved_files"]
-            self.assertEqual(saved, ["93A_demand_letter_1.docx"])
+            data = response.get_json()["data"]
+            self.assertEqual(data["saved_files"], ["93A_demand_letter_1.docx"])
             self.assertEqual(os.listdir(tmpdir), ["93A_demand_letter_1.docx"])
+            # The author has to be told: the name they will refer to the file
+            # by in the interview is not the name they uploaded.
+            self.assertEqual(
+                data["renamed_files"],
+                [
+                    {
+                        "from": "93A demand letter (1).docx",
+                        "to": "93A_demand_letter_1.docx",
+                        "reason": "unsupported_characters",
+                        "message": data["renamed_files"][0]["message"],
+                    }
+                ],
+            )
+            self.assertIn(
+                "93A demand letter (1).docx", data["renamed_files"][0]["message"]
+            )
+            self.assertIn(
+                "93A_demand_letter_1.docx", data["renamed_files"][0]["message"]
+            )
+
+    def test_an_upload_that_needed_no_renaming_reports_none(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            upload = FileStorage(
+                stream=BytesIO(b"template bytes"), filename="petition.docx"
+            )
+            with (
+                patch.object(api_editor, "_editor_auth_check", return_value=True),
+                patch.object(api_editor, "_current_user_id", return_value=7),
+                patch.object(
+                    api_editor,
+                    "_editor_storage_directory",
+                    return_value=(SimpleNamespace(finalize=lambda: None), tmpdir),
+                ),
+            ):
+                with api_editor.app.test_request_context(
+                    "/al/editor/api/section-file/upload",
+                    method="POST",
+                    data={
+                        "project": "default",
+                        "section": "templates",
+                        "files": upload,
+                    },
+                    content_type="multipart/form-data",
+                ):
+                    response = api_editor.editor_api_upload_section_file()
+
+            data = response.get_json()["data"]
+            self.assertEqual(data["saved_files"], ["petition.docx"])
+            self.assertEqual(data["renamed_files"], [])
+
+    def test_an_upload_whose_name_is_taken_says_so_rather_than_blaming_the_characters(
+        self,
+    ):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with open(os.path.join(tmpdir, "petition.docx"), "wb") as handle:
+                handle.write(b"first")
+            upload = FileStorage(stream=BytesIO(b"second"), filename="petition.docx")
+            with (
+                patch.object(api_editor, "_editor_auth_check", return_value=True),
+                patch.object(api_editor, "_current_user_id", return_value=7),
+                patch.object(
+                    api_editor,
+                    "_editor_storage_directory",
+                    return_value=(SimpleNamespace(finalize=lambda: None), tmpdir),
+                ),
+            ):
+                with api_editor.app.test_request_context(
+                    "/al/editor/api/section-file/upload",
+                    method="POST",
+                    data={
+                        "project": "default",
+                        "section": "templates",
+                        "files": upload,
+                    },
+                    content_type="multipart/form-data",
+                ):
+                    response = api_editor.editor_api_upload_section_file()
+
+            data = response.get_json()["data"]
+            self.assertEqual(data["saved_files"], ["petition_1.docx"])
+            self.assertEqual(data["renamed_files"][0]["reason"], "name_taken")
+            self.assertIn(
+                "already has a file with that name",
+                data["renamed_files"][0]["message"],
+            )
+
+    def test_renaming_a_file_to_an_unusable_name_reports_what_it_became(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with open(os.path.join(tmpdir, "petition.docx"), "wb") as handle:
+                handle.write(b"template bytes")
+            with (
+                patch.object(api_editor, "_editor_auth_check", return_value=True),
+                patch.object(api_editor, "_current_user_id", return_value=7),
+                patch.object(
+                    api_editor,
+                    "_editor_storage_directory",
+                    return_value=(SimpleNamespace(finalize=lambda: None), tmpdir),
+                ),
+                patch.object(api_editor, "rename_saved_file"),
+            ):
+                with api_editor.app.test_request_context(
+                    "/al/editor/api/section-file/rename",
+                    method="POST",
+                    json={
+                        "project": "default",
+                        "section": "templates",
+                        "filename": "petition.docx",
+                        "new_filename": "demand letter (final).docx",
+                    },
+                ):
+                    response = api_editor.editor_api_rename_section_file()
+
+            data = response.get_json()["data"]
+            self.assertEqual(data["filename"], "demand_letter_final.docx")
+            self.assertEqual(
+                data["renamed_files"][0]["from"], "demand letter (final).docx"
+            )
+            self.assertEqual(data["renamed_files"][0]["to"], "demand_letter_final.docx")
 
     def test_importing_an_older_template_renames_it_first(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/docassemble/ALWeaver/test_editor_api.py
+++ b/docassemble/ALWeaver/test_editor_api.py
@@ -14,6 +14,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from flask import Flask, jsonify
+from werkzeug.datastructures import FileStorage
 
 
 def _load_api_editor_for_tests():
@@ -1881,7 +1882,9 @@ class TestEditorTemplateAnalysisApi(unittest.TestCase):
     def test_a_queued_analysis_reports_where_to_poll(self):
         with (
             patch.object(
-                api_editor, "_template_import_target", return_value="/tmp/a.pdf"
+                api_editor,
+                "_template_import_target",
+                return_value=("/tmp/a.pdf", "affidavit.pdf"),
             ),
             patch.object(api_editor, "playground_read_yaml", return_value="---\n"),
             patch.object(api_editor, "_editor_async_is_configured", return_value=True),
@@ -3563,3 +3566,93 @@ class TestEditorPackageFileApi(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestEditorProjectFileNaming(unittest.TestCase):
+    """A file a project stores has to have a name Docassemble can resolve.
+
+    https://github.com/SuffolkLITLab/docassemble-ALWeaver/issues/1059
+    """
+
+    def test_an_upload_is_renamed_on_its_way_into_the_project(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            upload = FileStorage(
+                stream=BytesIO(b"template bytes"),
+                filename="93A demand letter (1).docx",
+            )
+            with (
+                patch.object(api_editor, "_editor_auth_check", return_value=True),
+                patch.object(api_editor, "_current_user_id", return_value=7),
+                patch.object(
+                    api_editor,
+                    "_editor_storage_directory",
+                    return_value=(SimpleNamespace(finalize=lambda: None), tmpdir),
+                ),
+            ):
+                with api_editor.app.test_request_context(
+                    "/al/editor/api/section-file/upload",
+                    method="POST",
+                    data={
+                        "project": "default",
+                        "section": "templates",
+                        "files": upload,
+                    },
+                    content_type="multipart/form-data",
+                ):
+                    response = api_editor.editor_api_upload_section_file()
+
+            self.assertEqual(response.status_code, 200)
+            saved = response.get_json()["data"]["saved_files"]
+            self.assertEqual(saved, ["93A_demand_letter_1.docx"])
+            self.assertEqual(os.listdir(tmpdir), ["93A_demand_letter_1.docx"])
+
+    def test_importing_an_older_template_renames_it_first(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            stored = os.path.join(tmpdir, "demand letter (1).docx")
+            with open(stored, "wb") as handle:
+                handle.write(b"template bytes")
+            renames = []
+
+            def fake_rename(area, directory, old_name, new_name):
+                renames.append((old_name, new_name))
+                os.rename(
+                    os.path.join(directory, old_name),
+                    os.path.join(directory, new_name),
+                )
+
+            with (
+                patch.object(
+                    api_editor,
+                    "_editor_storage_directory",
+                    return_value=(SimpleNamespace(finalize=lambda: None), tmpdir),
+                ),
+                patch.object(api_editor, "rename_saved_file", fake_rename),
+            ):
+                path, filename = api_editor._template_import_target(
+                    7, "Eviction", "demand letter (1).docx"
+                )
+
+            self.assertEqual(filename, "demand_letter_1.docx")
+            self.assertEqual(path, os.path.join(tmpdir, "demand_letter_1.docx"))
+            self.assertTrue(os.path.isfile(path))
+            self.assertEqual(renames, [("demand letter (1).docx", filename)])
+
+    def test_a_template_whose_safe_name_is_taken_is_reported_rather_than_replaced(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for name in ("demand letter (1).docx", "demand_letter_1.docx"):
+                with open(os.path.join(tmpdir, name), "wb") as handle:
+                    handle.write(b"template bytes")
+
+            with (
+                patch.object(
+                    api_editor,
+                    "_editor_storage_directory",
+                    return_value=(SimpleNamespace(finalize=lambda: None), tmpdir),
+                ),
+                patch.object(api_editor, "rename_saved_file") as mock_rename,
+            ):
+                with self.assertRaises(ValueError):
+                    api_editor._template_import_target(
+                        7, "Eviction", "demand letter (1).docx"
+                    )
+            mock_rename.assert_not_called()

--- a/docassemble/ALWeaver/test_editor_frontend.py
+++ b/docassemble/ALWeaver/test_editor_frontend.py
@@ -967,6 +967,24 @@ class TestEditorFrontend(unittest.TestCase):
             editor,
         )
 
+    def test_a_renamed_upload_is_announced_rather_than_left_to_be_noticed(self):
+        """https://github.com/SuffolkLITLab/docassemble-ALWeaver/issues/1059
+
+        A file whose name the Playground cannot resolve is stored under a
+        different one. The author will refer to it by that name in their
+        interview, so silently renaming it is worse than not renaming it.
+        """
+        editor = (self.package_dir / "data/static/editor.js").read_text()
+
+        self.assertIn("function reportRenamedFiles(data)", editor)
+        self.assertIn("data.renamed_files", editor)
+        # A status region, not an error: nothing went wrong, but the author
+        # has to read it.
+        self.assertIn("banner.id = 'editor-file-renamed'", editor)
+        self.assertIn("banner.setAttribute('aria-live', 'polite')", editor)
+        # Every path that can rename a file has to say so.
+        self.assertEqual(editor.count("reportRenamedFiles("), 6)
+
     def test_navbar_matches_docassemble_and_carries_the_account_menu(self):
         """The editor is a full-page app that sits where a native docassemble
         page would, so its bar has to be a real Bootstrap navbar at

--- a/docassemble/ALWeaver/test_generate_from_path.py
+++ b/docassemble/ALWeaver/test_generate_from_path.py
@@ -111,6 +111,56 @@ class TestGenerateInterviewFromPath(unittest.TestCase):
             self.assertTrue(result.package_zip_path)
             self.assertTrue(os.path.exists(result.package_zip_path))
 
+    def test_a_template_name_with_punctuation_is_renamed_everywhere(self):
+        """https://github.com/SuffolkLITLab/docassemble-ALWeaver/issues/1059
+
+        Docassemble strips everything outside ``[A-Za-z0-9-_. ]`` out of a
+        Playground template reference before looking the file up, so a
+        ``docx template file:`` line naming ``... (1).docx`` goes looking for
+        ``... 1.docx`` and reports the template missing. The generated YAML,
+        the reported template names and the packaged file all have to agree on
+        a name that survives that.
+        """
+        # Docassemble's own stripping, from `package_template_filename` in
+        # `docassemble.base.functions`.
+        docassemble_strip = re.compile(r"[^A-Za-z0-9\-\_\. ]")
+        uploaded_name = "93A_demand_letter_sample-labeled-highlighted (1).docx"
+        source = Path(__file__).parent / "test/test_docx_no_pdf_field_names.docx"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            upload_dir = os.path.join(tmpdir, "upload")
+            output_dir = os.path.join(tmpdir, "output")
+            os.makedirs(upload_dir)
+            os.makedirs(output_dir)
+            uploaded_path = os.path.join(upload_dir, uploaded_name)
+            shutil.copyfile(source, uploaded_path)
+
+            result = generate_interview_from_path(
+                uploaded_path,
+                output_dir=output_dir,
+                create_package_zip=True,
+                include_next_steps=False,
+            )
+
+            expected_name = "93A_demand_letter_sample-labeled-highlighted_1.docx"
+            self.assertEqual(list(result.template_names), [expected_name])
+
+            yaml_text = Path(result.yaml_path).read_text(encoding="utf-8")
+            referenced = re.findall(
+                r"(?m)^\s*docx template file:\s*(.+?)\s*$", yaml_text
+            )
+            self.assertEqual(referenced, [expected_name])
+            # The reference has to mean the same file after Docassemble is done
+            # with it, or the interview reports the template as missing.
+            self.assertEqual(docassemble_strip.sub("", referenced[0]), expected_name)
+
+            with zipfile.ZipFile(result.package_zip_path) as archive:
+                templates = [
+                    os.path.basename(name)
+                    for name in archive.namelist()
+                    if "/data/templates/" in name and name.endswith(".docx")
+                ]
+            self.assertEqual(templates, [expected_name])
+
     def test_ensure_unique_question_ids(self):
         sample = """---
 id: Duplicate title
@@ -1205,3 +1255,57 @@ class TestMultipleTemplates(unittest.TestCase):
                 create_package_zip=False,
                 additional_templates=[os.path.join(tmpdir, "nope.pdf")],
             )
+
+
+class TestUploadedTemplateNaming(unittest.TestCase):
+    """A template's name has to be one Docassemble can resolve.
+
+    https://github.com/SuffolkLITLab/docassemble-ALWeaver/issues/1059
+    """
+
+    def _interview_with(self, templates):
+        from docassemble.base.util import DAFileList
+        from .interview_generator import DAInterview
+
+        interview = DAInterview()
+        interview.uploaded_templates = DAFileList(
+            "uploaded_templates", auto_gather=False, gathered=True
+        )
+        for index, template in enumerate(templates):
+            interview.uploaded_templates[index] = template
+        interview._rename_uploaded_templates_safely()
+        return [document.filename for document in interview.uploaded_templates]
+
+    def test_an_uploaded_file_loses_its_punctuation(self):
+        from docassemble.base.util import DAFile
+
+        names = self._interview_with(
+            [DAFile("one", filename="93A demand letter (1).docx")]
+        )
+        self.assertEqual(names, ["93A_demand_letter_1.docx"])
+
+    def test_two_names_that_become_the_same_are_kept_apart(self):
+        from docassemble.base.util import DAFile
+
+        names = self._interview_with(
+            [
+                DAFile("one", filename="demand (1).docx"),
+                DAFile("two", filename="demand 1.docx"),
+            ]
+        )
+        self.assertEqual(names, ["demand_1.docx", "demand_1_2.docx"])
+
+    def test_a_static_file_keeps_the_name_that_finds_it_on_disk(self):
+        from .interview_generator import _make_static_file_from_path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "already_safe.docx")
+            shutil.copyfile(
+                Path(__file__).parent / "test/test_docx_no_pdf_field_names.docx", path
+            )
+            # `_resolve_template_inputs` has already named these, and the name
+            # is how the file is found again.
+            static_file = _make_static_file_from_path(
+                path, filename="petition (1).docx"
+            )
+            self.assertEqual(self._interview_with([static_file]), ["petition (1).docx"])

--- a/docassemble/ALWeaver/test_project_filenames.py
+++ b/docassemble/ALWeaver/test_project_filenames.py
@@ -1,0 +1,71 @@
+# do not pre-load
+
+import re
+import unittest
+
+from .project_filenames import is_safe_project_filename, safe_project_filename
+
+# What Docassemble strips out of a Playground template reference before it goes
+# looking for the file: `package_template_filename` in
+# `docassemble.base.functions`. A name that changes under this is a name the
+# YAML cannot point at.
+DOCASSEMBLE_PLAYGROUND_STRIP = re.compile(r"[^A-Za-z0-9\-\_\. ]")
+
+
+class TestSafeProjectFilename(unittest.TestCase):
+    def test_a_name_docassemble_can_already_resolve_is_left_alone(self):
+        for filename in (
+            "petition.pdf",
+            "next_steps_letter.docx",
+            "93a-demand.docx",
+            "affidavit",
+        ):
+            self.assertEqual(safe_project_filename(filename), filename)
+            self.assertTrue(is_safe_project_filename(filename))
+
+    def test_spaces_and_parentheses_become_one_underscore(self):
+        self.assertEqual(
+            safe_project_filename(
+                "93A_demand_letter_sample-labeled-highlighted (1).docx"
+            ),
+            "93A_demand_letter_sample-labeled-highlighted_1.docx",
+        )
+        self.assertFalse(
+            is_safe_project_filename(
+                "93A_demand_letter_sample-labeled-highlighted (1).docx"
+            )
+        )
+
+    def test_accented_letters_keep_their_plain_equivalent(self):
+        self.assertEqual(safe_project_filename("Citación.pdf"), "Citacion.pdf")
+
+    def test_padding_around_punctuation_is_dropped(self):
+        self.assertEqual(
+            safe_project_filename("report - final.docx"), "report-final.docx"
+        )
+
+    def test_a_directory_part_is_discarded(self):
+        self.assertEqual(safe_project_filename("a/b/c d.pdf"), "c_d.pdf")
+
+    def test_a_stem_made_only_of_punctuation_falls_back(self):
+        self.assertEqual(
+            safe_project_filename("((( ).docx", default_stem="template"),
+            "template.docx",
+        )
+        self.assertEqual(safe_project_filename("  ..  "), "file")
+
+    def test_every_result_survives_docassembles_template_lookup(self):
+        for filename in (
+            "93A_demand_letter_sample-labeled-highlighted (1).docx",
+            "Citación.pdf",
+            "report - final.docx",
+            "sample'quote\".docx",
+            "100% of the form.pdf",
+        ):
+            safe = safe_project_filename(filename)
+            self.assertEqual(DOCASSEMBLE_PLAYGROUND_STRIP.sub("", safe), safe)
+            self.assertNotIn(" ", safe)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #1059.

## The bug

Uploading `93A_demand_letter_sample-labeled-highlighted (1).docx` through **Create project** produced an interview that reported the template missing, even though the file was sitting in the templates folder under exactly that name.

Docassemble resolves a Playground template reference by stripping every character outside `[A-Za-z0-9-_. ]` out of the name written in the YAML, and *then* looking for a file called what is left ([`package_template_filename`](https://github.com/jhpyle/docassemble/blob/master/docassemble_base/docassemble/base/functions.py)). So this line:

```yaml
docx template file: 93A_demand_letter_sample-labeled-highlighted (1).docx
```

went looking for `93A_demand_letter_sample-labeled-highlighted 1.docx` — parentheses gone, space kept — and found nothing. The file was stored faithfully; the reference could never point at it.

## The fix

`project_filenames.py` is now the one place a file gets its project name. Letters, digits, `.`, `-` and `_` survive; accents become their plain equivalents (`Citación.pdf` → `Citacion.pdf`); everything else — spaces, parentheses, quotes — collapses to a single underscore. Uploads are renamed at the door, so the stored file, the generated YAML and the packaged template all agree on one name that survives Docassemble's stripping.

It is applied at every point a file enters a project:

| Where | What it covers |
| --- | --- |
| `_resolve_template_inputs` | the generation core — YAML, reported template names, package zip |
| `validate_upload_metadata` | the Weaver API's upload boundary |
| `editor_api_upload_section_file` | files dropped into templates/modules/static/sources |
| `editor_api_rename_section_file` | a name an author types by hand |
| `editor_api_template_variable_report` | the drafted report's output name |
| `_set_template_from_file` | the in-Docassemble Weaver interview, where Docassemble's own upload naming keeps accents |

A template that predates this and still carries an unresolvable name is renamed when it is imported into an interview, rather than having an attachment block written against a name that will not resolve. If the safe name is already taken by another file, that is reported instead of silently replacing anything.

Two names that differed only in punctuation (`demand (1).docx`, `demand 1.docx`) would collide once both are made safe, so both the generation path and the interview path suffix the second one.

## Announcing the rename

Renaming silently is worse than not renaming: the author refers to the file by the name they gave it, and that is not the name the project stores. Every path that can rename a file now returns `renamed_files` — the name that arrived, the name stored, and a sentence naming the rule that applied:

> `93A demand letter (1).docx` was saved as `93A_demand_letter_1.docx`. The Playground can only find a file whose name is made of letters, digits, dots, hyphens and underscores, so anything else in the name is replaced. Refer to it as `93A_demand_letter_1.docx` in your interview.

A name that had to change because the project already held a file called that says so instead, rather than blaming the characters in it. The editor renders these in a dismissible `aria-live="polite"` status banner beside the existing error banner — on upload, on rename, on importing an older template, and when a project is created from uploaded documents.

## Tests

- `test_project_filenames.py` — the helper, including a check that every result it produces is unchanged by Docassemble's own stripping regex
- `test_generate_from_path.py::test_a_template_name_with_punctuation_is_renamed_everywhere` — the regression test for this issue: generates from the exact filename from #1059 and asserts the reported names, the `docx template file:` line and the packaged template all agree, and that the reference resolves
- `TestUploadedTemplateNaming` — the in-interview upload path, collision suffixing, and that a `DAStaticFile` (whose filename *is* how it finds itself on disk) is left alone
- `TestEditorProjectFileNaming` — the editor's upload endpoint and the legacy-template rename on import, including the already-taken case
- `test_api_utils.py::test_validate_upload_metadata_strips_punctuation`

Full suite: 882 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015YNo7s2DarD3qPn9cQzfTu