### PR TITLE
Make style checks explicit and findings easier to inspect

### DIFF
--- a/.github/scripts/editor_a11y.js
+++ b/.github/scripts/editor_a11y.js
@@ -207,11 +207,10 @@ async function main() {
     blockingViolations = blockingViolations.concat(
       await audit(page, "validation drawer")
     );
-    await page.locator('[aria-label="Validation actions"]').click();
-    blockingViolations = blockingViolations.concat(
-      await audit(page, "validation actions menu")
-    );
-    await page.locator("#btn-style-check").click();
+    // The style check lives in the Interview menu, and the deterministic run
+    // is the one that needs no model configured on the test server.
+    await openInterviewMenu(page);
+    await page.locator('[data-action="run-style-check"]').click();
     await page.waitForTimeout(1_000);
     blockingViolations = blockingViolations.concat(
       await audit(page, "style-check results")

--- a/.github/scripts/editor_a11y.js
+++ b/.github/scripts/editor_a11y.js
@@ -108,6 +108,15 @@ async function closeModal(page, selector) {
   await modal.waitFor({ state: "hidden", timeout: 10_000 });
 }
 
+// The findings panel reports it is working before the answer arrives, so wait
+// for the run to finish rather than auditing the spinner.
+async function settledFindings(page) {
+  await page
+    .locator('#validation-drawer[aria-busy="false"]')
+    .waitFor({ timeout: 30_000 });
+  await page.waitForTimeout(250);
+}
+
 async function openInterviewMenu(page) {
   const button = page.locator("#interview-menu");
   const menu = page.locator('ul[aria-labelledby="interview-menu"]');
@@ -203,7 +212,7 @@ async function main() {
 
     // Validation actions and the open results drawer.
     await page.locator('[data-action="check-errors"]').click();
-    await page.waitForTimeout(1_000);
+    await settledFindings(page);
     blockingViolations = blockingViolations.concat(
       await audit(page, "validation drawer")
     );
@@ -211,7 +220,7 @@ async function main() {
     // is the one that needs no model configured on the test server.
     await openInterviewMenu(page);
     await page.locator('[data-action="run-style-check"]').click();
-    await page.waitForTimeout(1_000);
+    await settledFindings(page);
     blockingViolations = blockingViolations.concat(
       await audit(page, "style-check results")
     );

--- a/architecture.md
+++ b/architecture.md
@@ -305,7 +305,10 @@ developer. The findings panel shares a `.editor-workspace` flex wrapper with
 `.editor-layout`, which lets the same element dock along the bottom (short or
 tall), beside the editor as a right-hand column, or over the whole window; the
 choice is remembered in `localStorage` and ignored while the panel is
-collapsed.
+collapsed. Both checks draw the panel before their request goes out, so a run
+started from a menu reports itself while it is happening; switching between the
+two checks drops the other one's findings rather than showing them under the
+new run's title.
 
 `docassemble_compat.py` is Weaver's compatibility boundary for Docassemble
 1.9.x and 1.10.x. Session orchestration uses the stable high-level functions in

--- a/architecture.md
+++ b/architecture.md
@@ -296,6 +296,17 @@ buffer. Diagnostics use Weaver-owned level, filename, block, source-range, and
 YAML-path fields. The validation drawer identifies saved-source and
 unsaved-source results explicitly.
 
+The house-style check is separate from validation: it runs against the saved
+source via `GET /al/editor/api/weaver/style-check`, is reached from the
+Interview menu, and never blocks a save. Its AI suggestions are opt-in --
+"Style check" sends `include_llm=0` and "Style check + AI suggestions" sends
+`include_llm=1`, so a configured model on the server never decides for the
+developer. The findings panel shares a `.editor-workspace` flex wrapper with
+`.editor-layout`, which lets the same element dock along the bottom (short or
+tall), beside the editor as a right-hand column, or over the whole window; the
+choice is remembered in `localStorage` and ignored while the panel is
+collapsed.
+
 `docassemble_compat.py` is Weaver's compatibility boundary for Docassemble
 1.9.x and 1.10.x. Session orchestration uses the stable high-level functions in
 `docassemble.base.functions`; raw inspection actions feature-detect the 1.10

--- a/docassemble/ALWeaver/data/questions/review_screen.yml
+++ b/docassemble/ALWeaver/data/questions/review_screen.yml
@@ -66,7 +66,7 @@ mako: |
   <div class="card h-100 weaver-builtin review-question weaver-preview-card">
     <div class="card-header">
       <div class="weaver-card-heading">
-        <span class="weaver-card-icon" aria-hidden="true"><i class="fas fa-magic"></i></span>
+        <span class="weaver-card-icon" aria-hidden="true"><i class="fas fa-cube"></i></span>
         <div class="weaver-card-title">
       % if field.trigger_gather().endswith(".gather()"):
           Names of ${ field.trigger_gather().replace(".gather()", "").capitalize().replace("_", " ") }

--- a/docassemble/ALWeaver/data/static/editor.css
+++ b/docassemble/ALWeaver/data/static/editor.css
@@ -15,6 +15,7 @@
   /* Matches docassemble's navbar: 0.5rem padding + a 40px navbar-brand. */
   --editor-navbar-height: 56px;
   --editor-left-width: 280px;
+  --editor-validation-side-width: 400px;
   --editor-radius: 8px;
   --editor-radius-sm: 6px;
   --editor-card-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
@@ -2948,11 +2949,35 @@ html, body {
 
 /* ===== Validation / Errors drawer ===== */
 
+/* ===== Workspace: the editor grid plus the findings panel =====
+   The panel docks under the editor by default and beside it on request, so
+   the same element has to be able to sit in either direction. A flex wrapper
+   whose direction the dock choice flips does that without the grid in
+   `.editor-layout` having to know the panel exists. */
+
+.editor-workspace {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.editor-workspace.editor-workspace-side {
+  flex-direction: row;
+}
+
+.editor-workspace > .editor-layout {
+  min-width: 0;
+}
+
 .editor-validation-drawer {
   flex-shrink: 0;
   border-top: 1px solid var(--editor-border);
   background: #fff;
   z-index: 5;
+  min-width: 0;
 }
 
 .editor-validation-header {
@@ -2981,6 +3006,15 @@ html, body {
   background: #eef1f5;
 }
 
+/* Side-docked, the header is only a few hundred pixels wide, so the title
+   gives way before the chevron and the dock buttons do. */
+.editor-validation-toggle > span:first-of-type {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .editor-validation-actions {
   display: flex;
   align-items: center;
@@ -2995,14 +3029,6 @@ html, body {
   align-items: center;
   justify-content: center;
   line-height: 1;
-}
-
-.editor-validation-menu-btn::after {
-  display: none;
-}
-
-.editor-validation-menu {
-  min-width: 180px;
 }
 
 .editor-validation-chevron {
@@ -3023,6 +3049,106 @@ html, body {
 
 .editor-validation-drawer.open .editor-validation-body {
   display: block;
+}
+
+/* ===== Dock sizes =====
+   Only an open panel is resized. A collapsed one is a header strip along the
+   bottom whichever dock is remembered, so re-opening restores the choice
+   without a collapsed panel eating a column. */
+
+.editor-validation-drawer.open.editor-validation-tall .editor-validation-body {
+  max-height: 55vh;
+}
+
+.editor-workspace-side > .editor-validation-drawer {
+  display: flex;
+  flex-direction: column;
+  width: var(--editor-validation-side-width);
+  max-width: 60vw;
+  min-height: 0;
+  border-top: none;
+  border-left: 1px solid var(--editor-border);
+}
+
+.editor-workspace-side > .editor-validation-drawer .editor-validation-body {
+  flex: 1 1 auto;
+  max-height: none;
+  min-height: 0;
+}
+
+.editor-workspace-full > .editor-layout {
+  display: none;
+}
+
+.editor-workspace-full > .editor-validation-drawer {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-height: 0;
+  border-top: none;
+}
+
+.editor-workspace-full > .editor-validation-drawer .editor-validation-body {
+  flex: 1 1 auto;
+  max-height: none;
+  min-height: 0;
+}
+
+.editor-validation-dock {
+  display: none;
+  gap: 2px;
+  margin-right: 4px;
+}
+
+.editor-validation-drawer.open .editor-validation-dock {
+  display: inline-flex;
+}
+
+.editor-validation-dock-btn {
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  font-size: 11px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--editor-muted);
+}
+
+.editor-validation-dock-btn:hover,
+.editor-validation-dock-btn:focus-visible {
+  border-color: var(--editor-border);
+  background: #eef1f5;
+  color: var(--editor-fg);
+}
+
+.editor-validation-dock-btn[aria-pressed='true'] {
+  border-color: var(--editor-border);
+  background: #fff;
+  color: var(--editor-fg);
+  box-shadow: inset 0 0 0 1px var(--editor-border);
+}
+
+@media (max-width: 900px) {
+  /* Too narrow to put anything beside the editor. */
+  .editor-workspace.editor-workspace-side {
+    flex-direction: column;
+  }
+
+  .editor-workspace-side > .editor-validation-drawer {
+    width: auto;
+    max-width: none;
+    border-left: none;
+    border-top: 1px solid var(--editor-border);
+  }
+
+  .editor-workspace-side > .editor-validation-drawer .editor-validation-body {
+    max-height: 55vh;
+  }
 }
 
 .editor-validation-badge {
@@ -3319,7 +3445,7 @@ html, body {
   color: var(--editor-fg);
 }
 
-/* ===== Validation menu kebab ===== */
+/* ===== Validation drawer re-run button ===== */
 
 .editor-validation-menu-btn {
   border: 1px solid transparent;

--- a/docassemble/ALWeaver/data/static/editor.css
+++ b/docassemble/ALWeaver/data/static/editor.css
@@ -3051,6 +3051,68 @@ html, body {
   display: block;
 }
 
+/* ===== Running a check =====
+   The style check goes to the server, and with AI suggestions on it can sit
+   there for a while. The header spinner shows on a collapsed panel too, so a
+   check started from the Interview menu is visible either way. */
+
+.editor-validation-spinner {
+  width: 12px;
+  height: 12px;
+  flex-shrink: 0;
+  border: 2px solid rgba(13, 57, 112, 0.25);
+  border-top-color: var(--editor-primary);
+  border-radius: 50%;
+  animation: editor-agent-spin 0.8s linear infinite;
+}
+
+.editor-validation-toggle .editor-validation-spinner {
+  margin-left: 6px;
+}
+
+.editor-validation-running {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 2px;
+  color: var(--editor-muted);
+}
+
+.editor-validation-running-bar {
+  position: relative;
+  height: 3px;
+  margin-top: 8px;
+  border-radius: 999px;
+  background: rgba(13, 57, 112, 0.15);
+  overflow: hidden;
+}
+
+.editor-validation-running-bar::after {
+  content: '';
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 40%;
+  border-radius: 999px;
+  background: var(--editor-primary);
+  animation: editor-agent-slide 1.2s ease-in-out infinite;
+}
+
+.editor-validation-menu-btn[disabled] {
+  opacity: 0.5;
+  cursor: default;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .editor-validation-spinner,
+  .editor-validation-running-bar::after {
+    animation: none;
+  }
+
+  .editor-validation-running-bar::after {
+    width: 100%;
+  }
+}
+
 /* ===== Dock sizes =====
    Only an open panel is resized. A collapsed one is a header strip along the
    bottom whichever dock is remembered, so re-opening restores the choice

--- a/docassemble/ALWeaver/data/static/editor.js
+++ b/docassemble/ALWeaver/data/static/editor.js
@@ -8474,6 +8474,7 @@
   function discardResultsFromTheOtherCheck(nextMode) {
     if (state.validationMode === nextMode) return;
     state.validationErrors = [];
+    renderOutline();
   }
 
   function getValidationRunningText() {

--- a/docassemble/ALWeaver/data/static/editor.js
+++ b/docassemble/ALWeaver/data/static/editor.js
@@ -95,7 +95,12 @@
     fullYamlStash: {},
     validationErrors: [],
     validationOpen: false,
+    //: 'bottom' | 'tall' | 'side' | 'full' -- where the findings panel sits
+    validationDock: 'bottom',
     validationMode: 'validation',
+    // Whether the style check that produced the current results asked the
+    // server for AI suggestions. Re-running has to repeat the same choice.
+    styleCheckIncludeLlm: false,
     validationSourceScope: 'saved_source',
     validationBaseRevisionMatches: null,
     assemblyLineSettings: null,
@@ -104,6 +109,8 @@
   };
 
   var RECENT_PROJECTS_STORAGE_KEY = 'alweaver_recent_projects';
+  var VALIDATION_DOCK_STORAGE_KEY = 'alweaver_validation_dock';
+  var VALIDATION_DOCKS = ['bottom', 'tall', 'side', 'full'];
   var MAX_RECENT_PROJECTS = 8;
   var _symbolInsertContext = null;
   var _alFieldMethodContext = null;
@@ -8413,6 +8420,52 @@
   // -------------------------------------------------------------------------
   var _validationInFlight = false;
 
+  function readValidationDock() {
+    try {
+      var stored = window.localStorage.getItem(VALIDATION_DOCK_STORAGE_KEY);
+      return VALIDATION_DOCKS.indexOf(stored) === -1 ? 'bottom' : stored;
+    } catch (_err) {
+      return 'bottom';
+    }
+  }
+
+  function setValidationDock(dock) {
+    if (VALIDATION_DOCKS.indexOf(dock) === -1) return;
+    state.validationDock = dock;
+    try {
+      window.localStorage.setItem(VALIDATION_DOCK_STORAGE_KEY, dock);
+    } catch (_err) {
+      // Ignore storage failures (private mode, quota, etc.)
+    }
+  }
+
+  // A collapsed panel is a header strip along the bottom no matter which dock
+  // is remembered: docking a header-only panel into its own column would take
+  // space away from the editor and show nothing in return.
+  function applyValidationDock() {
+    var workspace = document.getElementById('editor-workspace');
+    var drawer = document.getElementById('validation-drawer');
+    var dock = state.validationOpen ? state.validationDock : 'bottom';
+    if (workspace) {
+      workspace.classList.toggle('editor-workspace-side', dock === 'side');
+      workspace.classList.toggle('editor-workspace-full', dock === 'full');
+    }
+    if (drawer) {
+      drawer.classList.toggle('editor-validation-tall', dock === 'tall');
+    }
+    Array.prototype.forEach.call(
+      document.querySelectorAll('[data-validation-dock]'),
+      function (button) {
+        button.setAttribute(
+          'aria-pressed',
+          button.getAttribute('data-validation-dock') === state.validationDock
+            ? 'true'
+            : 'false',
+        );
+      },
+    );
+  }
+
   function getValidationDrawerTitle() {
     return state.validationMode === 'style'
       ? 'Style suggestions'
@@ -8421,7 +8474,7 @@
 
   function runCurrentValidationCheck() {
     if (state.validationMode === 'style') {
-      runStyleCheck();
+      runStyleCheck(state.styleCheckIncludeLlm);
       return;
     }
     runValidation();
@@ -8557,9 +8610,15 @@
       });
   }
 
-  function runStyleCheck() {
+  // `includeLlm` is the developer's own choice, made when they picked the menu
+  // item: the deterministic house-style rules always run, and the AI
+  // suggestions are asked for only when they said so. Nothing here infers it
+  // from whether a model happens to be configured on the server.
+  function runStyleCheck(includeLlm) {
     if (!state.project || !state.filename || _validationInFlight) return;
+    var wantsLlm = Boolean(includeLlm);
     state.validationMode = 'style';
+    state.styleCheckIncludeLlm = wantsLlm;
     state.validationSourceScope = 'saved_source';
     state.validationBaseRevisionMatches = null;
     _validationInFlight = true;
@@ -8568,7 +8627,8 @@
         encodeURIComponent(state.project) +
         '&filename=' +
         encodeURIComponent(state.filename) +
-        '&include_llm=1',
+        '&include_llm=' +
+        (wantsLlm ? '1' : '0'),
     )
       .then(function (res) {
         _validationInFlight = false;
@@ -8667,6 +8727,7 @@
       },
     );
 
+    applyValidationDock();
     drawer.classList.toggle('editor-validation-has-issues', hasProblems);
     drawer.classList.remove(
       'validation-error',
@@ -8684,7 +8745,10 @@
     }
     drawer.classList.add('open');
     var scopeText = isStyleMode
-      ? 'Suggestions from the shared house-style checker, against the saved source. None of these stop the interview from running or from being saved.'
+      ? (state.styleCheckIncludeLlm
+          ? 'Suggestions from the shared house-style checker and from AI, against the saved source. '
+          : 'Suggestions from the shared house-style checker, against the saved source. AI suggestions were not requested. ') +
+        'None of these stop the interview from running or from being saved.'
       : state.validationSourceScope === 'unsaved_source'
         ? 'This validation covers the unsaved source currently in the editor.'
         : 'This validation covers the saved source.';
@@ -10573,7 +10637,7 @@
     html +=
       '<button type="button" class="btn btn-sm btn-outline-primary" data-action="open-screen-preview" title="See this screen the way Docassemble will draw it"><i class="fa-regular fa-eye me-1" aria-hidden="true"></i>Preview</button>';
     html +=
-      '<button class="btn btn-sm btn-outline-secondary" id="draft-review-screen" title="Re-draft this review screen from the questions the interview asks today, including questions in files it includes"><i class="fa-solid fa-wand-magic-sparkles me-1" aria-hidden="true"></i>Sync from questions</button>';
+      '<button class="btn btn-sm btn-outline-secondary" id="draft-review-screen" title="Re-draft this review screen from the questions the interview asks today, including questions in files it includes"><i class="fa-solid fa-arrows-rotate me-1" aria-hidden="true"></i>Sync from questions</button>';
     html +=
       '<button class="btn btn-sm btn-outline-secondary" id="toggle-edit-mode">' +
       (isYaml ? 'Structured view' : 'Edit full YAML') +
@@ -15934,6 +15998,13 @@
     }
 
     // Validation drawer toggle
+    var dockButton = target.closest('[data-validation-dock]');
+    if (dockButton) {
+      setValidationDock(dockButton.getAttribute('data-validation-dock'));
+      state.validationOpen = true;
+      renderValidationDrawer();
+      return;
+    }
     if (
       target.id === 'validation-toggle' ||
       target.closest('#validation-toggle')
@@ -15966,12 +16037,7 @@
       target.closest('#btn-run-validation')
     ) {
       state.validationOpen = true;
-      runValidation();
-      return;
-    }
-    if (target.id === 'btn-style-check' || target.closest('#btn-style-check')) {
-      state.validationOpen = true;
-      runStyleCheck();
+      runCurrentValidationCheck();
       return;
     }
 
@@ -15989,6 +16055,10 @@
           }
           state.currentView = 'interview';
           state.validationOpen = true;
+          // A full-window panel covers the block the developer just asked to
+          // see. Move the findings beside the editor rather than jumping to a
+          // block behind them.
+          if (state.validationDock === 'full') setValidationDock('side');
           state.selectedBlockId = validationBlockId;
           dirtyState.setActiveBlock(validationBlockId);
           var interviewTab = document.querySelector(
@@ -17137,6 +17207,11 @@
     if (uiAction === 'open-interview-flow-report') {
       stashCurrentEditorState();
       openInterviewFlowReport();
+      return;
+    }
+    if (uiAction === 'run-style-check' || uiAction === 'run-style-check-ai') {
+      state.validationOpen = true;
+      runStyleCheck(uiAction === 'run-style-check-ai');
       return;
     }
     if (orderBuilderBtn) {
@@ -19106,6 +19181,8 @@
     initProjectSearch();
     initGithubPublishing();
     renderSystemChecks();
+    state.validationDock = readValidationDock();
+    applyValidationDock();
     document
       .querySelectorAll('[data-action="open-runtime-inspector"]')
       .forEach(function (control) {

--- a/docassemble/ALWeaver/data/static/editor.js
+++ b/docassemble/ALWeaver/data/static/editor.js
@@ -8624,9 +8624,12 @@
         renderOutline();
       })
       .catch(function (error) {
-        if (isSupersededRequest(error)) return;
         _validationInFlight = false;
         state.validationBusy = false;
+        if (isSupersededRequest(error)) {
+          renderValidationDrawer();
+          return;
+        }
         state.validationErrors = [
           { level: 'error', message: 'Could not run validation right now.' },
         ];
@@ -8673,9 +8676,12 @@
         renderOutline();
       })
       .catch(function (error) {
-        if (isSupersededRequest(error)) return;
         _validationInFlight = false;
         state.validationBusy = false;
+        if (isSupersededRequest(error)) {
+          renderValidationDrawer();
+          return;
+        }
         state.validationErrors = [
           { level: 'error', message: 'Could not run style check right now.' },
         ];

--- a/docassemble/ALWeaver/data/static/editor.js
+++ b/docassemble/ALWeaver/data/static/editor.js
@@ -95,6 +95,7 @@
     fullYamlStash: {},
     validationErrors: [],
     validationOpen: false,
+    validationBusy: false,
     //: 'bottom' | 'tall' | 'side' | 'full' -- where the findings panel sits
     validationDock: 'bottom',
     validationMode: 'validation',
@@ -8466,6 +8467,24 @@
     );
   }
 
+  // A badge counting the errors a file has says nothing about how many style
+  // suggestions it has. Switching between the two checks therefore drops the
+  // old findings; re-running the same check keeps its numbers on screen so
+  // they do not blink off and back on.
+  function discardResultsFromTheOtherCheck(nextMode) {
+    if (state.validationMode === nextMode) return;
+    state.validationErrors = [];
+  }
+
+  function getValidationRunningText() {
+    if (state.validationMode !== 'style') {
+      return 'Checking this file for errors and warnings\u2026';
+    }
+    return state.styleCheckIncludeLlm
+      ? 'Running the house-style checks and asking the model for suggestions. This one goes to a language model, so give it a few seconds.'
+      : 'Running the house-style checks\u2026';
+  }
+
   function getValidationDrawerTitle() {
     return state.validationMode === 'style'
       ? 'Style suggestions'
@@ -8557,6 +8576,7 @@
 
   function runValidation() {
     if (!state.project || !state.filename || _validationInFlight) return;
+    discardResultsFromTheOtherCheck('validation');
     state.validationMode = 'validation';
     state.validationBaseRevisionMatches = null;
     var validationSnapshot;
@@ -8581,6 +8601,8 @@
     state.validationSourceScope = validationSnapshot.scope;
     var validationSource = validationSnapshot.rawYaml;
     _validationInFlight = true;
+    state.validationBusy = true;
+    renderValidationDrawer();
     apiPost('/api/validate-source', {
       project: state.project,
       filename: state.filename,
@@ -8589,6 +8611,7 @@
     })
       .then(function (res) {
         _validationInFlight = false;
+        state.validationBusy = false;
         if (res.success && res.data) {
           state.validationErrors =
             res.data.diagnostics || res.data.errors || [];
@@ -8602,6 +8625,7 @@
       .catch(function (error) {
         if (isSupersededRequest(error)) return;
         _validationInFlight = false;
+        state.validationBusy = false;
         state.validationErrors = [
           { level: 'error', message: 'Could not run validation right now.' },
         ];
@@ -8617,11 +8641,17 @@
   function runStyleCheck(includeLlm) {
     if (!state.project || !state.filename || _validationInFlight) return;
     var wantsLlm = Boolean(includeLlm);
+    discardResultsFromTheOtherCheck('style');
     state.validationMode = 'style';
     state.styleCheckIncludeLlm = wantsLlm;
     state.validationSourceScope = 'saved_source';
     state.validationBaseRevisionMatches = null;
     _validationInFlight = true;
+    // Say so before the request goes out. The old code only rendered on the
+    // response, so a check started from the menu looked like nothing had
+    // happened until it finished.
+    state.validationBusy = true;
+    renderValidationDrawer();
     apiGet(
       '/api/weaver/style-check?project=' +
         encodeURIComponent(state.project) +
@@ -8632,6 +8662,7 @@
     )
       .then(function (res) {
         _validationInFlight = false;
+        state.validationBusy = false;
         if (res.success && res.data) {
           state.validationErrors = res.data.errors || [];
         } else {
@@ -8643,6 +8674,7 @@
       .catch(function (error) {
         if (isSupersededRequest(error)) return;
         _validationInFlight = false;
+        state.validationBusy = false;
         state.validationErrors = [
           { level: 'error', message: 'Could not run style check right now.' },
         ];
@@ -8728,6 +8760,12 @@
     );
 
     applyValidationDock();
+    drawer.setAttribute('aria-busy', state.validationBusy ? 'true' : 'false');
+    var headerSpinner = document.getElementById('validation-spinner');
+    if (headerSpinner)
+      headerSpinner.classList.toggle('d-none', !state.validationBusy);
+    var rerunButton = document.getElementById('btn-run-validation');
+    if (rerunButton) rerunButton.disabled = state.validationBusy;
     drawer.classList.toggle('editor-validation-has-issues', hasProblems);
     drawer.classList.remove(
       'validation-error',
@@ -8744,6 +8782,17 @@
       return;
     }
     drawer.classList.add('open');
+    if (state.validationBusy) {
+      body.innerHTML =
+        '<div class="editor-validation-running" role="status">' +
+        '<span class="editor-validation-spinner" aria-hidden="true"></span>' +
+        '<span>' +
+        esc(getValidationRunningText()) +
+        '</span>' +
+        '</div>' +
+        '<div class="editor-validation-running-bar" aria-hidden="true"></div>';
+      return;
+    }
     var scopeText = isStyleMode
       ? (state.styleCheckIncludeLlm
           ? 'Suggestions from the shared house-style checker and from AI, against the saved source. '

--- a/docassemble/ALWeaver/data/templates/editor.html
+++ b/docassemble/ALWeaver/data/templates/editor.html
@@ -191,6 +191,7 @@
         <i class="fa-solid fa-triangle-exclamation me-1" aria-hidden="true"></i>
         <span id="validation-drawer-title">Errors &amp; Warnings</span>
         <span class="editor-validation-badge js-validation-badge d-none" data-validation-badge></span>
+        <span class="editor-validation-spinner d-none" id="validation-spinner" aria-hidden="true"></span>
         <i class="fa-solid fa-chevron-up ms-auto editor-validation-chevron" aria-hidden="true"></i>
       </button>
       <div class="editor-validation-actions">

--- a/docassemble/ALWeaver/data/templates/editor.html
+++ b/docassemble/ALWeaver/data/templates/editor.html
@@ -30,6 +30,8 @@
             <ul class="dropdown-menu" data-bs-theme="light" aria-labelledby="interview-menu">
               <li><button type="button" class="dropdown-item" data-action="open-interview-order"><i class="fa-solid fa-list-ol fa-fw me-2" aria-hidden="true"></i>Interview Order</button></li>
               <li><button type="button" class="dropdown-item" data-action="open-interview-flow-report"><i class="fa-solid fa-file-lines fa-fw me-2" aria-hidden="true"></i>Flow report</button></li>
+              <li><button type="button" class="dropdown-item" data-action="run-style-check"><i class="fa-solid fa-ruler fa-fw me-2" aria-hidden="true"></i>Style check</button></li>
+              <li><button type="button" class="dropdown-item" data-action="run-style-check-ai"><i class="fa-solid fa-wand-magic-sparkles fa-fw me-2" aria-hidden="true"></i>Style check + AI suggestions</button></li>
               <li><hr class="dropdown-divider"></li>
               <li><button type="button" class="dropdown-item" data-action="open-full-yaml"><i class="fa-solid fa-code fa-fw me-2" aria-hidden="true"></i>YAML source</button></li>
               <li><button type="button" class="dropdown-item" data-action="open-assemblyline-settings"><i class="fa-solid fa-sliders fa-fw me-2" aria-hidden="true"></i>AssemblyLine settings</button></li>
@@ -83,6 +85,7 @@
   </div>
 
   <!-- ===== MAIN LAYOUT ===== -->
+  <div class="editor-workspace" id="editor-workspace">
   <div class="editor-layout" id="editor-layout">
 
     <!-- LEFT RAIL -->
@@ -190,15 +193,18 @@
         <span class="editor-validation-badge js-validation-badge d-none" data-validation-badge></span>
         <i class="fa-solid fa-chevron-up ms-auto editor-validation-chevron" aria-hidden="true"></i>
       </button>
-      <div class="dropdown editor-validation-actions">
-        <button type="button" class="editor-validation-menu-btn" data-bs-toggle="dropdown" data-bs-boundary="viewport" data-bs-display="dynamic" aria-expanded="false" aria-label="Validation actions" title="Validation actions"><i class="fa-solid fa-ellipsis-vertical" aria-hidden="true"></i></button>
-        <ul class="dropdown-menu dropdown-menu-end editor-validation-menu">
-          <li><button type="button" class="dropdown-item" id="btn-run-validation"><i class="fa-solid fa-triangle-exclamation me-2" aria-hidden="true"></i>Errors &amp; warnings</button></li>
-          <li><button type="button" class="dropdown-item" id="btn-style-check"><i class="fa-solid fa-wand-magic-sparkles me-2" aria-hidden="true"></i>Style check</button></li>
-        </ul>
+      <div class="editor-validation-actions">
+        <div class="editor-validation-dock" role="group" aria-label="Where to put the findings panel">
+          <button type="button" class="editor-validation-dock-btn" data-validation-dock="bottom" title="Dock along the bottom" aria-label="Dock along the bottom"><i class="fa-solid fa-window-minimize" aria-hidden="true"></i></button>
+          <button type="button" class="editor-validation-dock-btn" data-validation-dock="tall" title="Make the panel taller" aria-label="Make the panel taller"><i class="fa-solid fa-up-down" aria-hidden="true"></i></button>
+          <button type="button" class="editor-validation-dock-btn" data-validation-dock="side" title="Dock to the right, beside the editor" aria-label="Dock to the right, beside the editor"><i class="fa-solid fa-table-columns" aria-hidden="true"></i></button>
+          <button type="button" class="editor-validation-dock-btn" data-validation-dock="full" title="Fill the window" aria-label="Fill the window"><i class="fa-solid fa-expand" aria-hidden="true"></i></button>
+        </div>
+        <button type="button" class="editor-validation-menu-btn" id="btn-run-validation" aria-label="Run these checks again" title="Run these checks again"><i class="fa-solid fa-rotate-right" aria-hidden="true"></i></button>
       </div>
     </div>
     <div class="editor-validation-body" id="validation-drawer-body" tabindex="0"></div>
+  </div>
   </div>
 </div>
 

--- a/docassemble/ALWeaver/test_editor_frontend.py
+++ b/docassemble/ALWeaver/test_editor_frontend.py
@@ -796,6 +796,14 @@ class TestEditorFrontend(unittest.TestCase):
         self.assertIn("function discardResultsFromTheOtherCheck(nextMode) {", editor)
         self.assertIn("discardResultsFromTheOtherCheck('style');", editor)
         self.assertIn("discardResultsFromTheOtherCheck('validation');", editor)
+        discard_helper = editor[
+            editor.index(
+                "function discardResultsFromTheOtherCheck(nextMode) {"
+            ) : editor.index("function getValidationRunningText() {")
+        ]
+        self.assertIn(
+            "state.validationErrors = [];\n    renderOutline();", discard_helper
+        )
 
         self.assertIn(".editor-validation-spinner {", css)
         self.assertIn(".editor-validation-running-bar {", css)

--- a/docassemble/ALWeaver/test_editor_frontend.py
+++ b/docassemble/ALWeaver/test_editor_frontend.py
@@ -770,6 +770,37 @@ class TestEditorFrontend(unittest.TestCase):
         self.assertIn(".editor-workspace-full > .editor-layout {", css)
         self.assertIn(".editor-validation-drawer.open.editor-validation-tall", css)
 
+    def test_a_running_check_says_so_before_its_answer_arrives(self):
+        """The style check goes to the server, so the panel has to show it is
+        working rather than sitting on the last run's results."""
+        template = (self.package_dir / "data/templates/editor.html").read_text()
+        editor = (self.package_dir / "data/static/editor.js").read_text()
+        css = (self.package_dir / "data/static/editor.css").read_text()
+
+        self.assertIn('id="validation-spinner"', template)
+
+        # The panel is drawn before the request goes out, not only after it
+        # comes back.
+        self.assertIn(
+            "state.validationBusy = true;\n    renderValidationDrawer();", editor
+        )
+        self.assertIn("state.validationBusy = false;", editor)
+        self.assertIn("function getValidationRunningText() {", editor)
+        self.assertIn("Running the house-style checks", editor)
+        # An AI run is the slow one, so it says as much.
+        self.assertIn("give it a few seconds", editor)
+        self.assertIn("drawer.setAttribute('aria-busy'", editor)
+        self.assertIn("rerunButton.disabled = state.validationBusy;", editor)
+        self.assertIn('<div class="editor-validation-running" role="status">', editor)
+        # Findings from the other check are not this check's answer.
+        self.assertIn("function discardResultsFromTheOtherCheck(nextMode) {", editor)
+        self.assertIn("discardResultsFromTheOtherCheck('style');", editor)
+        self.assertIn("discardResultsFromTheOtherCheck('validation');", editor)
+
+        self.assertIn(".editor-validation-spinner {", css)
+        self.assertIn(".editor-validation-running-bar {", css)
+        self.assertIn("prefers-reduced-motion", css)
+
     def test_the_magic_icon_marks_only_features_that_use_ai(self):
         """A wand promises generative AI. Deterministic screens and actions
         have to be drawn with something that does not."""

--- a/docassemble/ALWeaver/test_editor_frontend.py
+++ b/docassemble/ALWeaver/test_editor_frontend.py
@@ -781,9 +781,32 @@ class TestEditorFrontend(unittest.TestCase):
 
         # The panel is drawn before the request goes out, not only after it
         # comes back.
-        self.assertIn(
-            "state.validationBusy = true;\n    renderValidationDrawer();", editor
-        )
+        validation_runner = editor[
+            editor.index("function runValidation() {") : editor.index(
+                "function runStyleCheck(includeLlm) {"
+            )
+        ]
+        style_runner = editor[
+            editor.index("function runStyleCheck(includeLlm) {") : editor.index(
+                "function _validationLevelRank(level) {"
+            )
+        ]
+        for runner in (validation_runner, style_runner):
+            with self.subTest(runner=runner[:40]):
+                self.assertRegex(
+                    runner,
+                    r"state\.validationBusy = true;\s*renderValidationDrawer\(\);",
+                )
+                # A cancelled/stale request is still finished: unlock future
+                # checks and remove the already-rendered busy state.
+                self.assertRegex(
+                    runner,
+                    r"\.catch\(function \(error\) \{\s*"
+                    r"_validationInFlight = false;\s*"
+                    r"state\.validationBusy = false;\s*"
+                    r"if \(isSupersededRequest\(error\)\) \{\s*"
+                    r"renderValidationDrawer\(\);\s*return;",
+                )
         self.assertIn("state.validationBusy = false;", editor)
         self.assertIn("function getValidationRunningText() {", editor)
         self.assertIn("Running the house-style checks", editor)
@@ -801,8 +824,9 @@ class TestEditorFrontend(unittest.TestCase):
                 "function discardResultsFromTheOtherCheck(nextMode) {"
             ) : editor.index("function getValidationRunningText() {")
         ]
-        self.assertIn(
-            "state.validationErrors = [];\n    renderOutline();", discard_helper
+        self.assertRegex(
+            discard_helper,
+            r"state\.validationErrors = \[\];\s*renderOutline\(\);",
         )
 
         self.assertIn(".editor-validation-spinner {", css)

--- a/docassemble/ALWeaver/test_editor_frontend.py
+++ b/docassemble/ALWeaver/test_editor_frontend.py
@@ -702,6 +702,103 @@ class TestEditorFrontend(unittest.TestCase):
         self.assertIn("'Style suggestions'", editor)
         self.assertIn("None of these stop the interview from running", editor)
 
+    def test_the_style_check_asks_before_it_uses_ai(self):
+        """The AI half of the style check is opt-in, and both halves are
+        reachable from the Interview menu rather than the error drawer."""
+        template = (self.package_dir / "data/templates/editor.html").read_text()
+        editor = (self.package_dir / "data/static/editor.js").read_text()
+
+        self.assertIn('data-action="run-style-check"', template)
+        self.assertIn('data-action="run-style-check-ai"', template)
+        self.assertIn("Style check + AI suggestions", template)
+        # The drawer's own menu is gone; it only re-runs what is on screen.
+        self.assertNotIn('id="btn-style-check"', template)
+        self.assertNotIn('aria-label="Validation actions"', template)
+
+        self.assertIn("function runStyleCheck(includeLlm) {", editor)
+        self.assertIn("var wantsLlm = Boolean(includeLlm);", editor)
+        self.assertIn("(wantsLlm ? '1' : '0')", editor)
+        # Re-running has to repeat the choice the developer already made.
+        self.assertIn("runStyleCheck(state.styleCheckIncludeLlm);", editor)
+        self.assertIn(
+            "runStyleCheck(uiAction === 'run-style-check-ai');",
+            editor,
+        )
+        self.assertIn("AI suggestions were not requested.", editor)
+
+    def test_the_findings_panel_can_be_expanded_or_docked_beside_the_editor(self):
+        """The default bottom strip is too short to read a long list in, so the
+        panel also goes tall, into a right-hand column, or full window."""
+        template = (self.package_dir / "data/templates/editor.html").read_text()
+        editor = (self.package_dir / "data/static/editor.js").read_text()
+        css = (self.package_dir / "data/static/editor.css").read_text()
+
+        # The layout and the panel share a wrapper so the panel can sit either
+        # under the editor or beside it.
+        self.assertIn('id="editor-workspace"', template)
+        self.assertLess(
+            template.index('id="editor-workspace"'),
+            template.index('id="editor-layout"'),
+        )
+        self.assertLess(
+            template.index('id="editor-layout"'),
+            template.index('id="validation-drawer"'),
+        )
+        for dock in ("bottom", "tall", "side", "full"):
+            with self.subTest(dock=dock):
+                self.assertIn('data-validation-dock="%s"' % dock, template)
+
+        self.assertIn(
+            "var VALIDATION_DOCKS = ['bottom', 'tall', 'side', 'full'];", editor
+        )
+        self.assertIn("'alweaver_validation_dock'", editor)
+        self.assertIn("function applyValidationDock() {", editor)
+        # The choice outlives a reload.
+        self.assertIn("state.validationDock = readValidationDock();", editor)
+        # A collapsed panel is a bottom strip whatever dock is remembered.
+        self.assertIn(
+            "var dock = state.validationOpen ? state.validationDock : 'bottom';",
+            editor,
+        )
+        # Full window hides the canvas, so following a finding has to leave it.
+        self.assertIn(
+            "if (state.validationDock === 'full') setValidationDock('side');",
+            editor,
+        )
+
+        self.assertIn(".editor-workspace.editor-workspace-side {", css)
+        self.assertIn(".editor-workspace-full > .editor-layout {", css)
+        self.assertIn(".editor-validation-drawer.open.editor-validation-tall", css)
+
+    def test_the_magic_icon_marks_only_features_that_use_ai(self):
+        """A wand promises generative AI. Deterministic screens and actions
+        have to be drawn with something that does not."""
+        ai_markers = (
+            "toggle-assistant",
+            "run-style-check-ai",
+            "ai-screen",
+            "ai-generate-screen",
+            "ai-generate-fields",
+        )
+        for relative_path in (
+            "data/templates/editor.html",
+            "data/static/editor.js",
+            "data/questions/review_screen.yml",
+        ):
+            lines = (self.package_dir / relative_path).read_text().splitlines()
+            for index, line in enumerate(lines):
+                if "fa-magic" not in line and "wand-magic" not in line:
+                    continue
+                # An icon often sits on its own line inside the control that
+                # names the feature, so read a little of the way around it.
+                context = "\n".join(lines[max(0, index - 3) : index + 2])
+                with self.subTest(path=relative_path, line=index + 1):
+                    self.assertTrue(
+                        any(marker in context for marker in ai_markers),
+                        f"{relative_path}:{index + 1} uses the magic icon "
+                        "without using AI: " + line.strip(),
+                    )
+
     def test_new_project_collects_publishing_metadata_and_the_filename(self):
         editor = (self.package_dir / "data/static/editor.js").read_text()
 


### PR DESCRIPTION
## Summary

- move style checks into the Interview menu and split deterministic checks from optional AI suggestions
- reserve the wand icon for AI-backed actions and use descriptive icons for deterministic review features
- let the findings panel use bottom, tall, side, or full-window layouts and remember the selected dock
- show progress immediately while validation or style checks are running, including clearer messaging for AI checks

## Review and fixes

Reviewed the check-switching flow and fixed the P2 stale-outline finding: when switching between validation and style checks, clearing results now immediately re-renders the block outline. This prevents old per-block findings from remaining visible while the new request is in flight. Added focused regression coverage for the shared discard helper.

Closes #1055.
Closes #1058.

## Testing

- 54 focused editor frontend tests passed
- full commit hooks passed: Black, mypy, JavaScript static checks, pytest, and the no-preload check
- npm run check passed
- editor.js passed Node syntax validation
- Manual testing performed locally by Quinten